### PR TITLE
Fix the trap listener stop: a two-second wait for a value another goroutine took

### DIFF
--- a/pkg/snmp/client.go
+++ b/pkg/snmp/client.go
@@ -74,8 +74,16 @@ type Client struct {
 	// raced reproducibly under -race — and visibly without it, since a Start
 	// following a Stop could be refused by a listener that had not cleared
 	// itself yet, or clobber one that was still running.
+	//
+	// trapBound and trapDone belong to the SAME listener as trapListener and are
+	// replaced with it. gosnmp's own Listening() cannot be used for this by more
+	// than one waiter: it is `make(chan bool, 1)` carrying a VALUE, not a channel
+	// that closes, so the first receiver takes it and every other one waits for
+	// ever. These two are closed, which is a broadcast.
 	trapMu       sync.Mutex
 	trapListener *gosnmp.TrapListener
+	trapBound    chan struct{} // closed once the socket is bound
+	trapDone     chan struct{} // closed once Listen has returned
 	debugEnabled bool
 	debugLog     []DebugEntry
 	debugMu      sync.Mutex

--- a/pkg/snmp/trap.go
+++ b/pkg/snmp/trap.go
@@ -89,17 +89,31 @@ func (c *Client) StartTrapListener(port int, v3 V3Params) error {
 	// with 8 MiB. The loss is silent — the kernel drops the datagram before Go
 	// sees it, so there is no error, no journal entry and nothing to count.
 	//
-	// Listening() closes once the socket is bound, which is the earliest moment
+	// Listening() delivers once the socket is bound, which is the earliest moment
 	// there is a socket to configure. In its own goroutine so a listener that
 	// never binds cannot hold up the caller.
+	//
+	// THIS IS THE ONLY RECEIVE FROM Listening() IN THE PROGRAM, and it has to be:
+	// gosnmp makes it `make(chan bool, 1)` and SENDS a value rather than closing
+	// it, so a second waiter elsewhere does not learn the socket is up — it
+	// blocks until whatever timeout it carries. `bound` is closed instead, and
+	// closing is a broadcast, so StopTrapListener can wait on the same fact.
+	bound := make(chan struct{})
+	done := make(chan struct{})
 	c.trapListener = listener
+	c.trapBound = bound
+	c.trapDone = done
 
 	go func() {
 		select {
 		case <-listener.Listening():
+			close(bound)
 			raiseTrapReadBuffer(listener, TrapReadBuffer)
-		case <-time.After(5 * time.Second):
-			log.Printf("trap listener: did not bind within 5s; leaving the default read buffer")
+		case <-done:
+			// Listen returned without ever binding. There is no socket to
+			// enlarge, and `bound` stays open on purpose: a stop must be able
+			// to tell "not yet" from "never", and `done` is what says never.
+			log.Printf("trap listener: never bound; leaving the default read buffer")
 		}
 	}()
 
@@ -112,8 +126,11 @@ func (c *Client) StartTrapListener(port int, v3 V3Params) error {
 			c.trapMu.Lock()
 			if c.trapListener == listener {
 				c.trapListener = nil
+				c.trapBound = nil
+				c.trapDone = nil
 			}
 			c.trapMu.Unlock()
+			close(done)
 		}()
 		log.Printf("Starting trap listener on port %d", port)
 		err := listener.Listen(netaddr.ListenAddress(port))
@@ -129,6 +146,8 @@ func (c *Client) StartTrapListener(port int, v3 V3Params) error {
 func (c *Client) StopTrapListener() {
 	c.trapMu.Lock()
 	listener := c.trapListener
+	bound := c.trapBound
+	done := c.trapDone
 	c.trapMu.Unlock()
 
 	if listener == nil {
@@ -144,12 +163,25 @@ func (c *Client) StopTrapListener() {
 	// a listener running with nothing able to stop it. Measured: still running
 	// 2.1 s after Close returned in 73 ms.
 	//
-	// Listening() closes once the socket is bound. A bind that FAILS never
-	// closes it, hence the bound wait: there is nothing to stop in that case
-	// anyway.
+	// THIS WAS A TIMEOUT AND THAT WAS THE BUG. It waited on Listening()
+	// directly, which delivers a single VALUE that the read-buffer goroutine
+	// had normally already taken, so the wait here always ran to its two
+	// seconds and then closed anyway — with no happens-before edge to
+	// listenUDP's unlocked write of `conn`. `go test -race` caught it on CI
+	// (twice, in TestStartingTwiceIsRefused and TestStartStopStart) and it is
+	// not merely a detector artefact: with no edge, Close can read the nil it
+	// returns early on, having already burned `finish`, which is exactly the
+	// failure the paragraph above says was fixed.
+	//
+	// Waiting on the two facts instead needs no timeout, because Listen does
+	// exactly one of them: it binds, or it returns.
 	select {
-	case <-listener.Listening():
-	case <-time.After(stopBindGrace):
+	case <-bound:
+	case <-done:
+		// Never bound. There is no socket, and calling Close would only spend
+		// gosnmp's one-shot `finish` on nothing.
+		log.Println("Trap listener never bound; nothing to stop.")
+		return
 	}
 
 	// Close OUTSIDE the lock: it waits for the listen goroutine to unwind, and
@@ -157,11 +189,6 @@ func (c *Client) StopTrapListener() {
 	log.Println("Stopping trap listener...")
 	listener.Close()
 }
-
-// stopBindGrace is how long a stop waits for the socket to exist before giving
-// up on closing it. Binding is a local syscall; anything slower than this has
-// failed.
-const stopBindGrace = 2 * time.Second
 
 // TrapListenerRunning reports whether a listener is currently bound.
 func (c *Client) TrapListenerRunning() bool {

--- a/pkg/snmp/traplifecycle_test.go
+++ b/pkg/snmp/traplifecycle_test.go
@@ -83,6 +83,43 @@ func TestStartingTwiceIsRefused(t *testing.T) {
 	}
 }
 
+// Stopping a bound listener is immediate, and that is what says the two waits
+// are not fighting over the same value.
+//
+// gosnmp's Listening() is `make(chan bool, 1)` carrying a VALUE, not a channel
+// that closes. Two places here wanted to know the socket was up — the goroutine
+// that enlarges the read buffer, and the stop — and the first to receive took
+// it. In practice the buffer goroutine won at bind time, so EVERY stop then ran
+// to its two-second timeout before closing anything: two seconds added to every
+// window close, and a Close() with no happens-before edge to listenUDP's
+// unlocked write of `conn`, which `go test -race` flagged on CI in
+// TestStartingTwiceIsRefused and TestStartStopStart.
+//
+// Measured rather than asserted in the abstract: this fails at ~2s against the
+// old implementation and passes in milliseconds against the current one.
+func TestStoppingABoundListenerIsImmediate(t *testing.T) {
+	c := NewClient(context.TODO())
+	c.SetRecorder(events.Nop{})
+	port := freePort(t)
+
+	if err := c.StartTrapListener(port, V3Params{}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Let it bind, so this measures the stop and not the bind.
+	time.Sleep(300 * time.Millisecond)
+
+	start := time.Now()
+	c.StopTrapListener()
+	took := time.Since(start)
+
+	// Generous: closing a UDP socket is a syscall. Anything approaching a second
+	// means the stop is waiting on something it will never be handed.
+	if took > 500*time.Millisecond {
+		t.Errorf("stopping a bound listener took %v; it is waiting on a value "+
+			"another goroutine has already taken", took)
+	}
+}
+
 // And after a clean stop, starting again must work — otherwise changing the
 // trap port would need a restart.
 func TestStartStopStart(t *testing.T) {


### PR DESCRIPTION
`go test -race` has been red on CI in `TestStartingTwiceIsRefused` and `TestStartStopStart` — a read of gosnmp's `conn` in `TrapListener.Close()` racing the unlocked write in `listenUDP`. It reproduces on the runners and not locally, which is what kept it standing.

**The cause is one line of gosnmp:** `listening` is `make(chan bool, 1)` and `Listen` *sends* a value rather than closing the channel. Two places here waited on it — the goroutine that raises the socket read buffer to 8 MiB, and `StopTrapListener` — and a value goes to exactly one receiver. The buffer goroutine normally won it at bind time, so **every stop ran to its two-second timeout** and then called `Close()` with nothing establishing that `conn` had been written.

Not only a detector complaint: with no happens-before edge, `Close` can read the `nil` it returns early on, having already set gosnmp's one-shot `finish`. That is precisely the failure the comment above that wait claims to have fixed — a socket left bound with nothing able to close it.

## The fix

`StartTrapListener` receives from `Listening()` once — it is now the only receive in the program — and republishes the fact by closing `trapBound`. Closing is a broadcast; a value is not. `trapDone` closes when `Listen` returns. The stop waits on those two and needs no timeout, because `Listen` does exactly one of them: it binds, or it returns. A listener that never bound is no longer closed at all, since that would spend `finish` on nothing.

## The test

It pins the consequence rather than the race, because the race does not reproduce on demand and a test that cannot fail is worse than none: **stopping a bound listener must be immediate.** Measured — 2.0004s against the old implementation, milliseconds against this one.

gosnmp 1.44.0 (PR #7) was checked and carries the same unlocked write, so that bump does not address this.