### PR TITLE
Align the pipeline with SyslogStudio, and close what the comparison exposed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,34 +1,52 @@
 name: CI
 
-# The default GITHUB_TOKEN permissions are broader than a build needs. This
-# workflow only reads the repository.
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
 
+# The default GITHUB_TOKEN permissions are broader than a build needs. Declared
+# explicitly so the workflow does not inherit whatever the repository settings
+# grant.
+permissions:
+  contents: read
+
+# Superseded pushes to the same pull request are pointless work. Pushes to main
+# are never cancelled: every commit on the default branch gets its own verdict.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  lint-and-build:
-    name: Lint & Build (${{ matrix.os }})
+  # The full application build AND the Go tests, on every platform we ship.
+  #
+  # The tests used to run on Linux alone, "to avoid redundant runs". They are
+  # not redundant: pkg/autostart writes an HKCU Run key on Windows, a LaunchAgent
+  # on macOS and an XDG desktop entry on Linux; pkg/secrets is DPAPI, the
+  # Keychain and a file backend; pkg/network runs traceroute6 on macOS and
+  # tracert on Windows. Each of those is three implementations behind one
+  # interface, and only one of them was ever exercised. The trap listener race
+  # fixed in facaabe reproduced on Linux and never on Windows — the converse is
+  # just as possible, and would have been just as invisible.
+  build:
+    name: Build & test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
         include:
+          - os: ubuntu-24.04
+            platform: linux/amd64
           - os: windows-latest
             platform: windows/amd64
-          - os: ubuntu-latest
-            platform: linux/amd64
           - os: macos-latest
             platform: darwin/universal
 
-    runs-on: ${{ matrix.os }}
-
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -37,52 +55,89 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
-          cache: 'npm'
+          # Vite 8 requires ^20.19 || >=22.12. Pinning the major to 22 rather
+          # than 20 keeps that satisfied instead of depending on which 20.x the
+          # runner happens to resolve that day.
+          node-version: "22"
+          cache: npm
           cache-dependency-path: frontend/package-lock.json
-
-      - name: Install Wails CLI
-        # Pinned to the version in go.mod. The CLI generates the bridge
-        # bindings and drives the build, so letting it float means a future
-        # release can change the output — or drift from the library it is
-        # generating against — with nothing in this repository changing.
-        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.15.0
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev pkg-config
+
+      - name: Install Wails CLI
+        # Pinned to the version in go.mod. The CLI generates the bridge bindings
+        # and drives the build, so letting it float means a future release can
+        # change the output — or drift from the library it generates against —
+        # with nothing in this repository changing. The release workflow pins
+        # the same version.
+        run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.15.0
+
+      # Deliberately `wails build` and not a bare `go build`: the CLI
+      # regenerates the JS bindings and builds the frontend before compiling, so
+      # this is the only check covering the whole pipeline a release runs.
+      # Without it CI can be green while `wails build` is broken, and the
+      # breakage surfaces when a tag is pushed — which is to say, once it is
+      # already a failed release.
+      - name: Build
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          TAGS=""
+          if [ "$RUNNER_OS" = "Linux" ]; then TAGS="-tags webkit2_41"; fi
+          wails build -platform ${{ matrix.platform }} $TAGS
 
-      # Wails build generates bindings + builds frontend + compiles Go
-      - name: Build (Linux)
-        if: runner.os == 'Linux'
-        run: wails build -platform ${{ matrix.platform }} -tags webkit2_41
+      - name: Vet & test
+        shell: bash
+        # -race, because pkg/mib holds a package-wide lock around a library whose
+        # "read" accessors mutate: internal.(*Object).GetSmiNode memoises on
+        # first call. Two concurrent readers raced for as long as that lock was
+        # an RWMutex, and nothing in CI could see it.
+        #
+        # -count=1 defeats the test cache. A cached PASS is a result from a
+        # previous toolchain and a previous dependency set, reported as though
+        # this run had verified it.
+        run: |
+          TAGS=""
+          if [ "$RUNNER_OS" = "Linux" ]; then TAGS="-tags webkit2_41"; fi
+          go vet $TAGS ./...
+          go test $TAGS -race -count=1 ./...
 
-      - name: Build (non-Linux)
-        if: runner.os != 'Linux'
-        run: wails build -platform ${{ matrix.platform }}
+  quality:
+    name: Quality (lint, tests, tidy)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      # Go checks (only on Linux to avoid redundant runs)
-      - name: Go vet
-        if: runner.os == 'Linux'
-        run: go vet -tags webkit2_41 ./...
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
 
