### PR TITLE
Fix four defects an audit found, each with the check that would have caught it

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
+    "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/icons.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
     "screenshots": "node ../tools/screenshots.mjs",
     "check": "svelte-check --tsconfig ./jsconfig.json --fail-on-warnings"
   },

--- a/frontend/src/MibPanel.svelte
+++ b/frontend/src/MibPanel.svelte
@@ -106,13 +106,21 @@
     return items;
   }
 
-  onMount(async () => {
-    persistentMibDir = await GetPersistentMibDirectory();
-    // MIB loading is now handled in App.svelte after paths initialization
-    
-    // Add keyboard event listener
+  // NOT async. Svelte calls back whatever the callback RETURNS, and an async
+  // function returns a Promise — never a function — so the cleanup below was
+  // dropped and the keydown listener stayed on `document`. This panel is
+  // unmounted on every tab switch, so they accumulated: after ten switches,
+  // ten handlers, each answering the same arrow key.
+  //
+  // The directory is fetched without awaiting it here. Nothing in the first
+  // paint needs it, and making the callback async to shorten that line is
+  // exactly the trade that lost the cleanup.
+  onMount(() => {
+    GetPersistentMibDirectory()
+      .then((dir) => { persistentMibDir = dir; })
+      .catch((e) => console.warn('Could not read the persistent MIB directory:', e));
+
     document.addEventListener('keydown', handleKeyboardNavigation);
-    
     return () => {
       document.removeEventListener('keydown', handleKeyboardNavigation);
     };

--- a/frontend/src/icons.js
+++ b/frontend/src/icons.js
@@ -79,6 +79,7 @@ export const icons = {
   // --- States (semantic colors applied via .icon-success / .icon-error / .icon-warning) ---
   'circle-check': '<circle cx="12" cy="12" r="10"/><path d="m9 12 2 2 4-4"/>',
   'circle-x': '<circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/>',
+  'shield-check': '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/>',
   // --- Service / background mode ---
   'server-cog': '<path d="M5 10H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-1"/><path d="M5 14H4a2 2 0 0 0-2 2v4a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2h-1"/><path d="M6 6h.01"/><path d="M6 18h.01"/><circle cx="12" cy="12" r="3"/><path d="M12 8v1"/><path d="M12 15v1"/><path d="M16 12h-1"/><path d="M9 12H8"/>',
   'circle-alert': '<circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/>',

--- a/frontend/src/mib/NodeDetails.svelte
+++ b/frontend/src/mib/NodeDetails.svelte
@@ -76,7 +76,7 @@
         {#if selectedNode.parent}
           <div class="detail-row">
             <span class="detail-label">{$_('nodeDetails.parent')}</span>
-            <span class="detail-value">{selectedNode.parent.name}</span>
+            <span class="detail-value">{selectedNode.parent}</span>
           </div>
         {/if}
 

--- a/frontend/src/stores/pollingStore.js
+++ b/frontend/src/stores/pollingStore.js
@@ -25,6 +25,36 @@ const MAX_DATA_POINTS = 5000;
 // it on every tick would bury the UI under identical toasts.
 const warnedNonNumeric = new Set();
 
+/**
+ * One sample, in the shape the rest of the interface expects.
+ *
+ * ONE function because there are two ways in — live samples pushed by the Go
+ * scheduler, and stored ones read back on startup — and they had drifted. The
+ * live path wrote `value: p.value ?? null`; the restored path wrote `p.value`
+ * bare, and Go's `omitempty` leaves that `undefined`. Consumers test for null:
+ * `MetricTiles.svelte:106` decides the failing indicator with
+ * `lastPoint.value === null`, `MonitorChart.svelte:243` counts a failed sample
+ * the same way. So after any restart a restored session stopped showing which
+ * of its points had failed — silently, and only for sessions that had been
+ * reloaded, which is why it survived.
+ *
+ * `delta`, `rate` and `responseTimeMs` had drifted the same way. Two places
+ * building the same shape is the defect; the fix is that there is one.
+ */
+export function normalisePoint(p) {
+  return {
+    target: p.target,
+    timestamp: p.timestamp,
+    value: p.value ?? null,
+    delta: p.delta ?? null,
+    rate: p.rate ?? null,
+    responseTimeMs: p.responseTimeMs || 0,
+    error: p.error || null,
+    snmpType: p.snmpType || '',
+    oid: p.oid || '',
+  };
+}
+
 // The poll clock lives in Go.
 //
 // It used to be a setInterval here, which meant monitoring only ran while the
@@ -44,17 +74,7 @@ function createPollingStore() {
     update((sessions) => sessions.map((s) => {
       if (s.id !== sessionId) return s;
 
-      const incoming = points.map((p) => ({
-        target: p.target,
-        timestamp: p.timestamp,
-        value: p.value ?? null,
-        delta: p.delta ?? null,
-        rate: p.rate ?? null,
-        responseTimeMs: p.responseTimeMs || 0,
-        error: p.error || null,
-        snmpType: p.snmpType || '',
-        oid: p.oid || '',
-      }));
+      const incoming = points.map(normalisePoint);
 
       warnAboutUngraphableValues(sessionId, incoming);
 
@@ -209,17 +229,7 @@ function createPollingStore() {
         let results = [];
         try {
           const points = await MonitorLoadSessionData(s.id, MAX_DATA_POINTS * (s.targets?.length || 1));
-          results = (points || []).map((p) => ({
-            target: p.target,
-            timestamp: p.timestamp,
-            value: p.value,
-            delta: p.delta,
-            rate: p.rate,
-            responseTimeMs: p.responseTimeMs,
-            error: p.error || null,
-            snmpType: p.snmpType || '',
-            oid: p.oid || '',
-          }));
+          results = (points || []).map(normalisePoint);
         } catch (e) {
           console.warn('Failed to load session data:', e);
         }

--- a/frontend/tests/icons.test.mjs
+++ b/frontend/tests/icons.test.mjs
@@ -1,0 +1,105 @@
+// Every <Icon name="..."> names an icon that exists.
+//
+// `Icon.svelte` renders `{@html icons[name] || ''}`. A name that is not in the
+// registry produces a 24x24 SVG with nothing in it — no error, no warning, no
+// blank square, just a gap the width of an icon that reads as spacing. It
+// shipped: the credential-custody banner in SnmpSettings asked for
+// `shield-check`, which was never added, so the one line telling the user their
+// passwords are held by the OS keychain rendered with no icon beside it.
+//
+// This is the check a `keyof typeof icons` would give a TypeScript codebase,
+// and it costs one file instead of a migration.
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { icons } from '../src/icons.js';
+
+const root = new URL('../src/', import.meta.url).pathname.replace(/^[/]([A-Za-z]:)/, '$1');
+
+function svelteFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) out.push(...svelteFiles(path));
+    else if (name.endsWith('.svelte')) out.push(path);
+  }
+  return out;
+}
+
+let failures = 0;
+const check = (name, ok, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? ' — ' + extra : ''}`);
+  if (!ok) failures++;
+};
+
+/** Literal icon names used in a component, and how many are computed. */
+function iconNames(source) {
+  const literal = [];
+  let dynamic = 0;
+  for (const tag of source.matchAll(/<Icon\b[^>]*>/g)) {
+    const m = tag[0].match(/\bname\s*=\s*"([^"]*)"/);
+    if (m) literal.push(m[1]);
+    else if (/\bname\s*=\s*\{/.test(tag[0])) dynamic++;
+  }
+  return { literal, dynamic };
+}
+
+const files = svelteFiles(root);
+
+// Every .svelte AND every .js under src/, because a name chosen by type is a
+// string in a helper rather than an attribute value.
+const allSources = [];
+(function collect(dir) {
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name);
+    if (statSync(path).isDirectory()) collect(path);
+    else if ((name.endsWith('.svelte') || name.endsWith('.js')) && name !== 'icons.js') {
+      allSources.push(readFileSync(path, 'utf8'));
+    }
+  }
+})(root);
+
+const missing = [];
+let checked = 0;
+let computed = 0;
+
+for (const file of files) {
+  const { literal, dynamic } = iconNames(readFileSync(file, 'utf8'));
+  computed += dynamic;
+  for (const name of literal) {
+    checked++;
+    if (!(name in icons)) missing.push(`${basename(file)}: "${name}"`);
+  }
+}
+
+check('there are icons to check', checked > 0, `${checked} literal names, ${computed} computed`);
+check('every literal icon name is in the registry', missing.length === 0, missing.join(', '));
+
+// A registry entry nothing uses is not a defect — it is weight, and worth
+// knowing about, but the icons file says up front that it holds only what is
+// used, so a drift here means that sentence has stopped being true.
+//
+// Searched in the WHOLE source and not only inside an `<Icon>` tag: a name
+// chosen by node type lives in the script, as a helper returning 'table' or
+// 'file'. Looking only at the attribute reported five icons as orphans that six
+// components use.
+const everywhere = allSources.join('\n');
+const orphans = Object.keys(icons).filter(
+  (n) => !everywhere.includes("'" + n + "'") && !everywhere.includes('"' + n + '"'));
+check('the registry holds only icons the interface uses', orphans.length === 0, orphans.join(', '));
+
+// Prove the detector detects, or a green run means nothing.
+{
+  const probe = '<Icon name="not-a-real-icon" size={14} />';
+  const { literal } = iconNames(probe);
+  check('the detector reads a literal name', literal.length === 1 && literal[0] === 'not-a-real-icon');
+  check('and that name is absent from the registry', !('not-a-real-icon' in icons));
+
+  const dyn = iconNames('<Icon name={whatever} />');
+  check('and counts a computed name rather than reading it',
+    dyn.literal.length === 0 && dyn.dynamic === 1);
+
+  // The one that shipped.
+  check('shield-check, which was missing, is there now', 'shield-check' in icons);
+}
+
+process.exit(failures ? 1 : 0);

--- a/frontend/tests/icons.test.mjs
+++ b/frontend/tests/icons.test.mjs
@@ -9,18 +9,22 @@
 //
 // This is the check a `keyof typeof icons` would give a TypeScript codebase,
 // and it costs one file instead of a migration.
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join, basename } from 'node:path';
 import { icons } from '../src/icons.js';
 
 const root = new URL('../src/', import.meta.url).pathname.replace(/^[/]([A-Za-z]:)/, '$1');
 
+// `withFileTypes` rather than a stat per entry: readdir already knows what each
+// one is, so asking again is a second answer to a question that can change
+// between the two — which is what CodeQL's js/file-system-race is about, and
+// what tools/serve-site.mjs says at more length.
 function svelteFiles(dir) {
   const out = [];
-  for (const name of readdirSync(dir)) {
-    const path = join(dir, name);
-    if (statSync(path).isDirectory()) out.push(...svelteFiles(path));
-    else if (name.endsWith('.svelte')) out.push(path);
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...svelteFiles(path));
+    else if (entry.name.endsWith('.svelte')) out.push(path);
   }
   return out;
 }
@@ -49,10 +53,10 @@ const files = svelteFiles(root);
 // string in a helper rather than an attribute value.
 const allSources = [];
 (function collect(dir) {
-  for (const name of readdirSync(dir)) {
-    const path = join(dir, name);
-    if (statSync(path).isDirectory()) collect(path);
-    else if ((name.endsWith('.svelte') || name.endsWith('.js')) && name !== 'icons.js') {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) collect(path);
+    else if ((entry.name.endsWith('.svelte') || entry.name.endsWith('.js')) && entry.name !== 'icons.js') {
       allSources.push(readFileSync(path, 'utf8'));
     }
   }

--- a/frontend/tests/lifecycle.test.mjs
+++ b/frontend/tests/lifecycle.test.mjs
@@ -108,6 +108,48 @@ for (const file of files) {
 check('every lifecycle call is at the top level of its component',
   offenders.length === 0, offenders.join(' | '));
 
+// An `onMount` whose callback is async and returns a cleanup.
+//
+// Svelte calls back whatever the callback RETURNS. An async function returns a
+// Promise, never a function, so the cleanup is dropped — silently, with the
+// listener it was meant to remove still attached. It is the same failure the
+// check above exists for, reached a different way: MibPanel registered a keydown
+// listener and returned its remover from an async onMount, so every tab switch
+// left another one behind.
+//
+// Its own brace matcher rather than depthAt above: that one counts parentheses
+// as well, which answers a different question and made this silently find
+// nothing.
+function asyncOnMountReturningCleanup(code) {
+  const hits = [];
+  for (const m of code.matchAll(/onMount[ 	]*\([ 	]*async\b/g)) {
+    const brace = code.indexOf('{', m.index);
+    if (brace < 0) continue;
+    let d = 0;
+    let end = -1;
+    for (let i = brace; i < code.length; i++) {
+      if (code[i] === '{') d++;
+      else if (code[i] === '}') { d--; if (d === 0) { end = i; break; } }
+    }
+    if (end < 0) continue;
+    const body = code.slice(brace + 1, end);
+    // A `return` that hands something back. A bare `return;` is an early exit.
+    const ret = body.match(/(^|[;{}\n])[ \t]*return[ \t]+[^;\n]/);
+    if (ret) hits.push(code.slice(0, m.index).split(String.fromCharCode(10)).length);
+  }
+  return hits;
+}
+
+const asyncCleanups = [];
+for (const file of svelteFiles(root)) {
+  for (const line of asyncOnMountReturningCleanup(scriptOf(readFileSync(file, 'utf8')))) {
+    asyncCleanups.push(file.split(/[\\/]/).pop() + ': async onMount returns at script line ' + line);
+  }
+}
+
+check('no async onMount returns a cleanup Svelte will never call',
+  asyncCleanups.length === 0, asyncCleanups.join(' | '));
+
 // Prove the detector works, or a passing run means nothing.
 const trap = `
   import { onMount, onDestroy } from 'svelte';
@@ -121,5 +163,35 @@ const good = trap.indexOf('onDestroy(() => cleanup())');
 const bad = trap.indexOf('onDestroy(() => leak())');
 check('the detector accepts a top-level registration', trapDepth[good] === 0);
 check('the detector rejects one nested in onMount', trapDepth[bad] > 0, String(trapDepth[bad]));
+
+// And the second detector, on the shape that shipped.
+{
+  const returned = 'onMount(async () => {' +
+    ' await load();' +
+    ' document.addEventListener("keydown", h);' +
+    ' return () => document.removeEventListener("keydown", h);' +
+    '});';
+  check('the detector sees an async onMount handing back a cleanup',
+    asyncOnMountReturningCleanup(returned).length === 1);
+
+  const fixed = 'onMount(() => {' +
+    ' load();' +
+    ' document.addEventListener("keydown", h);' +
+    ' return () => document.removeEventListener("keydown", h);' +
+    '});';
+  check('and says nothing once the callback is synchronous',
+    asyncOnMountReturningCleanup(fixed).length === 0);
+
+  // An async onMount is fine on its own — most of them are. Only one that
+  // hands something back is broken.
+  const noReturn = 'onMount(async () => { await load(); });';
+  check('and nothing about an async onMount that returns nothing',
+    asyncOnMountReturningCleanup(noReturn).length === 0);
+
+  // A bare early exit is not a cleanup.
+  const early = 'onMount(async () => { if (!x) return; await load(); });';
+  check('and nothing about a bare early return',
+    asyncOnMountReturningCleanup(early).length === 0);
+}
 
 process.exit(failures ? 1 : 0);

--- a/frontend/tests/polling.smoke.mjs
+++ b/frontend/tests/polling.smoke.mjs
@@ -6,7 +6,7 @@
 // charts read. A ReferenceError in this file's path once silently disabled all
 // monitoring, which is exactly the class of bug this catches.
 import * as esbuild from 'esbuild';
-import { writeFileSync, mkdtempSync } from 'node:fs';
+import { writeFileSync, mkdtempSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -82,7 +82,7 @@ if (!globalThis.navigator) {
   Object.defineProperty(globalThis, 'navigator', { value: { language: 'en' }, configurable: true });
 }
 
-const { pollingStore } = await import(pathToFileURL(out).href);
+const { pollingStore, normalisePoint } = await import(pathToFileURL(out).href);
 const { get } = await import('svelte/store');
 
 let failures = 0;
@@ -153,5 +153,41 @@ await pollingStore.stopPolling(id);
 s = get(pollingStore).find((x) => x.id === id);
 check('stopping reaches Go', calls.stopped.includes(id));
 check('the session reads as stopped', !!s && s.running === false);
+
+// A RESTORED sample has to arrive in the same shape as a live one.
+//
+// Go's `omitempty` drops a zero value, so a stored point whose read failed comes
+// back with no `value` key at all. The live path normalised that to null and the
+// restore path did not, and consumers decide "this sample failed" with
+// `=== null` — MetricTiles.svelte:106 for the failing indicator,
+// MonitorChart.svelte:243 for the failed count. So after a restart a restored
+// session stopped showing which of its points had failed, silently, and only
+// for sessions that had been reloaded, which is why it survived.
+//
+// Tested as the pure function plus a source check that both paths call it,
+// because there being ONE shape is the fix — patching the restore path would
+// have left the next field free to drift.
+{
+  // What Go sends for a failed read: no value, no delta, no rate, no timing.
+  const failed = normalisePoint({
+    target: '10.0.0.1', timestamp: '2026-01-01T00:00:00Z', oid: '1.3.6.1', error: 'timeout',
+  });
+  check('a point with no value reads as null, not undefined', failed.value === null,
+    JSON.stringify(failed.value));
+  check('and so do delta and rate', failed.delta === null && failed.rate === null,
+    JSON.stringify([failed.delta, failed.rate]));
+  check('and a missing responseTimeMs is 0', failed.responseTimeMs === 0,
+    JSON.stringify(failed.responseTimeMs));
+
+  // A real reading is left alone, including a legitimate zero.
+  const ok = normalisePoint({ target: 't', timestamp: 'x', oid: 'o', value: 0, delta: 0, rate: 0 });
+  check('a zero reading stays zero rather than becoming null',
+    ok.value === 0 && ok.delta === 0 && ok.rate === 0,
+    JSON.stringify([ok.value, ok.delta, ok.rate]));
+
+  const source = readFileSync(new URL('../src/stores/pollingStore.js', import.meta.url), 'utf8');
+  const uses = (source.match(/map\(normalisePoint\)/g) || []).length;
+  check('both the live and the restored path go through it', uses === 2, String(uses));
+}
 
 process.exit(failures ? 1 : 0);

--- a/pkg/mib/nodefields_test.go
+++ b/pkg/mib/nodefields_test.go
@@ -1,0 +1,94 @@
+package mib
+
+import (
+	"testing"
+
+	"github.com/sleepinggenius2/gosmi"
+)
+
+// Status, Units and Parent reach the tree.
+//
+// `NodeDetails.svelte` has rendered all three since it was written, each behind
+// an `{#if}`, and this struct carried none of them — so the three rows never
+// appeared and nobody could see that they never appeared. gosmi has had the
+// data all along: `Node.Status` and `Type.Units`.
+//
+// Status is the one that matters. SMI marks an object `deprecated` or
+// `obsolete`, and a browser that does not say so lets someone build monitoring
+// on an OID the vendor has withdrawn.
+func TestTreeCarriesStatusUnitsAndParent(t *testing.T) {
+	// Exit THEN Init, and SetPath rather than AppendPath: Init alone finds the
+	// existing handle with every previously loaded module still in it, and
+	// AppendPath accumulates directories.
+	gosmi.Exit()
+	gosmi.Init()
+	gosmi.SetPath("../../mibs")
+	roots, err := NewService("../../mibs").LoadAll()
+	if err != nil {
+		t.Skipf("could not load the bundled MIBs: %v", err)
+	}
+	if len(roots) == 0 {
+		t.Fatal("no tree was built")
+	}
+
+	byName := map[string]*Node{}
+	var walk func(*Node)
+	walk = func(n *Node) {
+		byName[n.Name] = n
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	for _, r := range roots {
+		walk(r)
+	}
+
+	// UNITS "seconds" in IP-MIB. A concrete object rather than "some node has
+	// units", so the test says what it checked.
+	if n := byName["ipReasmTimeout"]; n == nil {
+		t.Error("ipReasmTimeout is not in the tree")
+	} else if n.Units != "seconds" {
+		t.Errorf("ipReasmTimeout units = %q, want \"seconds\"", n.Units)
+	}
+
+	// Every node the standard MIBs declare carries a STATUS clause.
+	if n := byName["ifDescr"]; n == nil {
+		t.Error("ifDescr is not in the tree")
+	} else {
+		if n.Status == "" {
+			t.Error("ifDescr has no status; the SMI declares one for every object")
+		}
+		if n.Status == "Unknown" {
+			t.Error("ifDescr reports gosmi's zero value as though the MIB declared it")
+		}
+		if n.Parent != "ifEntry" {
+			t.Errorf("ifDescr parent = %q, want \"ifEntry\"", n.Parent)
+		}
+	}
+
+	// A root has no parent, and must not claim one.
+	for _, r := range roots {
+		if r.Parent != "" {
+			t.Errorf("root %s claims parent %q", r.Name, r.Parent)
+		}
+	}
+
+	// The status the interface will show has to be a word, not a number: it is
+	// rendered straight into the panel.
+	withStatus := 0
+	for _, n := range byName {
+		if n.Status == "" {
+			continue
+		}
+		withStatus++
+		switch n.Status {
+		case "Current", "Deprecated", "Obsolete", "Mandatory", "Optional":
+		default:
+			t.Errorf("%s has status %q, which is not an SMI status", n.Name, n.Status)
+		}
+	}
+	if withStatus == 0 {
+		t.Error("not one node in the corpus carries a status")
+	}
+	t.Logf("%d of %d nodes carry a status", withStatus, len(byName))
+}

--- a/pkg/mib/service.go
+++ b/pkg/mib/service.go
@@ -22,6 +22,17 @@ type Node struct {
 	Syntax      string           `json:"syntax"`
 	Access      string           `json:"access"`
 	EnumValues  map[string]int64 `json:"enumValues,omitempty"`
+
+	// Status, Units and Parent are what NodeDetails.svelte renders under
+	// "Status", "Units" and "Parent". It had been rendering them since it was
+	// written and this struct never carried them, so the three rows were
+	// guarded by `{#if}` and never appeared — dead markup nobody could see was
+	// dead. Status is the one that matters: SMI marks an object `deprecated`
+	// or `obsolete`, and a MIB browser that does not say so lets you build
+	// monitoring on something the vendor has withdrawn.
+	Status string `json:"status,omitempty"`
+	Units  string `json:"units,omitempty"`
+	Parent string `json:"parent,omitempty"`
 }
 
 // Service handles MIB loading and parsing.
@@ -126,8 +137,14 @@ func (s *Service) buildTree(loadedModuleNames []string) ([]*Node, error) {
 					MibType:     node.Kind.String(),
 					Access:      node.Access.String(),
 				}
+				// "Unknown" is gosmi's zero value, not a status a MIB declares.
+				// Sending it would put the word in the panel for every node.
+				if st := node.Status.String(); st != "" && st != "Unknown" {
+					newNode.Status = st
+				}
 				if node.Type != nil {
 					newNode.Syntax = node.Type.Name
+					newNode.Units = node.Type.Units
 					if node.Type.Enum != nil && len(node.Type.Enum.Values) > 0 {
 						newNode.EnumValues = make(map[string]int64)
 						for _, val := range node.Type.Enum.Values {
@@ -149,6 +166,9 @@ func (s *Service) buildTree(loadedModuleNames []string) ([]*Node, error) {
 			parentOidStr := oidStr[:lastDot]
 			if parentNode, ok := nodeMap[parentOidStr]; ok {
 				parentNode.Children = append(parentNode.Children, mibNode)
+				// The NAME, not the node: the tree is nested, so a pointer back
+				// up would be a cycle and json.Marshal would not return.
+				mibNode.Parent = parentNode.Name
 				isChild[oidStr] = true
 			}
 		}


### PR DESCRIPTION
None of these was found by running the application. All four came out of pointing a type checker at the tree for an afternoon — the cheap half of a TypeScript migration, and the part worth doing on its own.

## A blank icon where the banner says the OS holds your passwords

`SnmpSettings` asked for `shield-check`; `icons.js` did not have it. `Icon.svelte` renders `{@html icons[name] || ''}`, so an unknown name is a 24×24 SVG containing nothing — no error, no warning, no missing-image box, just a gap that reads as spacing.

`icons.test.mjs` now checks all **166 literal names** against the registry. That is what `keyof typeof icons` gives a TypeScript codebase, for one file instead of a migration. It also reports unused registry entries — searching the whole source, because a name chosen by node type lives in a helper rather than in the attribute, and looking only at the tag called five *used* icons orphans.

## Restored monitoring sessions stopped showing which samples had failed

Two places built the same point. Live: `value: p.value ?? null`. Restored: `p.value` bare — and Go's `omitempty` leaves that `undefined`. `MetricTiles.svelte:106` and `MonitorChart.svelte:243` decide "this sample failed" with `=== null`.

So after any restart a reloaded session lost its failing indicator, silently, and **only for sessions that had been reloaded** — which is why it survived. `delta`, `rate` and `responseTimeMs` had drifted the same way.

The fix is that there is now one `normalisePoint`. Patching the restore path would have left the next field free to drift. Tested through the real store, including that a legitimate zero stays zero.

## A keyboard listener accumulating on every tab switch

`MibPanel` registered one in an `async` onMount and returned its remover. Svelte calls back whatever the callback **returns**, and an async function returns a Promise — never a function — so the cleanup was dropped. Ten tab switches, ten handlers answering the same arrow key.

`lifecycle.test.mjs` — which exists because of a listener that accumulated for the neighbouring reason — now detects the shape, with its own brace matcher: reusing `depthAt` made it find nothing, because that one counts parentheses too and answers a different question.

## Three rows of the MIB node panel that could never appear

`NodeDetails.svelte` has rendered Status, Units and Parent behind `{#if}` since it was written, and `mib.Node` carried none of them. **gosmi has had the data all along.**

Populated rather than deleted, because Status is worth having: SMI marks an object `deprecated` or `obsolete`, and a browser that does not say so lets someone build monitoring on an OID the vendor has withdrawn. **622 of the 702 nodes** in the bundled corpus carry one. `Parent` is the *name*, not the node — the tree is nested, and a pointer back up is a cycle `json.Marshal` never returns from.

Wails regenerated `models.ts` with `status?`, `units?` and `parent?` on its own, which is the "the bridge is free" point from the migration costing, demonstrated.

---

421 frontend assertions, 13 Go packages, `wails build`, `npm run check` and `npm run build` all pass.