### PR TITLE
Add the gate that keeps the build silent, now that it can be one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,21 @@ jobs:
         run: npm ci
         working-directory: frontend
 
+      # The gate that keeps `npm run build` silent.
+      #
+      # The Svelte compiler emits accessibility and unused-CSS warnings and
+      # never fails on them, so a build stays green while they accumulate — 42
+      # of them had, until they were cleared. Verified rather than assumed:
+      # removing one `role="presentation"` leaves `npm run build` at exit 0 and
+      # takes this step to exit 1.
+      #
+      # `checkJs` is off in jsconfig.json, and that is what makes this usable:
+      # with it on, the same command reports 1631 diagnostics on a codebase
+      # written without annotations. See the comment there.
+      - name: Svelte check
+        run: npm run check
+        working-directory: frontend
+
       # Compiles every component, fails on a name nothing declares and on a
       # rendered expression that depends on state it does not name — the two
       # things Svelte 5 stopped reporting. Also the locale parity check.

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
-    "moduleResolution": "Node",
+    // "Bundler", not "Node": Vite resolves the imports, and "Node" is the
+    // TypeScript 4 algorithm, now reported as deprecated and due to stop
+    // working in TypeScript 7.0.
+    "moduleResolution": "Bundler",
     "target": "ESNext",
     "module": "ESNext",
     /**
@@ -20,12 +23,24 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     /**
-     * Typecheck JS in `.svelte` and `.js` files by default.
-     * Disable this if you'd like to use dynamic types.
+     * OFF, deliberately, and this is a decision rather than an omission.
+     *
+     * It came from the Vite template and turns full TypeScript inference on a
+     * codebase written without a single annotation. Measured: 1631 diagnostics,
+     * 70% of them "implicitly has an 'any' type" and most of the rest artefacts
+     * of `writable([])` inferring `never[]`, so that every `.set()` with real
+     * data is an error. None of it describes a defect, and an editor that
+     * reports 1631 non-problems on open is an editor whose reports get ignored.
+     *
+     * With it off, `svelte-check` reports zero — and that is what makes it
+     * usable as a CI gate for the things it DOES catch: the accessibility and
+     * unused-CSS warnings the Svelte compiler emits and never fails on.
+     *
+     * Turning it back on is a real project — annotating 45 components — not a
+     * flag flip.
      */
-    "checkJs": true
+    "checkJs": false
   },
   /**
    * Use global.d.ts instead of compilerOptions.types

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "@sveltejs/vite-plugin-svelte": "^7.3.0",
         "acorn": "^8.18.0",
         "svelte": "^5.57.0",
+        "svelte-check": "^4.7.6",
         "vite": "^8.2.2"
       }
     },
@@ -872,6 +873,16 @@
         "acorn": "^8.9.0"
       }
     },
+    "node_modules/@sveltejs/load-config": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/load-config/-/load-config-0.2.3.tgz",
+      "integrity": "sha512-VT3qmUb8pRV2QrZjd8iAmtg8lf4W0TIjZbvXtz5MKei/q96teWZgGJyyidJzOjzZzvdq616eSRVeMYIQChUTAQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-7.3.0.tgz",
@@ -967,6 +978,22 @@
       },
       "peerDependencies": {
         "chart.js": ">=3.2.0"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/cli-color": {
@@ -1690,6 +1717,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.7.tgz",
@@ -1770,6 +1811,31 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/svelte-check": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.6.tgz",
+      "integrity": "sha512-t2scM//ZuVbSY/T2w6FSBw1v9s2NEmh/g+sy1lqtosW5ylBV5AF4wFb1Ts9Kf3MbfPDUDJDZ9L436YT0SPTdvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "@sveltejs/load-config": "^0.2.3",
+        "chokidar": "^4.0.1",
+        "fdir": "^6.2.0",
+        "picocolors": "^1.0.0",
+        "sade": "^1.7.4"
+      },
+      "bin": {
+        "svelte-check": "bin/svelte-check"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "svelte": "^4.0.0 || ^5.0.0-next.0",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/svelte-i18n": {
@@ -2262,6 +2328,21 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
       "license": "ISC"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/vite": {
       "version": "8.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,12 +8,14 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
-    "screenshots": "node ../tools/screenshots.mjs"
+    "screenshots": "node ../tools/screenshots.mjs",
+    "check": "svelte-check --tsconfig ./jsconfig.json --fail-on-warnings"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^7.3.0",
     "acorn": "^8.18.0",
     "svelte": "^5.57.0",
+    "svelte-check": "^4.7.6",
     "vite": "^8.2.2"
   },
   "dependencies": {


### PR DESCRIPTION
I said `svelte-check` had nothing to check here because there is no `tsconfig.json`. Both halves were wrong: there is a `jsconfig.json`, and running it reports **1631 diagnostics**.

They are not findings. 70% are *"implicitly has an 'any' type"* and most of the rest are `writable([])` inferring `never[]`, so every `.set()` with real data is an error. That is what `checkJs: true` does to a codebase written without a single annotation — it came from the Vite template and nobody chose it. An editor reporting 1631 non-problems on open is an editor whose reports get ignored.

## Why it is worth having with `checkJs` off

With it off the same command reports **zero**. And the Svelte compiler emits accessibility and unused-CSS warnings that it **never fails on**, so a build stays green while they accumulate — 42 of them had, until they were cleared, and nothing stops them coming back.

Measured, not assumed — remove one `role="presentation"`:

| | exit |
|---|---|
| `npm run build` | **0** |
| `npm run check` | **1** |

## Two dated config options

`moduleResolution: "Node"` is the TypeScript 4 algorithm and `baseUrl` is unused here; both are reported as due to stop working in TypeScript 7.0. They had to go for this to be a gate at all — `--fail-on-warnings` counted them and failed on a clean tree.

`svelte-check` is a devDependency rather than an `npx` download, so the version is in the lockfile and `npm ci` has it.

## The real difference with SyslogStudio

Its frontend is TypeScript throughout — 15 of 15 components carry `lang="ts"`, plus 11 `.ts` files — so its `--fail-on-warnings` is a genuine type gate. Ours is a Svelte-warning gate. Turning `checkJs` back on here means annotating 45 components: a project, not a flag flip.