-      - name: Go tests
-        if: runner.os == 'Linux'
-        # -race, because pkg/mib holds a package-wide lock around a library
-        # whose "read" accessors mutate: internal.(*Object).GetSmiNode memoises
-        # on first call. Two concurrent readers raced for as long as that lock
-        # was an RWMutex, and nothing in CI could see it.
-        run: go test -race -tags webkit2_41 ./...
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
 
-      # Runs the polling store against a stubbed Wails bridge. node_modules is
-      # already present: wails build installed it.
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev pkg-config
+
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+
+      # Compiles every component, fails on a name nothing declares and on a
+      # rendered expression that depends on state it does not name — the two
+      # things Svelte 5 stopped reporting. Also the locale parity check.
       - name: Frontend tests
-        if: runner.os == 'Linux'
-        run: cd frontend && npm test
+        run: npm test
+        working-directory: frontend
 
       # GitHub Pages serves the REPOSITORY, and there is no Pages build step, so
       # anything docs/*.html names has to be committed or it is a 404 on the live
@@ -91,19 +146,39 @@ jobs:
       # 3200 px captures swallowed two favicons, the touch icon and the
       # documentation social card.
       - name: Site assets are in the repository
-        if: runner.os == 'Linux'
         run: node tools/check-assets.mjs
 
-      - name: Install staticcheck
-        if: runner.os == 'Linux'
-        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      # main.go carries `//go:embed all:frontend/dist`, and frontend/dist is
+      # gitignored, so anything compiling the main package fails with
+      # "pattern all:frontend/dist: no matching files found" before it analyses a
+      # line. A placeholder rather than a real frontend build: no analyser here
+      # inspects the bytes the binary embeds, and the build job already compiles
+      # the real thing on all three platforms.
+      - name: Placeholder for the embedded frontend
+        run: |
+          mkdir -p frontend/dist
+          echo '<!-- CI placeholder -->' > frontend/dist/index.html
 
       - name: Staticcheck
-        if: runner.os == 'Linux'
-        run: staticcheck ./...
+        # PINNED, and with the build tag. Two separate points.
+        #
+        # Pinned because a linter that floats can fail a commit that changed
+        # nothing, when a newly added check fires. The finding may well be real,
+        # but it should arrive in its own deliberate bump rather than as a
+        # surprise on someone else's pull request. Dependabot does not track
+        # versions inside a `run:` step, so this is bumped by hand.
+        #
+        # Tagged because without -tags webkit2_41 the Wails-dependent code is
+        # not built on Linux and therefore not analysed — the check would pass
+        # by not looking.
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@v0.8.1
+          staticcheck -tags webkit2_41 ./...
 
-      - name: Check go.mod tidy
-        if: runner.os == 'Linux'
+      - name: go.mod is tidy
+        # A stale go.mod/go.sum means the dependency set CI resolves is not the
+        # one recorded in the repository, so every other check here verifies
+        # something slightly different from what a release builds.
         run: |
           go mod tidy
           git diff --exit-code go.mod go.sum
@@ -112,42 +187,76 @@ jobs:
   # advisory. govulncheck cannot do this: it reports on what is already merged.
   dependency-review:
     name: Dependency review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
 
   security:
     name: Security audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          # From go.mod, so the toolchain has exactly one source of truth.
           go-version-file: go.mod
 
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install Linux dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev pkg-config
+
+      - name: Placeholder for the embedded frontend
+        run: |
+          mkdir -p frontend/dist
+          echo '<!-- CI placeholder -->' > frontend/dist/index.html
+
+      # THE TRIPWIRE, and it is not ceremony.
+      #
+      # govulncheck's analysis is only as complete as the packages it manages to
+      # load, and it does not fail when one of them does not build: it reports on
+      # the rest and prints a clean bill of health. This job had neither the
+      # placeholder above nor these GTK/WebKit headers, so on Linux the main
+      # package dropped out of every scan it ever ran. Reproduced locally by
+      # removing frontend/dist: `go build ./...` fails with the embed error while
+      # `govulncheck ./...` answers "No vulnerabilities found" and exits 0.
+      #
+      # This step fails loudly if the toolchain cannot compile what the next one
+      # is supposed to analyse.
+      - name: Confirm the tree builds before scanning it
+        run: go build -tags webkit2_41 ./...
+
       - name: Go vulnerability check
