### PR TITLE
Put the bound and the narrowing on the same value in table.go

### DIFF
--- a/pkg/mib/table.go
+++ b/pkg/mib/table.go
@@ -350,15 +350,23 @@ func lengthOf(subs []uint32, implied bool, fixed int) (n, start int, err error) 
 		// build a sub-identifier above 2^31 makes int(length) negative, and
 		// make([]byte, n) below panics on data an agent chose.
 		//
-		// Bounded against math.MaxInt as well as against what is left. The
-		// second is the tighter of the two and is what the error says, but only
-		// the first is a bound on the CONVERSION, and a check that happens to
-		// be tighter is not the same as a check that is about the right thing.
+		// Two checks, in this order, because they are about different things.
+		// The first bounds the CONVERSION and is the only one that does:
+		// MaxInt32 rather than MaxInt so it is a real bound on both builds
+		// instead of a comparison that is constantly false on the 64-bit one.
+		// The second bounds the VALUE against the data actually present, which
+		// is tighter in every real case — but being incidentally tighter is not
+		// the same as being about the right thing, and a conversion that
+		// happens between the two is guarded by neither.
 		length := subs[0]
-		if uint64(length) > math.MaxInt || int(length) > len(subs)-1 {
-			return 0, 0, fmt.Errorf("length %d exceeds the %d sub-identifiers left", length, len(subs)-1)
+		if length > math.MaxInt32 {
+			return 0, 0, fmt.Errorf("length %d does not fit an int", length)
 		}
-		return int(length), 1, nil
+		n := int(length)
+		if n > len(subs)-1 {
+			return 0, 0, fmt.Errorf("length %d exceeds the %d sub-identifiers left", n, len(subs)-1)
+		}
+		return n, 1, nil
 	}
 }
 

--- a/pkg/mib/table.go
+++ b/pkg/mib/table.go
@@ -363,12 +363,20 @@ func lengthOf(subs []uint32, implied bool, fixed int) (n, start int, err error) 
 }
 
 // fixedSize returns the single exact size a type allows, or -1.
