### PR TITLE
Invert the highlighter in one pass instead of a chain of replaces

### DIFF
--- a/frontend/tests/tokenize.test.mjs
+++ b/frontend/tests/tokenize.test.mjs
@@ -13,14 +13,21 @@ const check = (name, ok, extra = '') => {
   if (!ok) failures++;
 };
 
-/** Recover the text a browser would render from the generated markup. */
+/**
+ * Recover the text a browser would render from the generated markup.
+ *
+ * ONE pass, not a chain of replaces. Tags and entities are recognised together,
+ * so a decoded `<` is never looked at again — which is what the chain was
+ * relying on its own ordering to avoid: `&amp;` had to come LAST, or
+ * `&amp;lt;` would decode to `<` instead of to `&lt;`. An inversion that is
+ * correct only in one order is a trap for whoever adds the next entity, and it
+ * is what CodeQL's js/incomplete-multi-character-sanitization is about.
+ */
+const ENTITIES = { lt: '<', gt: '>', quot: '"', amp: '&', '#39': "'" };
+
 function textOf(html) {
-  return html
-    .replace(/<[^>]+>/g, '')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, '&');
+  return html.replace(/<[^>]+>|&(lt|gt|quot|amp|#39);/g,
+    (whole, entity) => (entity === undefined ? '' : ENTITIES[entity]));
 }
 
 const SAMPLES = {


### PR DESCRIPTION
The last open CodeQL alert, `js/incomplete-multi-character-sanitization`.

The rule is about a real fragility even though this helper feeds a string comparison and never a DOM: stripping tags and *then* decoding entities can put back what the stripping removed.

The chain was correct, but only because of its order — `&amp;` had to come last, or `&amp;lt;` decoded to `<` instead of to `&lt;`. That is a trap for whoever adds the next entity. One pass recognises tags and entities together, so a decoded `<` is never looked at again and the order stops mattering.

Checked on the three cases that distinguish the two implementations: `&amp;lt;` → `&lt;`, `&lt;script&gt;` → `<script>`, `<span>x</span>&amp;` → `x&`.