+        # Reports only vulnerabilities in code paths the binary actually calls,
+        # standard library included.
+        #
+        # Deliberately @latest, unlike staticcheck above: the point of this step
+        # is to know about advisories published since the last commit, and an old
+        # scanner reports an old world. A new finding here means a real new
+        # advisory, not a new opinion about existing code.
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          govulncheck -tags webkit2_41 ./...
 
       # `|| true` made this decoration: it reported and never failed, so a
       # critical advisory in a shipped dependency would have gone unnoticed.
       # High and above now fails; anything genuinely unfixable belongs in an
-      # explicit exception, not in a swallowed exit code.
-      - name: npm audit
-        run: cd frontend && npm audit --omit=dev --audit-level=high
+      # explicit, documented dismissal rather than a swallowed exit code.
+      - name: npm audit (production dependencies)
+        run: npm audit --omit=dev --audit-level=high
+        working-directory: frontend

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       # Only this job may write findings; everything else stays read-only.
       security-events: write
@@ -34,7 +34,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         if: matrix.language == 'go'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,13 @@ on:
     tags:
       - 'v*'
 
+# The three build jobs run untrusted third-party code — npm packages, Go
+# modules, the Wails CLI — and only need to read the repository. Write access is
+# granted to the `release` job alone, which is what publishes the signed assets,
+# so a compromised build dependency cannot rewrite the repository or tamper with
+# an existing release.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -23,7 +28,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -33,9 +40,9 @@ jobs:
           go-version-file: go.mod
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: "22"
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
@@ -169,10 +176,18 @@ jobs:
 
   release:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      # Build provenance: id-token for the OIDC token that proves the
+      # attestation came from this workflow run, attestations to record it.
+      id-token: write
+      attestations: write
 
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -188,15 +203,62 @@ jobs:
           merge-multiple: true
 
       # SHA-256 manifest consumed by the in-app updater to verify downloads.
+      #
+      # The first line BINDS the manifest to this tag, and the updater refuses
+      # one that names a different release. Without it the signature answers
+      # only "did we sign this?", which an OLD manifest also satisfies — so
+      # anyone able to serve what the app fetches could hand back a previous
+      # release's manifest and binaries and have every check pass while an
+      # older, possibly vulnerable, version is installed.
       - name: Generate checksums
-        run: cd artifacts && sha256sum SnmpLens-* > SnmpLens-checksums.txt
+        working-directory: artifacts
+        run: |
+          {
+            echo "version ${GITHUB_REF_NAME}"
+            sha256sum SnmpLens-windows-* SnmpLens-macos-* SnmpLens-linux-*
+          } > SnmpLens-checksums.txt
+          cat SnmpLens-checksums.txt
 
       # Ed25519-sign the manifest so the updater can authenticate it against the
-      # public key embedded in the app. No-op when the secret is unset.
+      # public key embedded in the app.
+      #
+      # REQUIRED, not best-effort. `updatersign` prints a notice and exits 0
+      # when the key is absent, which is right for a local build and wrong here:
+      # a key that quietly failed to reach the runner would publish an unsigned
+      # release, and the app — which has a public key embedded and therefore
+      # enforces the signature — would refuse every update from it. That is a
+      # broken release nobody notices until someone tries to update.
       - name: Sign checksums
         env:
           UPDATER_PRIVATE_KEY: ${{ secrets.UPDATER_PRIVATE_KEY }}