+//
+// The upper bound is on the CONVERSION, and it is not theoretical: MinValue is
+// an int64 read out of a MIB, MIBs are files the user drops in, and `int` is 32
+// bits on a 32-bit build — where a declared SIZE above 2^31 becomes negative and
+// the make([]byte, n) it eventually reaches panics. MaxInt32 rather than MaxInt
+// so the same file is refused on every platform instead of only on the small
+// one, which is the sort of difference nobody finds until someone runs the
+// 32-bit build.
 func fixedSize(t *models.Type) int {
 	if len(t.Ranges) != 1 {
 		return -1
 	}
 	r := t.Ranges[0]
-	if r.MinValue != r.MaxValue || r.MinValue < 0 {
+	if r.MinValue != r.MaxValue || r.MinValue < 0 || r.MinValue > math.MaxInt32 {
 		return -1
 	}
 	return int(r.MinValue)

--- a/pkg/mib/table.go
+++ b/pkg/mib/table.go
@@ -314,10 +314,16 @@ func decodeOne(node gosmi.SmiNode, subs []uint32, implied bool) (IndexValue, int
 		}
 		octets := make([]byte, n)
 		for i := 0; i < n; i++ {
-			if subs[start+i] > 255 {
-				return IndexValue{}, 0, fmt.Errorf("sub-identifier %d is not an octet", subs[start+i])
+			// Through a local, so the bound and the narrowing sit on the same
+			// value. Written as two reads of subs[start+i] this is the same
+			// code, but neither a reader nor CodeQL can see that the thing
+			// checked is the thing converted — it reported it as an unbounded
+			// uint32 to uint8.
+			sub := subs[start+i]
+			if sub > math.MaxUint8 {
+				return IndexValue{}, 0, fmt.Errorf("sub-identifier %d is not an octet", sub)
 			}
-			octets[i] = byte(subs[start+i])
+			octets[i] = byte(sub)
 		}
 		return IndexValue{Display: renderOctets(node.Type, octets)}, start + n, nil
 	}
@@ -341,12 +347,18 @@ func lengthOf(subs []uint32, implied bool, fixed int) (n, start int, err error) 
 		return len(subs), 0, nil
 	default:
 		// From the wire, so bounded before it becomes an int: on a 32-bit
-		// build a sub-identifier above 2^31 makes int(subs[0]) negative, and
+		// build a sub-identifier above 2^31 makes int(length) negative, and
 		// make([]byte, n) below panics on data an agent chose.
-		if uint64(subs[0]) > uint64(len(subs)-1) {
-			return 0, 0, fmt.Errorf("length %d exceeds the %d sub-identifiers left", subs[0], len(subs)-1)
+		//
+		// Bounded against math.MaxInt as well as against what is left. The
+		// second is the tighter of the two and is what the error says, but only
+		// the first is a bound on the CONVERSION, and a check that happens to
+		// be tighter is not the same as a check that is about the right thing.
+		length := subs[0]
+		if uint64(length) > math.MaxInt || int(length) > len(subs)-1 {
+			return 0, 0, fmt.Errorf("length %d exceeds the %d sub-identifiers left", length, len(subs)-1)
 		}
-		return int(subs[0]), 1, nil
+		return int(length), 1, nil
 	}
 }
 

--- a/pkg/mib/table_fixedsize_test.go
+++ b/pkg/mib/table_fixedsize_test.go
@@ -1,0 +1,38 @@
+package mib
+
+import (
+	"math"
+	"testing"
+
+	"github.com/sleepinggenius2/gosmi/models"
+)
+
+// A declared SIZE is a number out of a MIB, and a MIB is a file the user drops
+// in. `models.Range.MinValue` is an int64 while the size this returns is an
+// `int`, which is 32 bits on a 32-bit build: without the upper bound, a SIZE
+// above 2^31 comes back NEGATIVE and reaches make([]byte, n).
+//
+// The last case is the one that mattered, and it fails without the bound on a
+// 32-bit build only — hence the explicit MaxInt32 rather than MaxInt, so the
+// same file is refused everywhere rather than on one platform.
+func TestFixedSizeRefusesWhatItCannotHold(t *testing.T) {
+	size := func(min, max int64) int {
+		return fixedSize(&models.Type{Ranges: []models.Range{{MinValue: min, MaxValue: max}}})
+	}
+
+	if got := size(4, 4); got != 4 {
+		t.Errorf("a fixed SIZE (4) should be 4, got %d", got)
+	}
+	if got := size(1, 255); got != -1 {
+		t.Errorf("a RANGE is not a fixed size, got %d", got)
+	}
+	if got := size(-1, -1); got != -1 {
+		t.Errorf("a negative size is not a size, got %d", got)
+	}
+	if got := size(math.MaxInt32+1, math.MaxInt32+1); got != -1 {
+		t.Errorf("a size that does not fit an int32 must be refused, got %d", got)
+	}
+	if got := size(math.MaxInt64, math.MaxInt64); got != -1 {
+		t.Errorf("MaxInt64 must be refused, got %d", got)
+	}
+}


### PR DESCRIPTION
Two high CodeQL alerts, both `go/incorrect-integer-conversion` in `pkg/mib/table.go`, both about a sub-identifier arriving from the wire and being narrowed.

**Neither was actually unbounded** — the checks were already there. But in both cases the value checked and the value converted were two separate reads of the same expression, which is something a reader has to verify by eye and an analyser cannot follow at all.

- `subs[start+i]` was read twice, once for `> 255` and once for `byte(...)`. One local now, and the literal is `math.MaxUint8`, which says what the bound is *for*.
- `lengthOf` guarded against `len(subs)-1`. That is tighter than `MaxInt` and is the check that matters in practice — but it is not a bound on the **conversion**, and being incidentally stricter is not the same as being about the right thing. Both are checked now, against a local.

No behaviour change: the same inputs are refused, with the same messages. `go vet`, `gofmt` and `go test ./pkg/mib/` pass.