### PR TITLE
Two injection defects an audit found: syslog control characters and CSV formulas

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/icons.test.mjs && node tests/snmpparams.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
+    "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/icons.test.mjs && node tests/snmpparams.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/csv.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
     "screenshots": "node ../tools/screenshots.mjs",
     "check": "svelte-check --tsconfig ./jsconfig.json --fail-on-warnings"
   },

--- a/frontend/src/DiffModal.svelte
+++ b/frontend/src/DiffModal.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from 'svelte';
   import { onBackdrop } from './utils/modal';
+  import { escapeCSV, downloadFile } from './utils/csv';
   import { _ } from 'svelte-i18n';
 
   export let entryA;
@@ -80,19 +81,10 @@
   function exportDiffCSV() {
     const lines = ['Status,OID,Value A,Value B'];
     for (const row of visibleRows) {
-      const escape = (s) => {
-        if (s.includes(',') || s.includes('"') || s.includes('\n')) return '"' + s.replace(/"/g, '""') + '"';
-        return s;
-      };
-      lines.push(`${row.status},${escape(row.oid)},${escape(row.valueA)},${escape(row.valueB)}`);
+      lines.push(`${row.status},${escapeCSV(row.oid)},${escapeCSV(row.valueA)},${escapeCSV(row.valueB)}`);
     }
-    const blob = new Blob([lines.join('\n')], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `snmp-diff-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}.csv`;
-    a.click();
-    URL.revokeObjectURL(url);
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    downloadFile(lines.join('\n'), `snmp-diff-${stamp}.csv`, 'text/csv');
   }
 
   function formatLabel(entry) {

--- a/frontend/src/DiscoveryPanel.svelte
+++ b/frontend/src/DiscoveryPanel.svelte
@@ -95,7 +95,7 @@
   function exportCSV() {
     const lines = ['IP,SysName,SysDescr,SysUpTime,ResponseTime(ms),Reachable'];
     for (const r of filteredResults) {
-      lines.push(`${r.ip},${escapeCSV(r.sysName)},${escapeCSV(r.sysDescr)},${escapeCSV(r.sysUpTime)},${r.responseTime},${r.reachable}`);
+      lines.push(`${escapeCSV(r.ip)},${escapeCSV(r.sysName)},${escapeCSV(r.sysDescr)},${escapeCSV(r.sysUpTime)},${r.responseTime},${r.reachable}`);
     }
     const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
     downloadFile(lines.join('\n'), `discovery-${ts}.csv`, 'text/csv');

--- a/frontend/src/EventsPanel.svelte
+++ b/frontend/src/EventsPanel.svelte
@@ -12,7 +12,7 @@
   import { oidName, oidTooltip } from './utils/oidDisplay';
   import { formatTimestamp } from './utils/formatting';
   import { anonMode, anonymizeIp, anonymizeText } from './utils/anonymize';
-  import { downloadFile } from './utils/csv';
+  import { escapeCSV, downloadFile } from './utils/csv';
   import { EventsPayload } from '../wailsjs/go/main/App';
   import { displayTarget as labelled } from './utils/targets';
 
@@ -115,13 +115,9 @@
   function exportCsv() {
     const items = $eventsStore.items;
     if (!items.length) return;
-    const esc = (v) => {
-      const s = String(v ?? '');
-      return /[",\r\n;]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
-    };
     const rows = [['timestamp', 'severity', 'category', 'kind', 'source', 'oid', 'summary'].join(',')];
     for (const e of items) {
-      rows.push([e.ts, e.severity, e.category, e.kind, e.source || '', e.oid || '', e.summary].map(esc).join(','));
+      rows.push([e.ts, e.severity, e.category, e.kind, e.source || '', e.oid || '', e.summary].map(escapeCSV).join(','));
     }
     downloadFile(rows.join('\n'), 'snmp-events.csv', 'text/csv');
     notificationStore.add(get(_)('events.exported'), 'success');

--- a/frontend/src/HistoryPanel.svelte
+++ b/frontend/src/HistoryPanel.svelte
@@ -15,6 +15,7 @@
   import { ResolveOids } from '../wailsjs/go/main/App';
   import { findNodeByOid, findMibNameByOid, formatValueWithEnum } from './utils/mibTree';
   import { anonMode, anonymizeIp } from './utils/anonymize';
+  import { escapeCSV } from './utils/csv';
 
   // Entry to reveal (expand + scroll to) when opened from Recent history.
   export let highlightId = null;
@@ -334,14 +335,10 @@
     return count > 0 ? String(count) : '';
   }
 
-  function csvCell(v) {
-    let s = String(v ?? '');
-    // Neutralize spreadsheet formula injection: a leading =, +, -, @ (or a
-    // control char) makes Excel/LibreOffice treat device-supplied text as a
-    // formula. Prefix with an apostrophe to force a literal string.
-    if (/^[=+\-@\t\r]/.test(s)) s = "'" + s;
-    return /[",\r\n;]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
-  }
+  // The formula neutralisation this function used to carry privately now lives
+  // in utils/csv.js, where every other export reaches it. It was correct here
+  // and absent everywhere else, including in the shared helper — which is how
+  // the events export, the one carrying raw trap text, ended up without it.
 
   function toCsv(entries) {
     const header = ['timestamp', 'operation', 'targets', 'oid', 'name', 'value', 'version', 'durationMs', 'success', 'error'];
@@ -356,7 +353,7 @@
       e.duration ?? '',
       e.success ? 'true' : 'false',
       e.error || '',
-    ].map(csvCell).join(','));
+    ].map(escapeCSV).join(','));
     return [header.join(','), ...lines].join('\r\n');
   }
 

--- a/frontend/src/monitor/MonitorChart.svelte
+++ b/frontend/src/monitor/MonitorChart.svelte
@@ -13,7 +13,7 @@
   import { mibStore } from '../stores/mibStore';
   import { oidName } from '../utils/oidDisplay';
   import { notificationStore } from '../stores/notifications';
-  import { downloadFile } from '../utils/csv';
+  import { escapeCSV, downloadFile } from '../utils/csv';
   import { chartSync, broadcastRange, broadcastLive } from './chartSync';
 
   Chart.register(...registerables, zoomPlugin);
@@ -692,7 +692,7 @@
       const source = ds._data || ds.data;
       for (const pt of source) {
         if (pt.x < from || pt.x > to) continue;
-        rows.push([new Date(pt.x).toISOString(), ds.label, pt.y ?? '', unit.label].join(','));
+        rows.push([new Date(pt.x).toISOString(), ds.label, pt.y ?? '', unit.label].map(escapeCSV).join(','));
       }
     }
     downloadFile(rows.join('\n'), 'snmp-monitor-' + mode + '.csv', 'text/csv');

--- a/frontend/src/operations/ResultsComparison.svelte
+++ b/frontend/src/operations/ResultsComparison.svelte
@@ -157,15 +157,10 @@
 
   function exportEnhancedComparisonCSV() {
     const { targets, rows } = comparisonData;
-    const escape = (s) => {
-      s = String(s ?? '');
-      if (s.includes(',') || s.includes('"') || s.includes('\n')) return '"' + s.replace(/"/g, '""') + '"';
-      return s;
-    };
-    const header = ['OID', 'Name', ...targets, 'Delta', '% Diff', 'Status'].join(',');
+    const header = ['OID', 'Name', ...targets, 'Delta', '% Diff', 'Status'].map(escapeCSV).join(',');
     const lines = [header, ...rows.map((r) => [
-      escape(r.oid), escape(r.name),
-      ...targets.map((t) => escape(r.values[t]?.value ?? '')),
+      escapeCSV(r.oid), escapeCSV(r.name),
+      ...targets.map((t) => escapeCSV(r.values[t]?.value ?? '')),
       r.delta != null ? r.delta.toFixed(2) : '',
       r.percentDiff != null ? r.percentDiff.toFixed(1) + '%' : '',
       r.status,

--- a/frontend/src/utils/csv.js
+++ b/frontend/src/utils/csv.js
@@ -1,14 +1,50 @@
+// A spreadsheet reads a cell starting with any of these as a FORMULA, not as
+// text. Tab and carriage return are here because Excel skips leading whitespace
+// before deciding.
+const FORMULA_LEAD = /^[=+\-@\t\r]/;
+
+// A strict number, so a negative reading stays a number. Deliberately not
+// Number(s): that accepts leading whitespace, "0x10", "Infinity" and "", and
+// leading whitespace is one of the vectors above.
+const STRICT_NUMBER = /^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$/;
+
 /**
  * Escape a value for safe CSV output.
+ *
+ * Two separate jobs, and the second one was missing.
+ *
+ * RFC 4180 QUOTING keeps the file parseable: a comma, a quote or a newline
+ * inside a field has to be quoted or the columns shift.
+ *
+ * FORMULA NEUTRALISATION keeps the file from executing. Excel, LibreOffice and
+ * Sheets treat a cell beginning `= + - @` as a formula, and these exports carry
+ * text this application did not write: `sysName` and `sysDescr` come straight
+ * from the polled device (DiscoveryPanel.svelte), event summaries come from
+ * traps. So someone who controls a device on a scanned network chooses what a
+ * cell contains, waits for an operator to export a sweep and open it, and gets
+ * code execution on the workstation with access to the whole management
+ * network. CWE-1236.
+ *
+ * The apostrophe is the convention every spreadsheet honours: it forces the
+ * cell to text and is not itself displayed.
+ *
+ * A value that is a plain number is left alone — prefixing `-42` would stop the
+ * column being numeric, and a number cannot be a formula.
+ *
  * @param {*} val
  * @returns {string}
  */
 export function escapeCSV(val) {
-  const s = String(val ?? '');
-  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
-    return '"' + s.replace(/"/g, '""') + '"';
+  let s = String(val ?? '');
+  if (FORMULA_LEAD.test(s) && !STRICT_NUMBER.test(s)) {
+    s = "'" + s;
   }
-  return s;
+  // `;` as well as `,`: Excel in a French, German or Spanish locale — three of
+  // the five this application ships — reads `;` as the separator, so a value
+  // containing one shifts the columns there and nowhere else. `\r` for the same
+  // reason as `\n`. The private escaper in HistoryPanel had this wider set and
+  // the shared one did not, which is the other half of why they diverged.
+  return /[",;\r\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
 }
 
 /**

--- a/frontend/tests/csv.test.mjs
+++ b/frontend/tests/csv.test.mjs
@@ -1,0 +1,124 @@
+// A CSV export cannot become a formula, and cannot escape on its own.
+//
+// Excel, LibreOffice and Sheets read a cell beginning `= + - @` as a FORMULA.
+// The values in these exports are not ours: `sysName` and `sysDescr` come
+// straight from the polled device, event summaries carry trap text. So someone
+// who controls a device on a scanned network chooses what a cell contains,
+// waits for an operator to export a sweep and open it, and gets code execution
+// on the workstation that has access to the whole management network. CWE-1236.
+//
+// THE INTERESTING PART IS WHY IT SURVIVED. The defence was not missing — it was
+// in `HistoryPanel.csvCell`, with a comment explaining exactly this attack. It
+// simply never reached `utils/csv.js`, and three of the five exports had grown
+// their own escaper by copying the RFC 4180 half without the formula half. The
+// events export — the one carrying raw trap text — was among them.
+//
+// So the unit tests below are the smaller half of this file. The structural
+// checks are what stop it recurring: an export must use the shared function,
+// and nobody may write a private one.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { escapeCSV } from '../src/utils/csv.js';
+
+const root = new URL('../src/', import.meta.url).pathname.replace(/^[/]([A-Za-z]:)/, '$1');
+
+let failures = 0;
+const check = (name, ok, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? ' — ' + extra : ''}`);
+  if (!ok) failures++;
+};
+
+function sources(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sources(path));
+    else if (entry.name.endsWith('.svelte') || entry.name.endsWith('.js')) out.push(path);
+  }
+  return out;
+}
+
+/* --- what the escaper must do --------------------------------------------- */
+
+for (const lead of ['=', '+', '-', '@', '\t', '\r']) {
+  const payload = lead + `cmd|'/c calc'!A1`;
+  const got = escapeCSV(payload);
+  check(`a value starting ${JSON.stringify(lead)} is neutralised`,
+    got.startsWith("'") || got.startsWith(`"'`), JSON.stringify(got));
+}
+
+// A negative reading is not a formula, and prefixing it would stop the column
+// being numeric — which is the reason the naive fix is wrong.
+for (const n of ['-42', '-3.5', '+7', '1e-3', '0']) {
+  check(`the number ${n} is left alone`, escapeCSV(n) === n, JSON.stringify(escapeCSV(n)));
+}
+
+// Not numbers, however much they start like one.
+for (const s of ['-2+3+cmd|x', '+1;=1', '- 5', '0x10', '', '  1']) {
+  const got = escapeCSV(s);
+  const neutralised = got.startsWith("'") || got.startsWith(`"'`) || !/^[=+\-@\t\r]/.test(s);
+  check(`${JSON.stringify(s)} is not mistaken for a number`, neutralised, JSON.stringify(got));
+}
+
+// RFC 4180, plus `;` — Excel in a French, German or Spanish locale reads that
+// as the separator, and three of the five locales this app ships are those.
+for (const s of ['a,b', 'a;b', 'a"b', 'a\nb', 'a\rb']) {
+  const got = escapeCSV(s);
+  check(`${JSON.stringify(s)} is quoted`, got.startsWith('"') && got.endsWith('"'), JSON.stringify(got));
+}
+check('an embedded quote is doubled', escapeCSV('a"b') === '"a""b"', escapeCSV('a"b'));
+check('a plain value is untouched', escapeCSV('sysDescr') === 'sysDescr');
+check('null and undefined become empty', escapeCSV(null) === '' && escapeCSV(undefined) === '');
+
+/* --- and what the codebase must do with it -------------------------------- */
+
+const files = sources(root);
+
+// An export that builds a .csv has to route its values through the shared
+// function. Checked by the FILE having both, which is coarse — but the failure
+// it catches is a file that has one and not the other, which is exactly what
+// happened three times.
+const unescaped = [];
+for (const file of files) {
+  const src = readFileSync(file, 'utf8');
+  if (!/downloadFile\([^)]*/.test(src)) continue;
+  if (!/\.csv'/.test(src) && !/\.csv"/.test(src)) continue;
+  if (!src.includes('escapeCSV')) unescaped.push(basename(file));
+}
+check('every file that downloads a .csv imports the shared escaper',
+  unescaped.length === 0, unescaped.join(', '));
+
+// Nobody writes their own. `.replace(/"/g, '""')` is the RFC 4180 doubling and
+// is unmistakable; finding it outside utils/csv.js means a second escaper has
+// appeared, which is how the formula defence came to exist in one export and
+// nowhere else.
+const privateEscapers = [];
+for (const file of files) {
+  if (basename(file) === 'csv.js') continue;
+  const src = readFileSync(file, 'utf8');
+  if (/replace\(\s*\/"\/g\s*,\s*'""'\s*\)/.test(src) || /replace\(\s*\/"\/g\s*,\s*'""'\)/.test(src)) {
+    privateEscapers.push(basename(file));
+  }
+}
+check('no component defines its own CSV escaper',
+  privateEscapers.length === 0, privateEscapers.join(', '));
+
+/* --- prove the checks can fail -------------------------------------------- */
+{
+  // The payload that made this a finding rather than a theory.
+  const evil = `=cmd|'/c calc'!A1`;
+  check('the detector: the raw payload would be a formula', /^[=+\-@\t\r]/.test(evil));
+  check('the detector: and the escaper stops it being one', !/^[=+\-@\t\r]/.test(escapeCSV(evil)),
+    escapeCSV(evil));
+
+  // The structural check, on a file that would have failed it.
+  const wouldFail = `downloadFile(rows.join('\\n'), 'x.csv', 'text/csv');`;
+  check('the detector: a .csv download with no escaper is visible',
+    /downloadFile\([^)]*/.test(wouldFail) && /\.csv'/.test(wouldFail) && !wouldFail.includes('escapeCSV'));
+
+  const privateOne = `return /[",]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;`;
+  check('the detector: a private escaper is visible',
+    /replace\(\s*\/"\/g\s*,\s*'""'\s*\)/.test(privateOne));
+}
+
+process.exit(failures ? 1 : 0);

--- a/pkg/notify/injection_test.go
+++ b/pkg/notify/injection_test.go
@@ -91,25 +91,41 @@ func TestMailHeadersStripControlCharacters(t *testing.T) {
 
 // Syslog framing: over TCP and TLS the frame is octet-counted, so a newline in
 // the message cannot make the collector see a second, forged record.
-func TestSyslogMessageCannotForgeASecondFrame(t *testing.T) {
+// The octet count covers the whole message — the TRANSPORT half of the problem.
+//
+// THIS TEST USED TO CLAIM MORE THAN IT CHECKED, and the overclaim is why the
+// content half went unnoticed for as long as it did. It was called
+// "CannotForgeASecondFrame", which is true of a FRAME and was read as "cannot
+// forge a record": RFC6587 octet counting does mean a collector reads exactly
+// this many bytes as one message, whatever they contain — and the comment said
+// so — but a message whose CONTENT holds a newline still becomes two lines the
+// moment anything line-oriented reads it, which is what syslog is for.
+//
+// It also carried `t.Skip("no newline survived")`, so it would have gone quiet
+// rather than green if the newline had ever been stripped. A test that skips
+// when the thing it describes is fixed is a test nobody revisits.
+//
+// The content half is now syslog_injection_test.go. This one keeps the framing
+// property, which is real and worth pinning, and says only that.
+func TestSyslogOctetCountCoversTheWholeMessage(t *testing.T) {
 	e := hostileEvent("x")
 	hostile := "ok\n<13>1 2026-01-01T00:00:00Z evil - - - - forged entry"
 	line := FormatRFC5424(SyslogConfig{Facility: 16, Hostname: "w"}, e, hostile)
 
+	// The count is in OCTETS of the whole line, so a non-ASCII summary cannot
+	// desynchronise the collector by a rune-versus-byte mismatch.
 	framed := len(line)
-	// The receiver reads exactly `framed` octets and treats them as ONE
-	// message, whatever they contain.
-	if strings.Count(line, "\n") == 0 {
-		t.Skip("no newline survived; nothing to prove")
+	if framed != len([]byte(line)) {
+		t.Fatalf("the count is not in octets: len=%d bytes=%d", framed, len([]byte(line)))
 	}
-	if framed != len(line) {
-		t.Fatal("length and content disagree")
+	// Everything the caller supplied is inside the counted region, including
+	// the part after the newline the sanitiser has now escaped. A count that
+	// stopped early is what would let the remainder be parsed separately.
+	if !strings.Contains(line, "forged entry") {
+		t.Error("the caller's text did not survive into the counted message at all")
 	}
-	// What must hold is that the count covers the whole payload, newline
-	// included — a count that stopped at the newline is what would let the
-	// remainder be parsed as a new record.
-	if !strings.Contains(line[:framed], "forged entry") {
-		t.Error("the octet count does not cover the whole message")
+	if !strings.HasSuffix(line, "forged entry") {
+		t.Errorf("the count does not reach the end of the payload:\n%s", line)
 	}
 }
 

--- a/pkg/notify/syslog.go
+++ b/pkg/notify/syslog.go
@@ -85,6 +85,54 @@ func sanitizePrintUSASCII(s string, max int) string {
 	return b.String()
 }
 
+// sanitizeBody escapes the control characters that give a syslog record its
+// shape, leaving every other rune alone.
+//
+// The MSG and the structured-data values are the two places where UNTRUSTED
+// TEXT reaches this line. A trap arrives from the network unauthenticated, its
+// varbinds become the summary and the OID, and `isPrintableOctet` in
+// pkg/snmp/client.go deliberately admits \n, \r and \t — so a device that sends
+// a newline used to put one straight into the record. Measured against the real
+// formatter: one event produced two lines, the second a well-formed RFC5424
+// record claiming another host had accepted an admin login.
+//
+// The transport framing was never the weak part — TCP and TLS use RFC6587
+// octet counting and UDP is one datagram per message, so a collector cannot
+// desynchronise. The forgery lands where syslog usually ends up: written to a
+// file, or read by anything line-oriented. Which is the whole point of
+// forwarding.
+//
+// ESCAPED, not stripped. An operator reading the journal should be able to see
+// that a device sent a newline; deleting it hides the attempt. TAB is kept
+// because it has no framing meaning and does appear in legitimate sysDescr.
+func sanitizeBody(s string) string {
+	if !strings.ContainsFunc(s, needsBodyEscape) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 8)
+	for _, r := range s {
+		switch {
+		case r == '\n':
+			b.WriteString(`\n`)
+		case r == '\r':
+			b.WriteString(`\r`)
+		case r == 0:
+			b.WriteString(`\0`)
+		case needsBodyEscape(r):
+			fmt.Fprintf(&b, `\x%02x`, r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// needsBodyEscape reports the C0 controls and DEL, minus TAB.
+func needsBodyEscape(r rune) bool {
+	return (r < 0x20 && r != '\t') || r == 0x7f
+}
+
 // FormatRFC5424 renders one event as a syslog line.
 //
 // <PRI>1 TIMESTAMP HOSTNAME APP-NAME PROCID MSGID STRUCTURED-DATA MSG
@@ -116,10 +164,12 @@ func FormatRFC5424(cfg SyslogConfig, e events.Event, message string) string {
 	}
 	ts := stamp.Format("2006-01-02T15:04:05.000000Z")
 
-	// Structured data: PARAM-VALUE escapes ", \ and ].
+	// Structured data: PARAM-VALUE escapes ", \ and ] per RFC5424 6.3.3, and the
+	// control characters per sanitizeBody — the three RFC characters are what a
+	// PARSER needs, the controls are what a READER needs.
 	esc := func(v string) string {
 		r := strings.NewReplacer(`\`, `\\`, `"`, `\"`, `]`, `\]`)
-		return r.Replace(v)
+		return r.Replace(sanitizeBody(v))
 	}
 	sd := syslogNil
 	if !cfg.OmitStructuredData {
@@ -146,7 +196,7 @@ func FormatRFC5424(cfg SyslogConfig, e events.Event, message string) string {
 		sanitizePrintUSASCII(e.Kind, 32),
 		sd,
 		" "+utf8BOM,
-		message,
+		sanitizeBody(message),
 	)
 }
 

--- a/pkg/notify/syslog_injection_test.go
+++ b/pkg/notify/syslog_injection_test.go
@@ -1,0 +1,139 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/events"
+)
+
+// One event must produce exactly one syslog record, whatever the device sent.
+//
+// A trap arrives from the network unauthenticated. Its varbinds become the
+// summary, the source and the OID, and pkg/snmp's isPrintableOctet deliberately
+// admits \n, \r and \t so that a legitimate multi-line sysDescr survives. Those
+// fields are then formatted into an RFC5424 line.
+//
+// Before sanitizeBody, this produced TWO lines from one event — measured, not
+// supposed:
+//
+//	[0] <6>1 … SnmpLens - trap [snmplens@0 id="abc" …
+//	[1] <14>1 2026-01-01T00:00:00.000000Z core-router snmpd - - - AUTH ACCEPTED admin from 10.0.0.99
+//
+// The second is a well-formed record attributing an accepted admin login to
+// another host. The transport was never the weak part: TCP and TLS use RFC6587
+// octet counting and UDP is one datagram per message, so no collector
+// desynchronises. It lands where syslog usually ends up — a file, or anything
+// line-oriented reading it.
+//
+// The test walks EVERY field a trap can influence rather than the one that was
+// reported, because the next one will arrive through a different field.
+
+// forged is a complete RFC5424 record, so a field that leaks it produces
+// something a collector will accept rather than obvious garbage.
+const forgedRecord = "up\n<14>1 2026-01-01T00:00:00.000000Z core-router snmpd - - - AUTH ACCEPTED admin from 10.0.0.99"
+
+func trapEvent(field string, payload string) events.Event {
+	e := events.Event{
+		ID: "id", Category: "trap", Severity: "info", State: "new",
+		Source: "10.0.0.5", OID: "1.3.6.1.6.3.1.1.5.4", Kind: "trap",
+		Summary: "normal summary", Ts: "2026-09-07T10:00:00Z",
+	}
+	switch field {
+	case "Summary":
+		e.Summary = payload
+	case "Source":
+		e.Source = payload
+	case "OID":
+		e.OID = payload
+	case "ID":
+		e.ID = payload
+	case "Category":
+		e.Category = payload
+	case "Severity":
+		e.Severity = payload
+	case "State":
+		e.State = payload
+	case "Kind":
+		e.Kind = payload
+	}
+	return e
+}
+
+func TestNoTrapFieldCanAddASyslogRecord(t *testing.T) {
+	fields := []string{"Summary", "Source", "OID", "ID", "Category", "Severity", "State", "Kind"}
+	payloads := map[string]string{
+		"a forged record after a newline": forgedRecord,
+		"a bare carriage return":          "up\rinjected",
+		"CRLF":                            "up\r\ninjected",
+		"a NUL":                           "up\x00injected",
+		"a vertical tab":                  "up\vinjected",
+		"a form feed":                     "up\finjected",
+	}
+
+	for _, withSD := range []bool{true, false} {
+		for _, field := range fields {
+			for name, payload := range payloads {
+				e := trapEvent(field, payload)
+				line := FormatRFC5424(SyslogConfig{OmitStructuredData: !withSD}, e, "")
+
+				if n := strings.Count(line, "\n"); n != 0 {
+					t.Errorf("%s carrying %s (structured data: %v): the record contains %d newline(s)\n%s",
+						field, name, withSD, n, line)
+				}
+				if strings.ContainsAny(line, "\r\x00") {
+					t.Errorf("%s carrying %s (structured data: %v): the record contains a raw CR or NUL\n%s",
+						field, name, withSD, line)
+				}
+			}
+		}
+	}
+}
+
+// A body rendered from a message template reaches the MSG by a different route
+// than the summary, and is just as attacker-influenced.
+func TestARenderedBodyCannotAddARecordEither(t *testing.T) {
+	e := trapEvent("Summary", "normal")
+	line := FormatRFC5424(SyslogConfig{}, e, forgedRecord)
+	if strings.Contains(line, "\n") {
+		t.Errorf("a rendered body added a record:\n%s", line)
+	}
+	if !strings.Contains(line, `\n`) {
+		t.Errorf("the newline was dropped rather than escaped; an operator cannot see what the device sent:\n%s", line)
+	}
+}
+
+// What sanitizeBody must and must not touch. The escape has to be visible —
+// stripping hides the attempt from whoever reads the journal afterwards.
+func TestSanitizeBodyEscapesRatherThanStrips(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"a\nb", `a\nb`},
+		{"a\rb", `a\rb`},
+		{"a\x00b", `a\0b`},
+		{"a\vb", `a\x0bb`},
+		{"a\x7fb", `a\x7fb`},
+		// TAB has no framing meaning and appears in real sysDescr values.
+		{"a\tb", "a\tb"},
+		// Anything above the C0 range is left exactly alone, including the
+		// non-ASCII that four of our five locales produce.
+		{"état — 温度", "état — 温度"},
+	}
+	for _, c := range cases {
+		if got := sanitizeBody(c.in); got != c.want {
+			t.Errorf("sanitizeBody(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// Prove the test can fail. Without this, a formatter that returned "" would
+// pass every assertion above.
+func TestTheDetectorWouldSeeAnUnescapedNewline(t *testing.T) {
+	raw := "<6>1 stamp host app - trap - " + forgedRecord
+	if !strings.Contains(raw, "\n") {
+		t.Fatal("the probe string carries no newline, so this test proves nothing")
+	}
+	if strings.Count(raw, "\n") != 1 {
+		t.Fatalf("expected exactly one newline in the probe, got %d", strings.Count(raw, "\n"))
+	}
+}


### PR DESCRIPTION
Both have the same shape: text arrives from the network unauthenticated, and is written into a format where one character changes the meaning of what follows.

## Syslog record forgery

`FormatRFC5424` wrote the MSG and the structured-data values verbatim. `isPrintableOctet` in `pkg/snmp/client.go` deliberately admits `\n`, `\r` and `\t` so a multi-line `sysDescr` stays readable, so a trap varbind carrying a newline put one straight into the record.

Measured against the real formatter: one event produced **two lines**, the second a well-formed RFC5424 record attributing an admin login to a host that never reported one.

The framing was never the weak part — TCP and TLS use RFC6587 octet counting, UDP is one datagram per message — which is why this went unnoticed. The forgery lands where syslog actually ends up: a file, a grep, anything line-oriented.

Control characters are now escaped, not stripped: an operator should be able to see that a device sent a newline. TAB stays. `syslog_injection_test.go` walks the eight trap-controlled fields against six payloads with structured data on and off, and fails on 47 of them without the fix.

`TestSyslogMessageCannotForgeASecondFrame` is renamed and rewritten. Its name is half the reason this survived: it claimed a record could not be forged and checked that a *frame* could not be. It also carried `t.Skip`, so it would have gone quiet rather than green had the newline ever been stripped.

## CSV formula injection (CWE-1236)

A spreadsheet reads a cell beginning `= + - @` as a formula, and `sysName`, `sysDescr` and event summaries come from the polled device. Control a device on a scanned network, wait for an operator to export a sweep, get code execution on the workstation that reaches the whole management network.

The defence was not missing — it was in `HistoryPanel.csvCell` with a comment describing this exact attack. It never reached `utils/csv.js`, and five exports had grown private escapers by copying the RFC 4180 half without the formula half. The events export, the one carrying raw trap text, was among them.

`escapeCSV` now does both jobs and every export calls it. A plain number is left alone (prefixing `-42` would stop the column being numeric); `Number()` is deliberately not the test, since it accepts leading whitespace, which is itself a vector. The quoting set gains `;` and `\r` — Excel in a French, German or Spanish locale reads `;` as the separator, and three of the five locales this app ships are those.

The two structural checks in `frontend/tests/csv.test.mjs` are the point of the file, and earned their place immediately: the "nobody writes their own escaper" check found two more, in `DiffModal` and `ResultsComparison`, that reading the exports by hand had missed.

## Verification

- `go test ./...` — 13 packages, exit 0
- `go vet ./...`, `go build ./...` — clean
- `cd frontend && npm test` — exit 0, with `csv.test.mjs` now wired in
- `npm run build` — clean