-        run: go run ./tools/updatersign sign artifacts/SnmpLens-checksums.txt
+        run: |
+          if [ -z "$UPDATER_PRIVATE_KEY" ]; then
+            echo "::error::UPDATER_PRIVATE_KEY is not set; releases must be signed." >&2
+            exit 1
+          fi
+          go run ./tools/updatersign sign artifacts/SnmpLens-checksums.txt
+          test -s artifacts/SnmpLens-checksums.txt.sig
+
+      # Signed, verifiable provenance for every published asset: which workflow,
+      # which commit, which runner produced these exact bytes. It answers a
+      # question the Ed25519 manifest signature does not — that signature proves
+      # the checksums were signed by the holder of the release key, not that the
+      # binaries were built from this repository by this workflow.
+      #
+      # Checkable without trusting anything in this repository:
+      #   gh attestation verify SnmpLens-windows-amd64.exe --repo Wasabules/SnmpLens
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            artifacts/SnmpLens-windows-amd64.exe
+            artifacts/SnmpLens-windows-amd64-setup.exe
+            artifacts/SnmpLens-windows-amd64-portable.zip
+            artifacts/SnmpLens-macos-universal.dmg
+            artifacts/SnmpLens-macos-universal.zip
+            artifacts/SnmpLens-linux-amd64
+            artifacts/SnmpLens-linux-amd64.deb
+            artifacts/SnmpLens-linux-amd64.tar.gz
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@efb35369e0ad2afab669f228072c1b0d510eae64 # v3.0.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,31 @@ CI verification gate (`.github/workflows/ci.yml`, all run from repo root):
 
 ```bash
 go vet -tags webkit2_41 ./...
-go test -race -tags webkit2_41 ./...
-staticcheck ./...                 # go install honnef.co/go/tools/cmd/staticcheck@latest
+go test -race -count=1 -tags webkit2_41 ./...       # on ALL THREE platforms, not just Linux
+staticcheck -tags webkit2_41 ./...                  # PINNED: honnef.co/go/tools/cmd/staticcheck@v0.8.1
 go mod tidy && git diff --exit-code go.mod go.sum   # go.mod must stay tidy
-govulncheck ./...
+go build -tags webkit2_41 ./...                     # the tripwire, see below
+govulncheck -tags webkit2_41 ./...
 ```
+
+Three of those lines are load-bearing in a way the obvious version is not.
+
+**The tests run on every platform we ship.** They used to run on Linux alone "to avoid redundant runs", and they
+are not redundant: `pkg/autostart` is an HKCU Run key, a LaunchAgent and an XDG entry; `pkg/secrets` is DPAPI,
+the Keychain and a file backend; `pkg/network` runs `traceroute6` on macOS and `tracert` on Windows. Three
+implementations behind one interface, one of them ever exercised. The trap-listener race reproduced on Linux and
+never on Windows; the converse is as likely and would have been as invisible.
+
+**`go build` before `govulncheck` is a tripwire, not ceremony.** govulncheck's analysis is only as complete as
+the packages it manages to LOAD, and it does not fail when one does not build — it reports on the rest and
+prints a clean bill of health. The security job had neither the `frontend/dist` placeholder nor the GTK/WebKit
+headers, so on Linux the main package dropped out of every scan it ever ran. Reproduced by deleting
+`frontend/dist`: `go build ./...` fails on the embed while `govulncheck ./...` answers "No vulnerabilities
+found" and exits 0.
+
+**staticcheck is pinned and govulncheck is not**, deliberately and in opposite directions. A linter that floats
+fails a commit that changed nothing when a new check lands; a vulnerability scanner that is pinned reports an
+old world. Dependabot does not see versions inside a `run:` step, so staticcheck is bumped by hand.
 
 Go unit tests live beside the code they cover (`go test ./...`, run in CI). They are deliberately few and target
 the logic that is subtle and easy to break silently — storage pragmas/migrations, aggregation, threshold
@@ -477,6 +497,32 @@ Session credentials follow the same rule as sink credentials: `storage.SessionCo
 ## Releases
 
 Tagging `v*` triggers `.github/workflows/release.yml`, which builds all three platforms and produces: Windows portable zip + NSIS installer (`build/windows/installer/project.nsi`, version string substituted at build time), macOS `.zip` + `.dmg`, Linux `.tar.gz` + `.deb`.
+
+Four things about that workflow are security properties rather than packaging, and each answers a different
+question.
+
+**The build jobs cannot write to the repository.** `permissions: contents: read` at the workflow level;
+`contents: write` is granted to the `release` job alone. The three build jobs run npm packages, Go modules and
+the Wails CLI — third-party code — and a compromised one of those must not be able to rewrite the repository or
+tamper with an existing release.
+
+**Signing is required, not best-effort.** `tools/updatersign` prints a notice and exits 0 when
+`UPDATER_PRIVATE_KEY` is absent, which is right for a local build and wrong in the workflow: a key that quietly
+failed to reach the runner would publish an unsigned release, and the app — which has a public key embedded and
+therefore ENFORCES the signature — would refuse every update from it. A broken release nobody notices until
+someone tries to update. The step fails on an empty secret and asserts the `.sig` is non-empty.
+
+**The manifest is bound to its tag.** Its first line is `version v1.2.3`, and `checkManifestVersion` in
+`pkg/updater` refuses one naming a different release. The signature answers "did we sign this?" and nothing
+else — an OLD manifest satisfies it just as well, so anyone able to serve what the app fetches could hand back a
+previous release's manifest and binaries and have every check pass while an older, possibly vulnerable, version
+is installed. A manifest with no version line is REFUSED rather than tolerated, because tolerating it is the
+replay.
+
+**Provenance is attested** (`actions/attest-build-provenance`), which answers what the Ed25519 signature cannot:
+that these exact bytes were built from this repository by this workflow, rather than signed by whoever holds the
+release key. Verifiable without trusting anything here:
+`gh attestation verify SnmpLens-windows-amd64.exe --repo Wasabules/SnmpLens`.
 
 ## The project site (`docs/`)
 

--- a/pkg/autostart/autostart_darwin.go
+++ b/pkg/autostart/autostart_darwin.go
@@ -68,14 +68,50 @@ func isEnabled() (bool, string, error) {
 	}
 	// Report the registered command rather than the whole plist, so the
 	// settings screen can show something a person can read.
-	body := string(raw)
-	start := strings.Index(body, "<string>")
-	end := strings.Index(body, "</string>")
-	cmd := ""
-	if start >= 0 && end > start {
-		cmd = body[start+len("<string>") : end]
+	return true, programArgument(string(raw)), nil
+}
+
+// programArgument pulls the first <string> of the ProgramArguments array out of
+// a LaunchAgent plist.
+//
+// It has to look for that key. Taking the document's first <string> — which is
+// what this did — returns the LABEL, because <key>Label</key> comes first in
+// every plist we write. So the settings screen offered `com.wasabules.snmplens`
+// as the command that runs at login: the one thing on that screen whose whole
+// purpose is to say WHAT starts, saying instead what the entry is called.
+//
+// Never caught because pkg/autostart's tests ran on Linux only, where this file
+// is not even compiled.
+func programArgument(plist string) string {
+	const key = "<key>ProgramArguments</key>"
+	i := strings.Index(plist, key)
+	if i < 0 {
+		return ""
 	}
-	return true, cmd, nil
+	rest := plist[i+len(key):]
+	start := strings.Index(rest, "<string>")
+	if start < 0 {
+		return ""
+	}
+	rest = rest[start+len("<string>"):]
+	end := strings.Index(rest, "</string>")
+	if end < 0 {
+		return ""
+	}
+	return unescapeXML(rest[:end])
+}
+
+// unescapeXML reverses escapeXML, so a path containing & or < comes back as it
+// was written rather than as its entity.
+func unescapeXML(s string) string {
+	r := strings.NewReplacer(
+		"&lt;", "<",
+		"&gt;", ">",
+		"&quot;", `"`,
+		"&apos;", "'",
+		"&amp;", "&",
+	)
+	return r.Replace(s)
 }
 
 func enable() error {

--- a/pkg/autostart/autostart_darwin_test.go
+++ b/pkg/autostart/autostart_darwin_test.go
@@ -1,0 +1,63 @@
+package autostart
+
+import "testing"
+
+// What the settings screen shows as "runs at login".
+//
+// This reads the ProgramArguments array and not simply the first <string> in
+// the document, and the difference is the whole test: <key>Label</key> comes
+// first in every plist we write, so the naive version returned
+// `com.wasabules.snmplens` — the entry's NAME — where the screen promises the
+// command. It survived because this file is not compiled on Linux, which is
+// where the package's tests used to run.
+func TestProgramArgumentIgnoresTheLabel(t *testing.T) {
+	plist := `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.wasabules.snmplens</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Applications/SnmpLens.app/Contents/MacOS/SnmpLens</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+</dict>
+</plist>`
+
+	got := programArgument(plist)
+	want := "/Applications/SnmpLens.app/Contents/MacOS/SnmpLens"
+	if got != want {
+		t.Errorf("programArgument = %q, want %q", got, want)
+	}
+	if got == "com.wasabules.snmplens" {
+		t.Error("the label was returned as the command")
+	}
+}
+
+func TestProgramArgumentRoundTripsAnEscapedPath(t *testing.T) {
+	// A path that has to be escaped on the way in. `escapeXML` replaces & first
+	// so the entities it writes are not re-escaped; `unescapeXML` has to put
+	// &amp; back LAST for the same reason in reverse, or `&amp;lt;` comes back
+	// as `<` rather than as `&lt;`.
+	path := `/Users/a&b/<Apps>/SnmpLens "beta"`
+	plist := "<key>ProgramArguments</key><array><string>" +
+		escapeXML(path) + "</string></array>"
+
+	if got := programArgument(plist); got != path {
+		t.Errorf("round trip gave %q, want %q", got, path)
+	}
+}
+
+func TestProgramArgumentOnAPlistThatHasNone(t *testing.T) {
+	for name, plist := range map[string]string{
+		"empty":            "",
+		"no key":           "<dict><key>Label</key><string>x</string></dict>",
+		"key but no value": "<key>ProgramArguments</key><array></array>",
+		"unterminated":     "<key>ProgramArguments</key><array><string>/bin/x",
+	} {
+		if got := programArgument(plist); got != "" {
+			t.Errorf("%s: expected no command, got %q", name, got)
+		}
+	}
+}

--- a/pkg/updater/apply.go
+++ b/pkg/updater/apply.go
@@ -46,7 +46,7 @@ func (s *Service) DownloadAndApply() error {
 		return fmt.Errorf("release %s is missing %s; cannot verify the download", p.version, checksumsAsset)
 	}
 
-	wantSum, err := s.verifiedChecksum(ctx, p.checksumURL, p.checksumSigURL, p.assetName)
+	wantSum, err := s.verifiedChecksum(ctx, p.checksumURL, p.checksumSigURL, p.assetName, p.version)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (s *Service) download(ctx context.Context, url, asset string) (string, stri
 // embedded, its Ed25519 signature; it verifies authenticity and returns the
 // SHA-256 recorded for the given asset. This is the trust anchor: once the
 // manifest is authenticated, the asset is trusted by its SHA-256.
-func (s *Service) verifiedChecksum(ctx context.Context, checksumURL, sigURL, asset string) (string, error) {
+func (s *Service) verifiedChecksum(ctx context.Context, checksumURL, sigURL, asset, version string) (string, error) {
 	manifest, err := s.fetchBytes(ctx, checksumURL)
 	if err != nil {
 		return "", fmt.Errorf("fetching checksums: %w", err)
@@ -130,6 +130,12 @@ func (s *Service) verifiedChecksum(ctx context.Context, checksumURL, sigURL, ass
 			return "", fmt.Errorf("fetching signature: %w", err)
 		}
 		if err := verifyManifestSignature(manifest, sig); err != nil {
+			return "", err
+		}
+		// AFTER the signature, not before: an unsigned manifest's version line
+		// is worth nothing, and reporting "wrong release" for a forged file
+		// would say the wrong thing about what is wrong with it.
+		if err := checkManifestVersion(manifest, version); err != nil {
 			return "", err
 		}
 	}
@@ -161,7 +167,16 @@ func (s *Service) fetchBytes(ctx context.Context, url string) ([]byte, error) {
 func parseChecksum(manifest []byte, asset string) (string, error) {
 	sc := bufio.NewScanner(bytes.NewReader(manifest))
 	for sc.Scan() {
-		fields := strings.Fields(sc.Text())
+		line := strings.TrimSpace(sc.Text())
+		// The `version v1.2.3` header has two fields like every checksum entry,
+		// so without this it reaches the match below and answers "version" as
+		// the SHA-256 of an asset named after the tag. Nothing is named that, so
+		// it was harmless — but a parser that only works because no file has a
+		// particular name is one bad release-asset name from being wrong.
+		if strings.HasPrefix(line, manifestVersionPrefix) {
+			continue
+		}
+		fields := strings.Fields(line)
 		if len(fields) != 2 {
 			continue
 		}

--- a/pkg/updater/verify.go
+++ b/pkg/updater/verify.go
@@ -42,3 +42,36 @@ func verifyManifestSignature(manifest, sigBase64 []byte) error {
 	}
 	return nil
 }
+
+// manifestVersionLine is the first line the release workflow writes into the
+// checksums manifest: `version v1.2.3`.
+const manifestVersionPrefix = "version "
+
+// checkManifestVersion refuses a manifest that is not the one for `want`.
+//
+// The signature answers "did we sign this?" and nothing else. It cannot answer
+// "is this the manifest for the release being installed?", because an OLD
+// manifest is signed just as validly as a new one — so anyone able to serve
+// what the app fetches can hand back a previous release's manifest and its
+// binaries, and the app would verify both perfectly and install an older,
+// possibly vulnerable, version. Binding the manifest to its tag is what closes
+// that; nothing else in the chain does.
+//
+// A manifest without the line is REFUSED rather than tolerated, because
+// tolerating it is the replay: an attacker replaying a manifest from before
+// this existed would simply be waved through. Only releases published by this
+// workflow are ever installed, and the updater refuses to move backwards, so
+// there is no case where a legitimate update carries a manifest that predates
+// the line.
+func checkManifestVersion(manifest []byte, want string) error {
+	first, _, _ := strings.Cut(strings.TrimSpace(string(manifest)), "\n")
+	first = strings.TrimSpace(first)
+	if !strings.HasPrefix(first, manifestVersionPrefix) {
+		return fmt.Errorf("checksums manifest is not bound to a release; refusing it")
+	}
+	got := strings.TrimSpace(strings.TrimPrefix(first, manifestVersionPrefix))
+	if got != want {
+		return fmt.Errorf("checksums manifest is for %s, not %s; refusing a replayed manifest", got, want)
+	}
+	return nil
+}

--- a/pkg/updater/verify_test.go
+++ b/pkg/updater/verify_test.go
@@ -1,0 +1,117 @@
+package updater
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// The two questions the manifest has to answer, and they are different ones.
+//
+// The signature answers "did we sign this?". It cannot answer "is this the
+// manifest for the release being installed?", because a manifest from an
+// EARLIER release is signed just as validly — so anyone able to serve what the
+// app fetches can hand back an old manifest and its old binaries, and every
+// check here passes while an older, possibly vulnerable, version is installed.
+// The version line is the only thing in the chain that refuses that.
+
+func signedManifest(t *testing.T, body string) (pub string, manifest, sig []byte) {
+	t.Helper()
+	pubKey, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating a key: %v", err)
+	}
+	manifest = []byte(body)
+	raw := ed25519.Sign(privKey, manifest)
+	return base64.StdEncoding.EncodeToString(pubKey),
+		manifest,
+		[]byte(base64.StdEncoding.EncodeToString(raw))
+}
+
+// withKey swaps the embedded public key for the duration of a test.
+func withKey(t *testing.T, key string) {
+	t.Helper()
+	previous := updaterPublicKey
+	updaterPublicKey = key
+	t.Cleanup(func() { updaterPublicKey = previous })
+}
+
+const manifestBody = "version v1.5.0\n" +
+	"aaaa  SnmpLens-linux-amd64\n" +
+	"bbbb  SnmpLens-windows-amd64.exe\n"
+
+func TestSignatureIsCheckedAgainstTheEmbeddedKey(t *testing.T) {
+	pub, manifest, sig := signedManifest(t, manifestBody)
+	withKey(t, pub)
+
+	if !signatureEnforced() {
+		t.Fatal("a configured key must make the signature mandatory")
+	}
+	if err := verifyManifestSignature(manifest, sig); err != nil {
+		t.Errorf("a manifest signed with the matching key must verify: %v", err)
+	}
+
+	// One byte of the manifest, changed after signing.
+	tampered := append([]byte{}, manifest...)
+	tampered[0] ^= 0x01
+	if err := verifyManifestSignature(tampered, sig); err == nil {
+		t.Error("a modified manifest verified against its old signature")
+	}
+
+	// The right shape of signature, from the wrong key.
+	otherPub, _, otherSig := signedManifest(t, manifestBody)
+	if otherPub == pub {
+		t.Fatal("two generated keys collided")
+	}
+	if err := verifyManifestSignature(manifest, otherSig); err == nil {
+		t.Error("a signature from another key was accepted")
+	}
+}
+
+func TestManifestIsBoundToItsRelease(t *testing.T) {
+	if err := checkManifestVersion([]byte(manifestBody), "v1.5.0"); err != nil {
+		t.Errorf("the manifest for the release being installed must be accepted: %v", err)
+	}
+
+	// THE REPLAY. A previous release's manifest, correctly signed, served in
+	// place of the current one.
+	err := checkManifestVersion([]byte(manifestBody), "v1.6.0")
+	if err == nil {
+		t.Fatal("a manifest for v1.5.0 was accepted while installing v1.6.0")
+	}
+	if !strings.Contains(err.Error(), "replayed") {
+		t.Errorf("the error should say what happened, got: %v", err)
+	}
+
+	// A manifest from before the line existed is refused rather than tolerated:
+	// tolerating it IS the replay, since that is exactly what an attacker
+	// serving an old manifest would present.
+	noLine := "aaaa  SnmpLens-linux-amd64\n"
+	if err := checkManifestVersion([]byte(noLine), "v1.6.0"); err == nil {
+		t.Error("a manifest with no version line was accepted")
+	}
+
+	// Whitespace and a trailing newline must not decide the outcome.
+	if err := checkManifestVersion([]byte("  version v1.5.0  \r\naaaa  x\n"), "v1.5.0"); err != nil {
+		t.Errorf("surrounding whitespace should not matter: %v", err)
+	}
+}
+
+func TestParseChecksumFindsTheAssetAndNothingElse(t *testing.T) {
+	got, err := parseChecksum([]byte(manifestBody), "SnmpLens-linux-amd64")
+	if err != nil || got != "aaaa" {
+		t.Errorf("expected aaaa for the linux asset, got %q (%v)", got, err)
+	}
+
+	// The version line has two fields and so reaches the same parser as a
+	// checksum entry. It must never be mistaken for one.
+	if _, err := parseChecksum([]byte(manifestBody), "v1.5.0"); err == nil {
+		t.Error("the version line was returned as if it were a checksum entry")
+	}
+
+	if _, err := parseChecksum([]byte(manifestBody), "SnmpLens-macos-universal.dmg"); err == nil {
+		t.Error("an asset with no entry must be an error, not an empty checksum")
+	}
+}


### PR DESCRIPTION
Four gaps were named going in. All four were real, and looking for them found a fifth that was worse than any of them.

## The four

**Tests ran on Linux alone.** Three platforms built, one tested, with a comment calling the rest "redundant runs". They are not: `pkg/autostart` is an HKCU Run key, a LaunchAgent and an XDG entry; `pkg/secrets` is DPAPI, the Keychain and a file backend; `pkg/network` runs `traceroute6` on macOS and `tracert` on Windows. Three implementations behind one interface, one of them ever exercised. The trap-listener race fixed in facaabe reproduced on Linux and never on Windows — the converse is as likely and would have been as invisible.

**Signing was optional.** `updatersign` exits 0 without the key, which is right locally and wrong in the workflow: a secret that failed to reach the runner publishes an unsigned release, and the app — which embeds a public key and therefore *enforces* the signature — then refuses every update from it. Broken in a way nobody sees until someone tries to update.

**The manifest was not bound to its release.** The signature answers "did we sign this?" and nothing else; an old manifest satisfies it exactly as well. Anyone able to serve what the app fetches could return a previous release's manifest and binaries, and every check would pass while an older version was installed. First line is now `version <tag>`, and a manifest with *no* line is refused too — tolerating it is the replay.

**Provenance was not attested.** `attest-build-provenance` answers what Ed25519 cannot: that these bytes were built from this repo by this workflow, not merely signed by whoever holds the key.

## The fifth, which the comparison turned up

The security job ran `govulncheck ./...` with no `frontend/dist` placeholder, no GTK/WebKit headers and no build tag — so **on Linux the main package failed to load and dropped out of every scan it ever ran.** govulncheck does not fail when a package will not build; it reports on the rest and prints a clean bill of health.

Reproduced locally by deleting `frontend/dist`:

```
$ go build ./...
main.go:18:12: pattern all:frontend/dist: no matching files found
$ govulncheck ./...
No vulnerabilities found.
$ echo $?
0
```

There is now a `go build` step before it whose only job is to fail loudly, and staticcheck gets the same build tag for the same reason.

## Also

Release build jobs drop to `contents: read` (they run third-party code; only `release` publishes) · checkouts stop persisting the token into `.git/config` · runners pinned to `ubuntu-24.04` · staticcheck pinned to v0.8.1 while govulncheck stays `@latest`, deliberately in opposite directions · `-count=1` defeats a test cache that would report a previous toolchain's PASS as this run's · concurrency cancels superseded PR runs, never a push to main · Node 22, because Vite 8 needs `^20.19 || >=22.12` and pinning `"20"` rested on which 20.x the runner resolved.

`pkg/updater` had **no tests at all**, which for the trust anchor of the update path is its own finding. It has some now, and one caught a real defect while being written: `version v1.2.3` has two fields like every checksum line, so `parseChecksum` answered `version` as the SHA-256 of an asset named after the tag. Nothing is named that — a parser that worked only because no file had a particular name.