### PR TITLE
The rest of the security audit: the three verified findings, the five that deserved a look, and five from the tail

### DIFF
--- a/app.go
+++ b/app.go
@@ -409,6 +409,10 @@ func (a *App) ListMibFiles(dirPath string) ([]string, error) {
 }
 
 // MibImportResult holds per-file results for a MIB import operation.
+// maxImportBytes bounds what ImportMibFiles will read into memory. The largest
+// MIBs in circulation are a couple of megabytes.
+const maxImportBytes = 16 << 20
+
 type MibImportResult struct {
 	FileName string `json:"fileName"`
 	Success  bool   `json:"success"`
@@ -455,18 +459,21 @@ func (a *App) importSingleFile(src string) MibImportResult {
 	name := filepath.Base(src)
 	dst := filepath.Join(a.persistentMibDir, name)
 
+	// Bounded before it is read. os.ReadFile on a renderer-named path is an
+	// unbounded allocation, so a path to a large file — or to a device that
+	// never ends — is a way to take the process down without sending a single
+	// packet. The largest MIB anyone ships is a couple of megabytes; the
+	// benchmark in pkg/mib uses 185 KB.
+	if info, err := os.Stat(src); err == nil && info.Size() > maxImportBytes {
+		return MibImportResult{FileName: name, Success: false,
+			Error: fmt.Sprintf("this file is %d MB; a MIB is text and nothing legitimate is over %d MB",
+				info.Size()/(1<<20), maxImportBytes/(1<<20))}
+	}
+
 	srcData, err := os.ReadFile(src)
 	if err != nil {
 		log.Printf("ImportMibFiles: failed to read %s: %v", src, err)
 		return MibImportResult{FileName: name, Success: false, Error: fmt.Sprintf("read error: %v", err)}
-	}
-
-	// Check if the destination already has an identical file
-	if dstData, err := os.ReadFile(dst); err == nil {
-		if bytes.Equal(srcData, dstData) {
-			log.Printf("ImportMibFiles: skipped %s (already exists)", name)
-			return MibImportResult{FileName: name, Success: true, Skipped: true}
-		}
 	}
 
 	// A standard MIB that ships in the binary is never overwritten from here.
@@ -493,6 +500,36 @@ func (a *App) importSingleFile(src string) MibImportResult {
 			Success:  false,
 			Error: fmt.Sprintf("%s ships with SnmpLens and nearly every MIB imports from it; "+
 				"replacing it would break MIB resolution. Use the MIB editor if you really mean to change it.", name),
+		}
+	}
+
+	// Only a MIB gets into the MIB directory.
+	//
+	// This is a security boundary as much as a usability one. This method reads
+	// any absolute path the renderer names, and MibEditorRead hands the content
+	// of anything in that directory back — so the two calls together are an
+	// arbitrary-file-read primitive over the bridge. What decides how much that
+	// is worth is what is allowed to land here. A private key, a password file,
+	// a browser profile: not a MIB, not admitted, never readable.
+	//
+	// It is NOT a validity check: a MIB with a syntax error is precisely what
+	// the diagnosis feature exists for. The refusal reuses pkg/mib's own
+	// description of the files people download by mistake, so an HTML page or a
+	// PDF is still named as what it is — now without leaving a copy behind.
+	if summary, hint, reject := mib.ImportRejection(srcData); reject {
+		msg := summary
+		if hint != "" {
+			msg += " — " + hint
+		}
+		log.Printf("ImportMibFiles: refused %s (%s)", name, summary)
+		return MibImportResult{FileName: name, Success: false, Error: msg}
+	}
+
+	// Check if the destination already has an identical file
+	if dstData, err := os.ReadFile(dst); err == nil {
+		if bytes.Equal(srcData, dstData) {
+			log.Printf("ImportMibFiles: skipped %s (already exists)", name)
+			return MibImportResult{FileName: name, Success: true, Skipped: true}
 		}
 	}
 
@@ -557,6 +594,25 @@ func (a *App) CheckForUpdate() updater.UpdateInfo {
 	if err != nil {
 		log.Printf("Update check failed: %v", err)
 	}
+	return withCheckError(info, err)
+}
+
+// withCheckError puts the reason a check failed where the renderer can see it.
+//
+// Separate from the bridge method so it can be tested without a network: the
+// Service holds its http.Client unexported, so there is no seam in package
+// main, and the interesting part is not the HTTP call — it is that the error
+// stops being dropped.
+//
+// Available is forced false as well. A check that failed cannot have found an
+// update, and leaving whatever the zero value happened to be would let a
+// failure offer a download.
+func withCheckError(info updater.UpdateInfo, err error) updater.UpdateInfo {
+	if err == nil {
+		return info
+	}
+	info.Error = err.Error()
+	info.Available = false
 	return info
 }
 
@@ -646,9 +702,29 @@ func (a *App) MonitorLoadHistoricalData(sessionID, from, to string) ([]storage.D
 }
 
 // MonitorDeleteSession removes a session and all its data.
+// MonitorDeleteSession removes a session AND the credentials it named.
+//
+// Deleting the row alone left the session's community and v3 passphrases in
+// DPAPI, the Keychain or the file store forever, under a key nothing in the
+// app will ever look up again — the same defect NotifyDeleteSink had, in the
+// other place that writes to pkg/secrets. Session credentials are deliberately
+// kept out of monitoring.db (storage.SessionConn holds only what is safe to
+// read in a copied database), which is exactly why deleting the database row
+// cannot be the whole of it.
+//
+// The credential goes first, for the reason NotifyDeleteSink gives: it is the
+// part that cannot be retried once the row is gone. If the store refuses — a
+// locked keychain — the session stays and the operator can try again after
+// unlocking. With no store at all there is nothing that could have been
+// written, so the deletion proceeds.
 func (a *App) MonitorDeleteSession(sessionID string) error {
 	if a.storage == nil {
 		return fmt.Errorf("storage not initialized")
+	}
+	if a.secrets != nil {
+		if err := a.secrets.Delete(secrets.SessionRef(sessionID)); err != nil {
+			return fmt.Errorf("the session was kept: its stored credentials could not be removed: %w", err)
+		}
 	}
 	return a.storage.DeleteSession(sessionID)
 }
@@ -666,7 +742,19 @@ func (a *App) MonitorCleanup(daysToKeep int) (int64, error) {
 	if a.storage == nil {
 		return 0, fmt.Errorf("storage not initialized")
 	}
-	return a.storage.Cleanup(time.Duration(daysToKeep) * 24 * time.Hour)
+	n, removedSessions, err := a.storage.Cleanup(time.Duration(daysToKeep) * 24 * time.Hour)
+	// The rows are gone; their credentials must go with them. Best effort and
+	// logged rather than returned: retention has already done the part the
+	// operator asked for, and a locked keychain is not a reason to report the
+	// cleanup as failed.
+	if a.secrets != nil {
+		for _, id := range removedSessions {
+			if delErr := a.secrets.Delete(secrets.SessionRef(id)); delErr != nil {
+				log.Printf("monitor: session %s was removed but its credentials could not be: %v", id, delErr)
+			}
+		}
+	}
+	return n, err
 }
 
 // MonitorLoadBuckets returns a session's data aggregated into fixed-width time

--- a/app.go
+++ b/app.go
@@ -469,6 +469,33 @@ func (a *App) importSingleFile(src string) MibImportResult {
 		}
 	}
 
+	// A standard MIB that ships in the binary is never overwritten from here.
+	//
+	// This is not an exotic case: vendor archives routinely include their own
+	// SNMPv2-SMI, SNMPv2-TC and SNMPv2-CONF, and nearly every other MIB imports
+	// from those three. Replacing one with a copy that differs or is truncated
+	// breaks the tree for everything, and it STAYS broken across restarts,
+	// because ensureStandardMibs restores only files that are ABSENT
+	// (`if _, err := os.Stat(destPath); err == nil { continue }`) — a replaced
+	// one is never repaired. So one drag-and-drop of a vendor zip could take
+	// out MIB resolution for good, with nothing saying what happened.
+	//
+	// Refused rather than backed up: the MIB editor already owns deliberate
+	// change to a bundled file, with its own backup directory and
+	// MibEditorRestoreBundled to undo it. An import is a bulk operation nobody
+	// reads the results of unless something goes wrong, which is exactly when
+	// this needs to be loud. The refusal reaches the per-file error list the
+	// import dialog already shows.
+	if _, bundled := a.bundledContent(name); bundled {
+		log.Printf("ImportMibFiles: refused to replace the bundled %s", name)
+		return MibImportResult{
+			FileName: name,
+			Success:  false,
+			Error: fmt.Sprintf("%s ships with SnmpLens and nearly every MIB imports from it; "+
+				"replacing it would break MIB resolution. Use the MIB editor if you really mean to change it.", name),
+		}
+	}
+
 	if err := os.WriteFile(dst, srcData, 0644); err != nil {
 		log.Printf("ImportMibFiles: failed to write %s: %v", dst, err)
 		return MibImportResult{FileName: name, Success: false, Error: fmt.Sprintf("write error: %v", err)}
@@ -1167,6 +1194,48 @@ func (a *App) sinkSecret(sinkID string) string {
 	return v
 }
 
+// storedSink returns the destination currently on file under id.
+//
+// There is no GetSink, and adding one for this would put a second read path
+// against notify_sinks; the list is a handful of rows read on a settings
+// screen, not a hot path.
+func (a *App) storedSink(id string) (notify.SinkConfig, bool) {
+	if a.storage == nil || id == "" {
+		return notify.SinkConfig{}, false
+	}
+	sinks, err := a.storage.ListSinks()
+	if err != nil {
+		return notify.SinkConfig{}, false
+	}
+	for _, s := range sinks {
+		if s.ID == id {
+			return s, true
+		}
+	}
+	return notify.SinkConfig{}, false
+}
+
+// boundSinkSecret returns the stored credential for cfg.ID, but ONLY if cfg
+// still names the destination that credential was stored against.
+//
+// See notify.Destination for why this exists: resolving by id while taking the
+// address from the caller is the one path that turns a write-only credential
+// store into a read primitive.
+func (a *App) boundSinkSecret(cfg notify.SinkConfig) (string, error) {
+	stored, ok := a.storedSink(cfg.ID)
+	if !ok {
+		// Nothing on file under that id: a sink being tested before it is
+		// saved. There is no stored credential to hand out, and the caller
+		// supplying one in cfg.Secret is the normal path for a new sink.
+		return "", nil
+	}
+	if !notify.SameDestination(stored, cfg) {
+		return "", fmt.Errorf("this destination differs from the saved one, so the stored credential " +
+			"cannot be used with it. Enter the credential to test the new destination")
+	}
+	return a.sinkSecret(cfg.ID), nil
+}
+
 // SecretsBackend names the protection actually in use on this machine, so the
 // settings UI can state what is true here rather than what was hoped for.
 func (a *App) SecretsBackend() string {
@@ -1247,9 +1316,28 @@ func (a *App) NotifySaveSink(cfg notify.SinkConfig) (notify.SinkConfig, error) {
 	incoming := cfg.Secret
 	cfg.Secret = ""
 
+	// Pointing an EXISTING sink at a new destination is the durable version of
+	// the same problem NotifyTestSink has: the save path never compared the
+	// address it was given with the address the credential was stored against,
+	// so a renderer that cannot read a credential could still aim it. Read the
+	// previous row BEFORE writing over it.
+	previous, hadRow := a.storedSink(cfg.ID)
+	rebound := hadRow && !notify.SameDestination(previous, cfg)
+
 	saved, err := a.storage.SaveSink(cfg)
 	if err != nil {
 		return saved, err
+	}
+
+	// A credential does not follow its destination. Deleted rather than
+	// refused: a collector really does move, and refusing the save would leave
+	// the operator editing a form they cannot submit, holding a credential
+	// they cannot read back. HasSecret then comes back false, which is what
+	// the form shows, and the renderer says so out loud.
+	if rebound && incoming == "" && a.secrets != nil {
+		if err := a.secrets.Delete(secrets.SinkRef(saved.ID)); err != nil {
+			log.Printf("NotifySaveSink: could not unbind the credential of %s: %v", saved.ID, err)
+		}
 	}
 
 	// An empty field means "leave the stored credential alone", not "clear it":
@@ -1362,13 +1450,23 @@ func (a *App) NotifyTestSink(cfg notify.SinkConfig) error {
 	// already-saved sink authenticating with nothing. The symptom was the
 	// confusing one — "Test fails but the alerts themselves arrive".
 	//
-	// Looking the credential up by sink id means a caller could name one sink
-	// and point the test at another destination. That is accepted: the caller
-	// is our own renderer, and anyone able to drive it already has the user's
-	// session and could simply read the sink list instead.
+	// Looking the credential up by sink id is BOUND to the destination stored
+	// under that id. Without that, this method is a read primitive over a
+	// write-only store: name an existing sink's id, point the URL at your own
+	// server, press Test, receive the bearer token or the SMTP password.
+	//
+	// The comment that used to stand here accepted it, on the grounds that
+	// anyone able to drive the renderer "could simply read the sink list
+	// instead". The line above in NotifyListSinks — sinks[i].Secret = "" —
+	// disproves that: the store is deliberately write-only from the renderer,
+	// and this was the one hole in it.
 	secret := cfg.Secret
 	if secret == "" {
-		secret = a.sinkSecret(cfg.ID)
+		bound, err := a.boundSinkSecret(cfg)
+		if err != nil {
+			return err
+		}
+		secret = bound
 	}
 	sink, ok := notify.Build(cfg, secret)
 	if !ok {

--- a/app_busy_test.go
+++ b/app_busy_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/events"
+	"SnmpLens/pkg/storage"
+)
+
+// A router that cannot write must not spin, and must still stop.
+//
+// A failed batch is put back so the watermark cannot pass it. Putting it back
+// into the QUEUE meant the loop read it straight out again: measured at 1244
+// failed database transactions in 300 ms — about 4 000 a second, each one a
+// write attempt against a database that had just refused one, on a connection
+// pool of four that the trap listener's insert also needs.
+//
+// Shutdown never converged either: drain kept finding the events it had just
+// requeued, so stopping took the whole 5 s grace period. Measured at 5.49 s.
+func TestAFailingRouterBacksOffAndStillStops(t *testing.T) {
+	a := newTestApp(t)
+	r := newEventRouter(a)
+
+	var attempts int64
+	r.enqueue = func([]storage.RoutedGroup, int64) error {
+		atomic.AddInt64(&attempts, 1)
+		return errors.New("disk full")
+	}
+
+	// A full batch, which is what made it a tight loop: below routeBatchSize
+	// the loop waits for the ticker anyway, so the defect only showed at the
+	// size a real storm produces.
+	for i := int64(1); i <= int64(routeBatchSize); i++ {
+		e := trapEvent(int(i))
+		e.Seq = i
+		if !r.accept(e) {
+			t.Fatal("the queue refused an event")
+		}
+	}
+
+	r.start()
+	time.Sleep(300 * time.Millisecond)
+
+	stopStart := time.Now()
+	r.stop()
+	stopTook := time.Since(stopStart)
+
+	got := atomic.LoadInt64(&attempts)
+	// The first backoff is a second, so 300 ms can hold one attempt and the
+	// retry of it at most. Anything in the hundreds is the spin.
+	if got > 3 {
+		t.Errorf("%d write attempts in 300 ms; the router is spinning on a database "+
+			"that keeps refusing, on the same four-connection pool the trap insert needs", got)
+	}
+	if stopTook >= routeStopGrace {
+		t.Errorf("stopping took %s, the whole grace period: drain never converges while "+
+			"routing keeps failing", stopTook.Round(time.Millisecond))
+	}
+
+	// The events are not lost: none of them settled, so the watermark cannot
+	// pass them and replay covers them at the next launch.
+	r.mu.Lock()
+	owed := len(r.inflight)
+	confirmed := r.confirmed
+	r.mu.Unlock()
+	if owed == 0 {
+		t.Error("the events were marked done although nothing was ever written")
+	}
+	if confirmed != 0 {
+		t.Errorf("the watermark moved to %d with no successful write", confirmed)
+	}
+}
+
+// The backoff must let go once the write works again, or one transient failure
+// would slow routing for the rest of the session.
+func TestTheBackoffClearsOnTheFirstSuccessfulWrite(t *testing.T) {
+	a := newTestApp(t)
+	r := newEventRouter(a)
+
+	fail := true
+	r.enqueue = func([]storage.RoutedGroup, int64) error {
+		if fail {
+			return errors.New("temporarily unavailable")
+		}
+		return nil
+	}
+
+	e := trapEvent(1)
+	e.Seq = 1
+	r.accept(e)
+	<-r.queue
+	b := []events.Event{{Seq: 1, ID: "e1"}}
+	r.flush(&b)
+	if r.backoff == 0 {
+		t.Fatal("a failed write did not arm a backoff")
+	}
+
+	fail = false
+	// The deferred event is due after the backoff; take it by hand rather than
+	// waiting a second for the ticker.
+	r.retryAt = time.Time{}
+	var next []events.Event
+	r.takeDeferred(&next)
+	if len(next) != 1 {
+		t.Fatalf("the deferred event was not offered again: %d", len(next))
+	}
+	r.flush(&next)
+
+	if r.backoff != 0 {
+		t.Errorf("the backoff survived a successful write: %s", r.backoff)
+	}
+	r.mu.Lock()
+	owed := len(r.inflight)
+	r.mu.Unlock()
+	if owed != 0 {
+		t.Errorf("%d events still owed after the retry succeeded", owed)
+	}
+}

--- a/app_importgate_test.go
+++ b/app_importgate_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/mib"
+)
+
+func newImportApp(t *testing.T) (*App, string) {
+	t.Helper()
+	root := t.TempDir()
+	mibDir := filepath.Join(root, "SnmpLens", "mibs")
+	if err := os.MkdirAll(mibDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return &App{persistentMibDir: mibDir, mibService: mib.NewService(mibDir), mibs: mibs}, mibDir
+}
+
+// ImportMibFiles reads any absolute path the renderer names, and MibEditorRead
+// hands the content of anything in the MIB directory back. Those two calls
+// together are an arbitrary-file-read primitive over the bridge, and what
+// decides how much it is worth is what is allowed to land in the directory.
+func TestImportRefusesWhatIsNotAMib(t *testing.T) {
+	a, mibDir := newImportApp(t)
+	srcDir := t.TempDir()
+
+	cases := []struct {
+		name    string
+		content []byte
+		says    string
+	}{
+		{"id_rsa", []byte("-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEA\n-----END OPENSSH PRIVATE KEY-----\n"), "DEFINITIONS"},
+		{"passwords.txt", []byte("admin:hunter2\nroot:correcthorse\n"), "DEFINITIONS"},
+		{"spec.pdf", []byte("%PDF-1.7\n%\xe2\xe3\xcf\xd3\n"), "PDF"},
+		{"mibs.zip", []byte("PK\x03\x04\x14\x00\x00\x00"), "zip"},
+		{"page.html", []byte("<!DOCTYPE html>\n<html><body>IF-MIB</body></html>"), "HTML"},
+		{"cookies.sqlite", []byte("SQLite format 3\x00\x00\x00\x01"), "binary"},
+		{"empty", []byte(""), "empty"},
+	}
+
+	for _, c := range cases {
+		p := filepath.Join(srcDir, c.name)
+		if err := os.WriteFile(p, c.content, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		res := a.importSingleFile(p)
+		if res.Success {
+			t.Errorf("%s was imported; it is now readable through MibEditorRead", c.name)
+			continue
+		}
+		if !strings.Contains(res.Error, c.says) {
+			t.Errorf("%s: the refusal does not say what the file is: %q", c.name, res.Error)
+		}
+		// And nothing was left behind.
+		if _, err := os.Stat(filepath.Join(mibDir, c.name)); err == nil {
+			t.Errorf("%s was copied in despite the refusal", c.name)
+		}
+	}
+}
+
+// The gate must not become a validity check. A MIB with a syntax error is
+// exactly what the diagnosis feature exists for, and refusing those would
+// remove the reason anyone imports a broken file.
+func TestABrokenMibStillImports(t *testing.T) {
+	a, mibDir := newImportApp(t)
+	srcDir := t.TempDir()
+
+	broken := "ACME-POE-MIB DEFINITIONS ::= BEGIN\nIMPORTS FROM;\nacme OBJECT IDENTIFIER ::= { enterprises\nEND\n"
+	p := filepath.Join(srcDir, "ACME-POE-MIB")
+	if err := os.WriteFile(p, []byte(broken), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if res := a.importSingleFile(p); !res.Success {
+		t.Fatalf("a MIB with a syntax error was refused: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(mibDir, "ACME-POE-MIB")); err != nil {
+		t.Fatalf("it was not written: %v", err)
+	}
+}
+
+// Vendor MIBs routinely carry a licence header longer than the 4 KiB window
+// describeNonMib looks at, so the gate re-checks the whole file. Refusing a
+// real MIB is a worse failure here than accepting a text file that happens to
+// contain the word.
+func TestALongLicenceHeaderDoesNotLookLikeANonMib(t *testing.T) {
+	a, mibDir := newImportApp(t)
+	srcDir := t.TempDir()
+
+	var b strings.Builder
+	for b.Len() < 6000 {
+		b.WriteString("-- Copyright (c) 2026 Example Corp. All rights reserved. Redistribution\n")
+	}
+	b.WriteString("BIG-VENDOR-MIB DEFINITIONS ::= BEGIN\nEND\n")
+
+	p := filepath.Join(srcDir, "BIG-VENDOR-MIB")
+	if err := os.WriteFile(p, []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if res := a.importSingleFile(p); !res.Success {
+		t.Fatalf("a MIB behind a 6 KB licence header was refused: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(mibDir, "BIG-VENDOR-MIB")); err != nil {
+		t.Fatalf("it was not written: %v", err)
+	}
+
+	// And the narrower diagnosis window still says what it says — this test is
+	// about the gate being wider, not about changing the diagnosis.
+	if _, _, bad := mib.ImportRejection([]byte(b.String())); bad {
+		t.Error("ImportRejection disagrees with importSingleFile")
+	}
+}
+
+// An unbounded os.ReadFile on a renderer-named path is a way to take the
+// process down without sending a packet.
+func TestImportRefusesAFileTooLargeToBeAMib(t *testing.T) {
+	a, _ := newImportApp(t)
+	srcDir := t.TempDir()
+
+	p := filepath.Join(srcDir, "HUGE-MIB")
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Sparse where the filesystem supports it, so this costs no real disk.
+	if err := f.Truncate(maxImportBytes + 1); err != nil {
+		f.Close()
+		t.Skipf("cannot create a large sparse file: %v", err)
+	}
+	f.Close()
+
+	res := a.importSingleFile(p)
+	if res.Success {
+		t.Fatal("a file larger than the cap was read into memory and imported")
+	}
+	if !strings.Contains(res.Error, "MB") {
+		t.Errorf("the refusal does not say how big it is: %q", res.Error)
+	}
+}

--- a/app_mibimport_test.go
+++ b/app_mibimport_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/mib"
+)
+
+// A vendor MIB archive must not be able to replace a standard MIB.
+//
+// Vendor zips routinely ship their own SNMPv2-SMI, SNMPv2-TC and SNMPv2-CONF,
+// and nearly every other MIB imports from those three. The import wrote with
+// os.WriteFile unconditionally, and ensureStandardMibs restores only files
+// that are ABSENT — so a replaced one is never repaired and the tree stays
+// broken across restarts, with nothing saying why.
+func TestImportRefusesToReplaceABundledMib(t *testing.T) {
+	root := t.TempDir()
+	mibDir := filepath.Join(root, "SnmpLens", "mibs")
+	if err := os.MkdirAll(mibDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// mibs is the real embed.FS from main.go: the bundled list the check
+	// consults is the one that actually ships.
+	a := &App{persistentMibDir: mibDir, mibService: mib.NewService(mibDir), mibs: mibs}
+
+	// The file an operator already has, and the copy the archive would put
+	// over it. Different bytes, so the identical-file skip does not apply.
+	good := []byte("SNMPv2-SMI DEFINITIONS ::= BEGIN\n-- the bundled copy\nEND\n")
+	dst := filepath.Join(mibDir, "SNMPv2-SMI")
+	if err := os.WriteFile(dst, good, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := t.TempDir()
+	hostile := filepath.Join(srcDir, "SNMPv2-SMI")
+	if err := os.WriteFile(hostile, []byte("truncated vendor copy\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := a.importSingleFile(hostile)
+	if res.Success {
+		t.Fatalf("the bundled SNMPv2-SMI was replaced: %+v", res)
+	}
+	// The refusal has to say what happened and what to do; this result goes
+	// straight into the per-file list the import dialog shows.
+	if !strings.Contains(res.Error, "SNMPv2-SMI") || !strings.Contains(res.Error, "MIB editor") {
+		t.Errorf("the refusal does not explain itself: %q", res.Error)
+	}
+
+	// And the file on disk is untouched.
+	after, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(good) {
+		t.Fatalf("the file was written anyway:\n%s", after)
+	}
+}
+
+// Every bundled name is covered, not only the three obvious ones. The list is
+// read from the embed rather than repeated here, so a MIB added to mibs/ is
+// protected the day it is added.
+func TestEveryBundledNameIsRefused(t *testing.T) {
+	root := t.TempDir()
+	mibDir := filepath.Join(root, "SnmpLens", "mibs")
+	if err := os.MkdirAll(mibDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a := &App{persistentMibDir: mibDir, mibService: mib.NewService(mibDir), mibs: mibs}
+
+	entries, err := mibs.ReadDir("mibs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("no bundled MIBs; this test proves nothing")
+	}
+	srcDir := t.TempDir()
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		p := filepath.Join(srcDir, e.Name())
+		if err := os.WriteFile(p, []byte("replacement\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if res := a.importSingleFile(p); res.Success {
+			t.Errorf("%s was importable over the bundled copy", e.Name())
+		}
+	}
+}
+
+// The detector: a MIB that is NOT bundled must still import, or the fix would
+// have broken the feature it is protecting.
+func TestAVendorMibStillImports(t *testing.T) {
+	root := t.TempDir()
+	mibDir := filepath.Join(root, "SnmpLens", "mibs")
+	if err := os.MkdirAll(mibDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a := &App{persistentMibDir: mibDir, mibService: mib.NewService(mibDir), mibs: mibs}
+
+	srcDir := t.TempDir()
+	p := filepath.Join(srcDir, "ACME-POE-MIB")
+	if err := os.WriteFile(p, []byte("ACME-POE-MIB DEFINITIONS ::= BEGIN\nEND\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res := a.importSingleFile(p)
+	if !res.Success || res.Skipped {
+		t.Fatalf("a vendor MIB was refused: %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(mibDir, "ACME-POE-MIB")); err != nil {
+		t.Fatalf("it was not written: %v", err)
+	}
+}

--- a/app_mibimport_test.go
+++ b/app_mibimport_test.go
@@ -36,7 +36,7 @@ func TestImportRefusesToReplaceABundledMib(t *testing.T) {
 
 	srcDir := t.TempDir()
 	hostile := filepath.Join(srcDir, "SNMPv2-SMI")
-	if err := os.WriteFile(hostile, []byte("truncated vendor copy\n"), 0o644); err != nil {
+	if err := os.WriteFile(hostile, []byte("SNMPv2-SMI DEFINITIONS ::= BEGIN\n-- the vendor copy, truncated\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -84,7 +84,7 @@ func TestEveryBundledNameIsRefused(t *testing.T) {
 			continue
 		}
 		p := filepath.Join(srcDir, e.Name())
-		if err := os.WriteFile(p, []byte("replacement\n"), 0o644); err != nil {
+		if err := os.WriteFile(p, []byte("REPLACEMENT DEFINITIONS ::= BEGIN\nEND\n"), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		if res := a.importSingleFile(p); res.Success {

--- a/app_router.go
+++ b/app_router.go
@@ -102,6 +102,20 @@ type eventRouter struct {
 	inflight  map[int64]bool
 	highest   int64 // the highest seq ever accepted
 	confirmed int64 // the highest seq known to be written
+
+	// enqueue overrides the storage write, and exists so a test can fail THAT
+	// specifically. Closing the database fails routedGroupsFor first, which is
+	// a different path with a different answer, so the one case that matters
+	// here — the configuration reads fine and the write does not — has no
+	// other way to be reached.
+	enqueue func([]storage.RoutedGroup, int64) error
+}
+
+func (r *eventRouter) enqueueRouted(groups []storage.RoutedGroup, mark int64) error {
+	if r.enqueue != nil {
+		return r.enqueue(groups, mark)
+	}
+	return r.app.storage.EnqueueRouted(groups, mark)
 }
 
 func newEventRouter(a *App) *eventRouter {
@@ -134,6 +148,47 @@ func (r *eventRouter) accept(e events.Event) bool {
 		r.settle(nil, e.Seq)
 		return false
 	}
+}
+
+// markIfSettled returns the watermark that WOULD be safe if seqs were settled,
+// without settling them.
+//
+// The order matters and it was wrong. settle ran before EnqueueRouted, so a
+// failed write left the batch out of `inflight` and `confirmed` already moved
+// past it. The comment at the failure site was right that the STORED watermark
+// stays put — EnqueueRouted is atomic — and that a restart therefore replays
+// them. What it missed is the running process: the next successful flush
+// computes its mark from an `inflight` those seqs are no longer in, and writes
+// a watermark ABOVE a batch whose deliveries were never written. Neither
+// delivered nor replayed, which is the single outcome this whole design exists
+// to prevent.
+//
+// So nothing settles until the write has succeeded.
+func (r *eventRouter) markIfSettled(seqs []int64) int64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	settling := make(map[int64]struct{}, len(seqs))
+	for _, s := range seqs {
+		settling[s] = struct{}{}
+	}
+	lowest := int64(0)
+	for s := range r.inflight {
+		if _, going := settling[s]; going {
+			continue
+		}
+		if lowest == 0 || s < lowest {
+			lowest = s
+		}
+	}
+	mark := r.highest
+	if lowest > 0 {
+		mark = lowest - 1
+	}
+	if mark < r.confirmed {
+		mark = r.confirmed
+	}
+	return mark
 }
 
 // settle marks seqs as no longer owed and returns the watermark that is now
@@ -223,6 +278,7 @@ func (r *eventRouter) flush(batch *[]events.Event) {
 
 	groups := make([]storage.RoutedGroup, 0, len(pending))
 	seqs := make([]int64, 0, len(pending))
+	routed := make([]events.Event, 0, len(pending))
 	var failed int
 	for _, e := range pending {
 		g, err := r.app.routedGroupsFor(e)
@@ -241,6 +297,7 @@ func (r *eventRouter) flush(batch *[]events.Event) {
 			continue
 		}
 		seqs = append(seqs, e.Seq)
+		routed = append(routed, e)
 		groups = append(groups, g...)
 	}
 	if failed > 0 {
@@ -248,17 +305,27 @@ func (r *eventRouter) flush(batch *[]events.Event) {
 			"watermark", failed, len(pending))
 	}
 
-	mark := r.settle(seqs, 0)
-	if err := r.app.storage.EnqueueRouted(groups, mark); err != nil {
-		// The events stay above the watermark, because settle only ever moves
-		// the number we intend to write and EnqueueRouted is atomic — so a
-		// failure leaves the stored watermark where it was, and the next launch
-		// replays them. Copying flushBatch, which drops its buffer before the
-		// write and only logs, would lose the whole batch here.
-		log.Printf("notify: routing %d events failed, they will be replayed on the "+
-			"next launch: %v", len(pending), err)
+	mark := r.markIfSettled(seqs)
+	if err := r.enqueueRouted(groups, mark); err != nil {
+		// NOTHING has been settled at this point, so the batch is still owed:
+		// the watermark cannot pass it in this process, and the stored one has
+		// not moved either, so a restart replays it. Best effort at another
+		// attempt here too — and if the queue is full, staying owed is the
+		// safe outcome, since a replay is INSERT OR IGNORE against
+		// UNIQUE(event_id, sink_id).
+		requeued := 0
+		for _, e := range routed {
+			select {
+			case r.queue <- e:
+				requeued++
+			default:
+			}
+		}
+		log.Printf("notify: writing %d routed events failed (%d requeued, the rest stay "+
+			"owed and are replayed next launch): %v", len(routed), requeued, err)
 		return
 	}
+	r.settle(seqs, 0)
 	if r.app.dispatcher != nil {
 		r.app.dispatcher.Wake()
 	}

--- a/app_router.go
+++ b/app_router.go
@@ -73,6 +73,21 @@ const (
 	// notify.StopGrace does: an application that will not close is worse than a
 	// flush that finishes on the next launch, which the watermark makes safe.
 	routeStopGrace = 5 * time.Second
+
+	// routeRetryMin and routeRetryMax bound how fast a FAILING flush is retried.
+	//
+	// A batch that cannot be written is put back, and putting it back into the
+	// queue meant the loop read it straight out again: measured at 1244 failed
+	// database transactions in 300 ms, about 4 000 a second, each one a write
+	// attempt against a database that had just refused one. Shutdown never
+	// converged either — drain kept finding the events it had just requeued, so
+	// stopping took the whole 5 s grace period every time.
+	//
+	// Failed events wait in `deferred` instead, held by the router goroutine
+	// and retried on a doubling backoff. They stay in `inflight` throughout, so
+	// the watermark cannot pass them whatever happens here.
+	routeRetryMin = 1 * time.Second
+	routeRetryMax = 30 * time.Second
 )
 
 // eventRouter carries journalled events from their producer to the outbox.
@@ -92,6 +107,12 @@ type eventRouter struct {
 	// flushed": that would strand a lower-seq event still waiting.
 	//
 	// What is safe is the LOWEST seq still in flight, minus one.
+	// Retry bookkeeping for batches that could not be written, touched only by
+	// the router goroutine.
+	deferred []events.Event
+	retryAt  time.Time
+	backoff  time.Duration
+
 	// Pool-wait bookkeeping, touched only by the router goroutine.
 	lastPoolCount int64
 	lastPoolWait  time.Duration
@@ -245,6 +266,7 @@ func (r *eventRouter) start() {
 				}
 
 			case <-ticker.C:
+				r.takeDeferred(&batch)
 				r.flush(&batch)
 				r.watchPool()
 			}
@@ -266,6 +288,50 @@ func (r *eventRouter) drain(batch *[]events.Event) {
 			return
 		}
 	}
+}
+
+// defer1 holds an event for a later attempt.
+//
+// Bounded: past routeQueueDepth the surplus is dropped FROM THE LIST ONLY. It
+// stays in `inflight`, so the watermark cannot pass it and the next launch
+// replays it from the journal — which is the same guarantee a crash would
+// give, and strictly better than growing without limit inside a process that
+// is already failing to write.
+func (r *eventRouter) defer1(e events.Event) {
+	if len(r.deferred) >= routeQueueDepth {
+		return
+	}
+	r.deferred = append(r.deferred, e)
+}
+
+// failedFlush doubles the retry delay.
+func (r *eventRouter) failedFlush() {
+	if r.backoff == 0 {
+		r.backoff = routeRetryMin
+	} else if r.backoff < routeRetryMax {
+		r.backoff *= 2
+		if r.backoff > routeRetryMax {
+			r.backoff = routeRetryMax
+		}
+	}
+	r.retryAt = time.Now().Add(r.backoff)
+}
+
+// takeDeferred moves due events back into the batch, bounded by the batch size
+// so one transaction stays one transaction.
+func (r *eventRouter) takeDeferred(batch *[]events.Event) {
+	if len(r.deferred) == 0 || time.Now().Before(r.retryAt) {
+		return
+	}
+	room := routeBatchSize - len(*batch)
+	if room <= 0 {
+		return
+	}
+	if room > len(r.deferred) {
+		room = len(r.deferred)
+	}
+	*batch = append(*batch, r.deferred[:room]...)
+	r.deferred = append(r.deferred[:0], r.deferred[room:]...)
 }
 
 // flush routes a batch and writes it, with the watermark, in one transaction.
@@ -290,10 +356,7 @@ func (r *eventRouter) flush(batch *[]events.Event) {
 			// Best effort at retrying it in this process too; if the queue is
 			// full, the watermark simply stays put until a restart.
 			failed++
-			select {
-			case r.queue <- e:
-			default:
-			}
+			r.defer1(e)
 			continue
 		}
 		seqs = append(seqs, e.Seq)
@@ -313,19 +376,18 @@ func (r *eventRouter) flush(batch *[]events.Event) {
 		// attempt here too — and if the queue is full, staying owed is the
 		// safe outcome, since a replay is INSERT OR IGNORE against
 		// UNIQUE(event_id, sink_id).
-		requeued := 0
 		for _, e := range routed {
-			select {
-			case r.queue <- e:
-				requeued++
-			default:
-			}
+			r.defer1(e)
 		}
-		log.Printf("notify: writing %d routed events failed (%d requeued, the rest stay "+
-			"owed and are replayed next launch): %v", len(routed), requeued, err)
+		r.failedFlush()
+		log.Printf("notify: writing %d routed events failed; retrying in %s (they stay "+
+			"owed, so the watermark cannot pass them): %v", len(routed), r.backoff, err)
 		return
 	}
 	r.settle(seqs, 0)
+	// A write got through, so whatever was wrong is not wrong any more.
+	r.backoff = 0
+	r.retryAt = time.Time{}
 	if r.app.dispatcher != nil {
 		r.app.dispatcher.Wake()
 	}

--- a/app_routewrite_test.go
+++ b/app_routewrite_test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"SnmpLens/pkg/events"
+	"SnmpLens/pkg/storage"
+)
+
+// A batch whose WRITE fails must stay owed, so that a later flush cannot claim
+// it.
+//
+// settle ran before EnqueueRouted, and the comment at the failure site argued
+// that the stored watermark stays put — true, the write is atomic — and that a
+// restart therefore replays. What it missed is the running process: settle had
+// already removed those seqs from `inflight` and advanced `confirmed`, so the
+// NEXT successful flush computed its mark from an inflight they were no longer
+// in and wrote a watermark above a batch whose deliveries were never written.
+// Neither delivered nor replayed.
+//
+// The two flushes below are the whole point. One failing flush proves little;
+// what proves the defect is what the SECOND one writes.
+func TestAFailedWriteIsNotClaimedByTheNextFlush(t *testing.T) {
+	a := newTestApp(t)
+	r := newEventRouter(a)
+
+	var wrote []int64
+	fail := true
+	r.enqueue = func(_ []storage.RoutedGroup, mark int64) error {
+		if fail {
+			return errors.New("disk full")
+		}
+		wrote = append(wrote, mark)
+		return nil
+	}
+
+	// Batch one: seqs 10 and 11. Accepted, taken back out of the queue so the
+	// flush is driven by hand.
+	for _, seq := range []int64{10, 11} {
+		e := trapEvent(int(seq))
+		e.Seq = seq
+		if !r.accept(e) {
+			t.Fatal("the queue refused an event")
+		}
+		<-r.queue
+	}
+	first := []events.Event{{Seq: 10, ID: "e10"}, {Seq: 11, ID: "e11"}}
+	r.flush(&first)
+
+	// It failed, so both are still owed.
+	r.mu.Lock()
+	owed := len(r.inflight)
+	confirmed := r.confirmed
+	r.mu.Unlock()
+	if owed == 0 {
+		t.Error("a batch whose write failed was marked as done")
+	}
+	if confirmed >= 10 {
+		t.Errorf("the in-memory watermark reached %d despite the write failing", confirmed)
+	}
+
+	// The flush requeued them; drop those copies, because this test drives the
+	// second batch by hand and a requeued event would be flushed twice.
+	for len(r.queue) > 0 {
+		<-r.queue
+	}
+
+	// Batch two: a later, higher event that writes fine. This is the moment the
+	// defect showed — its mark must NOT reach past the batch that failed.
+	fail = false
+	e := trapEvent(20)
+	e.Seq = 20
+	r.accept(e)
+	<-r.queue
+	second := []events.Event{{Seq: 20, ID: "e20"}}
+	r.flush(&second)
+
+	if len(wrote) != 1 {
+		t.Fatalf("the second flush wrote %d watermarks, want 1", len(wrote))
+	}
+	if wrote[0] >= 10 {
+		t.Errorf("the second flush recorded the watermark at %d, past events 10 and 11 "+
+			"whose deliveries were never written: they are neither delivered nor replayed", wrote[0])
+	}
+}
+
+// The control: with the write succeeding, the watermark still advances. A fix
+// that simply never settles would pass the test above and break the feature.
+func TestACleanBatchStillAdvancesTheWatermark(t *testing.T) {
+	a := newTestApp(t)
+	r := newEventRouter(a)
+
+	var wrote []int64
+	r.enqueue = func(_ []storage.RoutedGroup, mark int64) error {
+		wrote = append(wrote, mark)
+		return nil
+	}
+
+	for _, seq := range []int64{3, 4} {
+		e := trapEvent(int(seq))
+		e.Seq = seq
+		r.accept(e)
+		<-r.queue
+	}
+	batch := []events.Event{{Seq: 3, ID: "e3"}, {Seq: 4, ID: "e4"}}
+	r.flush(&batch)
+
+	r.mu.Lock()
+	owed := len(r.inflight)
+	confirmed := r.confirmed
+	r.mu.Unlock()
+
+	if owed != 0 {
+		t.Errorf("%d events still owed after a clean flush", owed)
+	}
+	if confirmed != 4 {
+		t.Errorf("in-memory watermark = %d, want 4", confirmed)
+	}
+	if len(wrote) != 1 || wrote[0] != 4 {
+		t.Errorf("watermarks written = %v, want [4]", wrote)
+	}
+}
+
+// markIfSettled must answer what settle would, without settling — otherwise
+// the write records one number and the bookkeeping keeps another.
+func TestMarkIfSettledAgreesWithSettle(t *testing.T) {
+	a := newTestApp(t)
+
+	for _, seqs := range [][]int64{{5}, {5, 6}, {5, 6, 7}, {}} {
+		r := newEventRouter(a)
+		for _, seq := range []int64{5, 6, 7} {
+			e := trapEvent(int(seq))
+			e.Seq = seq
+			r.accept(e)
+			<-r.queue
+		}
+		predicted := r.markIfSettled(seqs)
+		actual := r.settle(seqs, 0)
+		if predicted != actual {
+			t.Errorf("settling %v: markIfSettled said %d, settle produced %d", seqs, predicted, actual)
+		}
+	}
+}

--- a/app_sessionsecret_test.go
+++ b/app_sessionsecret_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/secrets"
+)
+
+// Deleting a monitoring session must take its credentials with it.
+//
+// A session's community and v3 passphrases live in pkg/secrets under
+// SessionRef(id), deliberately NOT in monitoring.db — storage.SessionConn holds
+// only what is safe to read in a copied database. Which is exactly why deleting
+// the database row cannot be the whole of it: the row goes and the credential
+// stays, under a key nothing in the app will ever look up again. The same
+// defect NotifyDeleteSink had, in the other place that writes to pkg/secrets.
+func TestDeletingASessionRemovesItsCredentials(t *testing.T) {
+	a := newTestApp(t)
+
+	id, err := a.storage.CreateSession("core switches", "1.3.6.1.2.1.2.2.1.10.1",
+		[]string{"10.0.0.1"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := a.secrets.Set(secrets.SessionRef(id), `{"community":"s3cret"}`); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if err := a.MonitorDeleteSession(id); err != nil {
+		t.Fatalf("MonitorDeleteSession: %v", err)
+	}
+	if got, _ := a.secrets.Get(secrets.SessionRef(id)); got != "" {
+		t.Errorf("the session's credentials outlived it: %q", got)
+	}
+}
+
+// Retention deletes finished, empty sessions in bulk. That is the same defect
+// at a larger scale, and the caller cannot fix it without being told which ids
+// went — which is why Cleanup returns them.
+func TestRetentionRemovesTheCredentialsOfTheSessionsItDeletes(t *testing.T) {
+	a := newTestApp(t)
+
+	id, err := a.storage.CreateSession("finished", "1.3.6.1.2.1.1.3.0",
+		[]string{"10.0.0.2"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	if err := a.storage.UpdateSession(id, false, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+	if err := a.secrets.Set(secrets.SessionRef(id), `{"community":"s3cret"}`); err != nil {
+		t.Fatal(err)
+	}
+
+	// No data points were ever written, so retention removes the session.
+	if _, err := a.MonitorCleanup(1); err != nil {
+		t.Fatalf("MonitorCleanup: %v", err)
+	}
+
+	sessions, err := a.storage.ListSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, existing := range sessions {
+		if existing.ID == id {
+			t.Fatal("the session was not removed; this test proves nothing")
+		}
+	}
+	if got, _ := a.secrets.Get(secrets.SessionRef(id)); got != "" {
+		t.Errorf("retention removed the session and left its credentials: %q", got)
+	}
+}
+
+// An ACTIVE session, or one that holds data, must survive retention — and so
+// must its credentials. A cleanup that removes a running session's community
+// is worse than one that leaves an orphan behind.
+func TestRetentionLeavesLiveSessionsAndTheirCredentialsAlone(t *testing.T) {
+	a := newTestApp(t)
+
+	live, err := a.storage.CreateSession("running", "1.3.6.1.2.1.1.3.0",
+		[]string{"10.0.0.3"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.secrets.Set(secrets.SessionRef(live), `{"community":"keep-me"}`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.MonitorCleanup(1); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := a.storage.ListSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, existing := range sessions {
+		if existing.ID == live {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("retention removed an active session")
+	}
+	if got, _ := a.secrets.Get(secrets.SessionRef(live)); got == "" {
+		t.Error("retention removed an active session's credentials")
+	}
+}

--- a/app_sinkbinding_test.go
+++ b/app_sinkbinding_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"SnmpLens/pkg/notify"
+	"SnmpLens/pkg/secrets"
+)
+
+// A sink credential is write-only from the renderer: NotifyListSinks blanks
+// Secret and the form shows "configured" from HasSecret without ever receiving
+// the value. Two methods resolved that credential BY SINK ID while taking the
+// destination from whatever the caller sent, which turned the pair into a read
+// primitive over the store — name an existing sink's id, point the URL at your
+// own server, collect the bearer token.
+//
+// This is the measurement, not the argument: a real receiver on a real socket,
+// recording every Authorization header it is sent.
+
+type collector struct {
+	*httptest.Server
+	mu   sync.Mutex
+	auth []string
+}
+
+func newCollector(t *testing.T) *collector {
+	t.Helper()
+	c := &collector{}
+	c.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.mu.Lock()
+		c.auth = append(c.auth, r.Header.Get("Authorization"))
+		c.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(c.Close)
+	return c
+}
+
+func (c *collector) saw(secret string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, a := range c.auth {
+		if strings.Contains(a, secret) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *collector) requests() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.auth)
+}
+
+const stolen = "TOP-SECRET-TOKEN"
+
+func TestTestSinkWillNotSendAStoredCredentialElsewhere(t *testing.T) {
+	a := newTestApp(t)
+	own := newCollector(t)
+	attacker := newCollector(t)
+
+	saved, err := a.NotifySaveSink(notify.SinkConfig{
+		Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: own.URL},
+		Secret:  stolen,
+	})
+	if err != nil {
+		t.Fatalf("NotifySaveSink: %v", err)
+	}
+
+	// The attack: the sink's own id, somebody else's URL, no credential
+	// supplied — exactly what the renderer can construct without ever being
+	// able to READ the credential.
+	err = a.NotifyTestSink(notify.SinkConfig{
+		ID: saved.ID, Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: attacker.URL},
+	})
+	if err == nil {
+		t.Fatal("the test was accepted against a destination the credential was not stored for")
+	}
+	if attacker.saw(stolen) {
+		t.Fatalf("the credential was delivered to the attacker: %v", attacker.auth)
+	}
+	if attacker.requests() != 0 {
+		t.Errorf("the attacker received %d request(s); it should never have been contacted", attacker.requests())
+	}
+	// The refusal has to tell the operator what to do, because it fires on the
+	// legitimate case too — editing a URL and pressing Test before saving.
+	if !strings.Contains(strings.ToLower(err.Error()), "credential") {
+		t.Errorf("the refusal does not explain itself: %v", err)
+	}
+}
+
+// The control: testing the destination the credential WAS stored for still
+// authenticates. Without this, the fix could be "never resolve anything",
+// which would break the one button an operator presses to check a sink.
+func TestTestSinkStillAuthenticatesToItsOwnDestination(t *testing.T) {
+	a := newTestApp(t)
+	own := newCollector(t)
+
+	saved, err := a.NotifySaveSink(notify.SinkConfig{
+		Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: own.URL},
+		Secret:  stolen,
+	})
+	if err != nil {
+		t.Fatalf("NotifySaveSink: %v", err)
+	}
+
+	if err := a.NotifyTestSink(notify.SinkConfig{
+		ID: saved.ID, Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: own.URL},
+	}); err != nil {
+		t.Fatalf("testing the sink's own destination was refused: %v", err)
+	}
+	if !own.saw(stolen) {
+		t.Fatalf("the credential did not reach its own destination: %v", own.auth)
+	}
+}
+
+// A sink that has not been saved yet has no stored credential to hand out, and
+// must still be testable with one the operator just typed.
+func TestTestSinkWorksForAnUnsavedSink(t *testing.T) {
+	a := newTestApp(t)
+	dest := newCollector(t)
+
+	if err := a.NotifyTestSink(notify.SinkConfig{
+		Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: dest.URL},
+		Secret:  "typed-in-the-form",
+	}); err != nil {
+		t.Fatalf("testing a new sink was refused: %v", err)
+	}
+	if !dest.saw("typed-in-the-form") {
+		t.Fatalf("the typed credential did not arrive: %v", dest.auth)
+	}
+}
+
+// The durable half of the same defect: the SAVE path never compared the
+// address it was given with the one the credential was stored against, so a
+// renderer that cannot read a credential could still aim it. Pointing a sink
+// somewhere new unbinds the credential.
+func TestSavingANewDestinationUnbindsTheStoredCredential(t *testing.T) {
+	a := newTestApp(t)
+
+	saved, err := a.NotifySaveSink(notify.SinkConfig{
+		Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: "https://hooks.example.com/x"},
+		Secret:  stolen,
+	})
+	if err != nil {
+		t.Fatalf("NotifySaveSink: %v", err)
+	}
+	if !saved.HasSecret {
+		t.Fatal("the credential was not stored in the first place")
+	}
+
+	moved, err := a.NotifySaveSink(notify.SinkConfig{
+		ID: saved.ID, Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: "https://attacker.example/collect"},
+	})
+	if err != nil {
+		t.Fatalf("the save was refused rather than unbinding: %v", err)
+	}
+	if moved.HasSecret {
+		t.Fatal("the credential followed the destination to a new address")
+	}
+	if got, _ := a.secrets.Get(secrets.SinkRef(saved.ID)); got != "" {
+		t.Fatalf("the credential is still in the store: %q", got)
+	}
+}
+
+// Editing anything else — the name, the template, the timeout — must leave the
+// credential alone, or every save becomes a re-entry of the password.
+func TestSavingAnUnrelatedChangeKeepsTheCredential(t *testing.T) {
+	a := newTestApp(t)
+
+	saved, err := a.NotifySaveSink(notify.SinkConfig{
+		Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: "https://hooks.example.com/x", Timeout: 10},
+		Secret:  stolen,
+	})
+	if err != nil {
+		t.Fatalf("NotifySaveSink: %v", err)
+	}
+
+	again, err := a.NotifySaveSink(notify.SinkConfig{
+		ID: saved.ID, Name: "NOC renamed", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: "https://hooks.example.com/x", Timeout: 30},
+	})
+	if err != nil {
+		t.Fatalf("NotifySaveSink: %v", err)
+	}
+	if !again.HasSecret {
+		t.Fatal("an unrelated edit dropped the credential")
+	}
+}
+
+// What counts as the destination, per kind. Each pair differs in exactly one
+// field, and these are the comparisons both paths above rely on.
+func TestDestinationDistinguishesWhatItMust(t *testing.T) {
+	wh := func(url string) notify.SinkConfig {
+		return notify.SinkConfig{Kind: notify.SinkWebhook, Webhook: notify.WebhookConfig{URL: url}}
+	}
+	em := func(host string, port int, enc string) notify.SinkConfig {
+		return notify.SinkConfig{Kind: notify.SinkEmail,
+			Email: notify.EmailConfig{Host: host, Port: port, Encryption: enc}}
+	}
+	sl := func(proto, addr string) notify.SinkConfig {
+		return notify.SinkConfig{Kind: notify.SinkSyslog,
+			Syslog: notify.SyslogConfig{Protocol: proto, Address: addr}}
+	}
+
+	cases := []struct {
+		name string
+		a, b notify.SinkConfig
+		want bool
+	}{
+		{"a different webhook host is a different destination", wh("https://a.example/x"), wh("https://b.example/x"), false},
+		{"a different path is too", wh("https://a.example/x"), wh("https://a.example/y"), false},
+		{"https to http is a downgrade, not the same place", wh("https://a.example/x"), wh("http://a.example/x"), false},
+		{"surrounding whitespace is not a move", wh("https://a.example/x"), wh("  https://a.example/x  "), true},
+		{"a placeholder URL is compared UNSUBSTITUTED", wh("https://hooks.slack.com/{{secret}}"), wh("https://hooks.slack.com/{{secret}}"), true},
+		{"a different SMTP host", em("mail.a", 587, "starttls"), em("mail.b", 587, "starttls"), false},
+		{"a different port", em("mail.a", 587, "starttls"), em("mail.a", 465, "starttls"), false},
+		{"dropping encryption puts the password on the wire in the clear", em("mail.a", 587, "starttls"), em("mail.a", 587, "none"), false},
+		{"host case does not matter", em("Mail.A", 587, "starttls"), em("mail.a", 587, "starttls"), true},
+		{"a different collector", sl("tls", "a:6514"), sl("tls", "b:6514"), false},
+		{"a different transport", sl("tls", "a:6514"), sl("tcp", "a:6514"), false},
+		{"the same collector", sl("TLS", "A:6514"), sl("tls", "a:6514"), true},
+	}
+	for _, c := range cases {
+		if got := notify.SameDestination(c.a, c.b); got != c.want {
+			t.Errorf("%s: SameDestination = %v, want %v", c.name, got, c.want)
+		}
+	}
+
+	// A kind nothing can build binds to nothing, including itself — otherwise
+	// two unknown kinds would compare equal on two empty strings.
+	unknown := notify.SinkConfig{Kind: "carrier-pigeon"}
+	if _, ok := notify.Destination(unknown); ok {
+		t.Error("an unknown kind reported a destination")
+	}
+	if notify.SameDestination(unknown, unknown) {
+		t.Error("an unknown kind matched itself")
+	}
+}
+
+// Every kind Build accepts must have a destination, or a sink added later gets
+// the old behaviour by default: a credential bound to nothing.
+func TestEveryBuildableKindHasADestination(t *testing.T) {
+	for _, kind := range []string{notify.SinkSyslog, notify.SinkWebhook, notify.SinkEmail} {
+		cfg := notify.SinkConfig{Kind: kind}
+		if _, ok := notify.Build(cfg, ""); !ok {
+			t.Fatalf("%s is no longer buildable; this test is out of date", kind)
+		}
+		if _, ok := notify.Destination(cfg); !ok {
+			t.Errorf("%s can be built but has no destination", kind)
+		}
+	}
+}

--- a/app_updatecheck_test.go
+++ b/app_updatecheck_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/updater"
+)
+
+// A check that could not be answered must not read as "you are up to date".
+//
+// App.CheckForUpdate returns no error across the bridge. It logged the failure
+// and returned the zero value, so Available was false and the renderer said
+// "You're on the latest version" — reassurance produced by a failure. Every
+// reason a check fails (no network, GitHub rate-limiting, a proxy, a refused
+// response) looked identical to good news, in a product whose updates carry
+// security fixes.
+func TestAFailedUpdateCheckSaysSo(t *testing.T) {
+	got := withCheckError(updater.UpdateInfo{CurrentVersion: "v1.5.0"},
+		errors.New("GitHub API returned 403 Forbidden: rate limit exceeded"))
+
+	if got.Error == "" {
+		t.Fatal("a failed check reported nothing; the renderer shows that as " +
+			`"You're on the latest version"`)
+	}
+	if !strings.Contains(got.Error, "403") {
+		t.Errorf("the reason was lost: %q", got.Error)
+	}
+	if got.Available {
+		t.Error("a failed check claimed an update is available")
+	}
+	// What is known is still returned: the current version is read locally and
+	// is not in doubt because GitHub was unreachable.
+	if got.CurrentVersion != "v1.5.0" {
+		t.Errorf("CurrentVersion = %q", got.CurrentVersion)
+	}
+}
+
+// The control: a successful check reports no error, or every check would turn
+// into a warning.
+func TestASuccessfulUpdateCheckReportsNoError(t *testing.T) {
+	got := withCheckError(updater.UpdateInfo{
+		CurrentVersion: "v1.5.0", LatestVersion: "v1.5.0",
+	}, nil)
+	if got.Error != "" {
+		t.Errorf("a successful check reported an error: %q", got.Error)
+	}
+}
+
+// The renderer has to READ the field, and read it BEFORE concluding "up to
+// date" — a failure looks exactly like "not available". Checked over the
+// source, because the alternative is a browser.
+func TestTheRendererDistinguishesAFailedCheck(t *testing.T) {
+	for _, f := range []string{
+		filepath.Join("frontend", "src", "settings", "GeneralSettings.svelte"),
+		filepath.Join("frontend", "src", "stores", "updateStore.js"),
+	} {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("%s: %v", f, err)
+		}
+		if !strings.Contains(string(src), "info.error") {
+			t.Errorf("%s does not read the reason a check failed", f)
+		}
+	}
+
+	body, err := os.ReadFile(filepath.Join("frontend", "src", "settings", "GeneralSettings.svelte"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	errAt := strings.Index(string(body), "info.error")
+	upAt := strings.Index(string(body), "update.upToDate")
+	if errAt < 0 || upAt < 0 || errAt > upAt {
+		t.Errorf("the up-to-date message is not guarded by the error check (error@%d upToDate@%d)",
+			errAt, upAt)
+	}
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/icons.test.mjs && node tests/snmpparams.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/csv.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
+    "test": "node tests/compile.test.mjs && node tests/reactive.test.mjs && node tests/icons.test.mjs && node tests/snmpparams.test.mjs && node tests/polling.smoke.mjs && node tests/i18n.parity.mjs && node tests/tokenize.test.mjs && node tests/metrics.test.mjs && node tests/mibeditor.store.test.mjs && node tests/search.test.mjs && node tests/lifecycle.test.mjs && node tests/history.test.mjs && node tests/props.test.mjs && node tests/iptext.test.mjs && node tests/tablerows.test.mjs && node tests/modals.test.mjs && node tests/credentials.test.mjs && node tests/render.test.mjs && node tests/anonymous.test.mjs && node tests/csv.test.mjs && node tests/burst.test.mjs && node tests/routepriority.test.mjs && node tests/deliverylog.test.mjs",
     "screenshots": "node ../tools/screenshots.mjs",
     "check": "svelte-check --tsconfig ./jsconfig.json --fail-on-warnings"
   },

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -865,6 +865,7 @@
     "secretOnFile": "gespeichert — leer lassen zum Beibehalten",
     "secretSet": "Zugangsdaten gesetzt",
     "secretCleared": "Zugangsdaten entfernt.",
+    "secretUnbound": "Das Ziel wurde geändert, daher wurden die gespeicherten Zugangsdaten entfernt. Geben Sie sie erneut ein, um sich beim neuen Ziel zu authentifizieren.",
     "clearSecret": "Gespeicherte Zugangsdaten entfernen",
     "secretHint": "Außerhalb der Datenbank gespeichert, geschützt durch: {backend}",
     "urlSecretHint": "Slack, Teams und Discord authentifizieren sich allein über die URL. Schreiben Sie {{secret}} hinein, dann wird dieser Teil beim Zugangsdatum statt in der Datenbank gespeichert.",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -389,6 +389,7 @@
     "listenerStopFailed": "Trap-Listener konnte nicht gestoppt werden: {error}",
     "allCleared": "Alle Traps gelöscht.",
     "newTrapReceived": "Neuer {type} empfangen von {source}",
+    "moreTrapsReceived": "und {count} weitere Traps",
     "listenerError": "Trap-Listener-Fehler: {error}",
     "enterTarget": "Bitte geben Sie eine Ziel-IP ein.",
     "enterTrapOid": "Bitte geben Sie eine Trap OID ein.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -389,6 +389,7 @@
     "listenerStopFailed": "Failed to stop trap listener: {error}",
     "allCleared": "All traps cleared.",
     "newTrapReceived": "New {type} received from {source}",
+    "moreTrapsReceived": "and {count} more traps",
     "listenerError": "Trap listener error: {error}",
     "enterTarget": "Please enter a target IP.",
     "enterTrapOid": "Please enter a Trap OID.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -865,6 +865,7 @@
     "secretOnFile": "stored — leave blank to keep it",
     "secretSet": "credential set",
     "secretCleared": "Credential removed.",
+    "secretUnbound": "The destination changed, so the stored credential was removed. Enter it again to authenticate to the new one.",
     "clearSecret": "Remove the stored credential",
     "secretHint": "Stored outside the database, protected by: {backend}",
     "urlSecretHint": "Slack, Teams and Discord authenticate by the URL alone. Write {{secret}} in it and that part is kept with the credential instead of in the database.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -389,6 +389,7 @@
     "listenerStopFailed": "Error al detener el receptor de Traps: {error}",
     "allCleared": "Todos los Traps borrados.",
     "newTrapReceived": "Nuevo {type} recibido de {source}",
+    "moreTrapsReceived": "y {count} traps más",
     "listenerError": "Error del receptor de Traps: {error}",
     "enterTarget": "Por favor, introduzca una IP de objetivo.",
     "enterTrapOid": "Por favor, introduzca un OID de Trap.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -865,6 +865,7 @@
     "secretOnFile": "guardada — dejar vacío para conservarla",
     "secretSet": "credencial guardada",
     "secretCleared": "Credencial eliminada.",
+    "secretUnbound": "El destino ha cambiado, por lo que se ha eliminado la credencial almacenada. Introdúzcala de nuevo para autenticarse en el nuevo destino.",
     "clearSecret": "Eliminar la credencial guardada",
     "secretHint": "Almacenada fuera de la base de datos, protegida por: {backend}",
     "urlSecretHint": "Slack, Teams y Discord se autentican solo mediante la URL. Escriba {{secret}} en ella y esa parte se guardará junto a la credencial en lugar de en la base de datos.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -865,6 +865,7 @@
     "secretOnFile": "enregistré — laisser vide pour le conserver",
     "secretSet": "identifiant enregistré",
     "secretCleared": "Identifiant supprimé.",
+    "secretUnbound": "La destination a changé, l'identifiant enregistré a donc été supprimé. Saisissez-le à nouveau pour vous authentifier auprès de la nouvelle.",
     "clearSecret": "Supprimer l'identifiant enregistré",
     "secretHint": "Stocké hors de la base, protégé par : {backend}",
     "urlSecretHint": "Slack, Teams et Discord s'authentifient par la seule URL. Écrivez {{secret}} dedans et cette partie sera conservée avec l'identifiant plutôt que dans la base.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -389,6 +389,7 @@
     "listenerStopFailed": "Échec de l'arrêt de l'écoute : {error}",
     "allCleared": "Tous les traps ont été effacés.",
     "newTrapReceived": "Nouveau {type} reçu de {source}",
+    "moreTrapsReceived": "et {count} autres traps",
     "listenerError": "Erreur de l'écoute : {error}",
     "enterTarget": "Veuillez saisir une adresse IP cible.",
     "enterTrapOid": "Veuillez saisir un Trap OID.",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -865,6 +865,7 @@
     "secretOnFile": "已保存 — 留空则保持不变",
     "secretSet": "已设置凭据",
     "secretCleared": "凭据已删除。",
+    "secretUnbound": "目标已更改，因此已删除已保存的凭据。请重新输入以向新目标进行身份验证。",
     "clearSecret": "删除已保存的凭据",
     "secretHint": "存储在数据库之外，保护方式：{backend}",
     "urlSecretHint": "Slack、Teams 和 Discord 仅凭 URL 进行身份验证。在其中写入 {{secret}}，该部分将与凭据一同保存，而不写入数据库。",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -389,6 +389,7 @@
     "listenerStopFailed": "停止 Trap 监听器失败：{error}",
     "allCleared": "所有 Trap 已清除。",
     "newTrapReceived": "收到新的 {type}，来自 {source}",
+    "moreTrapsReceived": "以及另外 {count} 个 trap",
     "listenerError": "Trap 监听器错误：{error}",
     "enterTarget": "请输入目标 IP。",
     "enterTrapOid": "请输入 Trap OID。",

--- a/frontend/src/monitor/AlertTimeline.svelte
+++ b/frontend/src/monitor/AlertTimeline.svelte
@@ -9,6 +9,11 @@
   import { oidName, oidTooltip } from '../utils/oidDisplay';
   import { EventsQuery } from '../../wailsjs/go/main/App';
   import { EventsOn } from '../../wailsjs/runtime/runtime';
+  import { capNewestFirst } from '../utils/burst';
+
+  // Far more incidents than anyone reads on a timeline, and a ceiling all
+  // the same: 'event:new' arrives at whatever rate the network chooses.
+  const MAX_INCIDENTS = 500;
   import { displayTarget as labelled } from '../utils/targets';
 
   export let session;
@@ -41,7 +46,10 @@
     unlisten = EventsOn('event:new', (ev) => {
       if (!ev || ev.sessionId !== session?.id) return;
       if (ev.category !== 'threshold' && ev.category !== 'reachability') return;
-      incidents = [ev, ...incidents];
+      // Capped: this list is fed by 'event:new', which a trap flood drives at
+      // the rate the network chooses. It has no paging, so dropping the tail
+      // costs nothing a reload does not restore.
+      incidents = capNewestFirst([ev, ...incidents], MAX_INCIDENTS);
     });
   });
 

--- a/frontend/src/settings/GeneralSettings.svelte
+++ b/frontend/src/settings/GeneralSettings.svelte
@@ -17,7 +17,13 @@
       notificationStore.add(t('update.checkFailed', { values: { error: String(e) } }), 'error');
       return null;
     });
-    if (info && !info.available) {
+    // .error before .available: a check that failed reports the zero value, so
+    // "not available" is also what a failure looks like. Saying "you're on the
+    // latest version" because GitHub was unreachable is reassurance produced
+    // by a failure, in a product whose updates carry security fixes.
+    if (info && info.error) {
+      notificationStore.add(t('update.checkFailed', { values: { error: info.error } }), 'error');
+    } else if (info && !info.available) {
       notificationStore.add(t('update.upToDate'), 'success');
     }
   }

--- a/frontend/src/settings/NotifySettings.svelte
+++ b/frontend/src/settings/NotifySettings.svelte
@@ -103,10 +103,19 @@
         editingSink.email.to = editingSink.email.toRaw.split(/[,;]+/).map((x) => x.trim()).filter(Boolean);
         delete editingSink.email.toRaw;
       }
-      await NotifySaveSink(editingSink);
+      // A stored credential is bound to the destination it was stored
+      // against, so pointing an existing sink somewhere new unbinds it. Say
+      // so: the form will show the credential as no longer configured, and a
+      // sink that silently stops authenticating is the failure this whole
+      // screen exists to avoid.
+      const hadSecret = !!editingSink.hasSecret && !editingSink.secret;
+      const saved = await NotifySaveSink(editingSink);
       editingSink = null;
       await reload();
       notificationStore.add(get(_)('notify.sinkSaved'), 'success');
+      if (hadSecret && saved && !saved.hasSecret) {
+        notificationStore.add(get(_)('notify.secretUnbound'), 'info');
+      }
     } catch (e) {
       notificationStore.add(String(e), 'error');
     }

--- a/frontend/src/stores/eventsStore.js
+++ b/frontend/src/stores/eventsStore.js
@@ -178,6 +178,11 @@ function createEventsStore() {
     await load(get({ subscribe }).filter);
   }
 
+  // How many events the LIVE TAIL may hold. loadMore is a deliberate user
+  // action and is not bounded by this; what is bounded is growth driven from
+  // the network.
+  const MAX_LIVE_ITEMS = 2000;
+
   /**
    * Live tail. The Go side persists an event and THEN emits this — the row
    * exists whether or not a window was listening, so a missed emit costs a
@@ -195,7 +200,28 @@ function createEventsStore() {
         // otherwise the list would silently disagree with its own filter.
         if (s.nextCursor && s.items.length === 0) return s;
         if (!matchesFilter(ev, s.filter)) return s;
-        return { ...s, items: [ev, ...s.items], total: s.total + 1 };
+
+        // Capped, and the CURSOR IS REPAIRED with it. The live tail had no
+        // ceiling, and it is fed at whatever rate the network sends traps —
+        // the Go side absorbs 2000 a second by design, and every one of them
+        // is emitted here.
+        //
+        // Truncating the tail alone would open a hole: nextCursor is a
+        // beforeSeq, so paging would resume below the events just dropped and
+        // silently skip them. Setting it to the seq of the last kept item
+        // means "load more" continues exactly where the visible list ends,
+        // which is what the cursor already meant.
+        const items = [ev, ...s.items];
+        if (items.length <= MAX_LIVE_ITEMS) {
+          return { ...s, items, total: s.total + 1 };
+        }
+        const kept = items.slice(0, MAX_LIVE_ITEMS);
+        return {
+          ...s,
+          items: kept,
+          total: s.total + 1,
+          nextCursor: kept[kept.length - 1].seq || s.nextCursor,
+        };
       });
     });
   }

--- a/frontend/src/stores/notifications.js
+++ b/frontend/src/stores/notifications.js
@@ -1,4 +1,15 @@
 import { writable } from 'svelte/store';
+import { capNewestFirst } from '../utils/burst';
+
+// Toasts are ephemeral by definition, and this list had no ceiling: a trap
+// flood with the Traps panel hidden raised one per trap, each with its own
+// five-second timer, and the window whose job is to show the flood was what
+// stopped working. Ten thousand live toasts are not ten thousand pieces of
+// information.
+//
+// Newest-first is how they are capped; they are STORED oldest-first, because
+// that is the order they are rendered in, so the cap drops from the front.
+const MAX_TOASTS = 6;
 
 // Monotonic, collision-free. Date.now() gave two toasts raised in the same
 // synchronous tick the SAME id: they collided as {#each} keys, and removing
@@ -12,7 +23,12 @@ function createNotificationStore() {
     const id = `${Date.now()}-${idSeq++}`;
     const notification = { id, message, type };
     
-    update(notifications => [...notifications, notification]);
+    // The oldest go first. A toast that has been on screen for four of its five
+    // seconds has been read or it has not; the one that just arrived has not.
+    update(notifications => {
+      const next = [...notifications, notification];
+      return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+    });
 
     if (timeout) {
       setTimeout(() => {

--- a/frontend/src/stores/trapStore.js
+++ b/frontend/src/stores/trapStore.js
@@ -6,6 +6,37 @@ import { notificationStore } from './notifications';
 import { settingsStore } from './settingsStore';
 import { buildTrapListenerRequest } from '../utils/snmpParams';
 import { sendNativeNotification } from '../utils/nativeNotify';
+import { createBurstGate } from '../utils/burst';
+
+// What a trap flood used to do to the window that is supposed to show it.
+//
+// Every received trap raised a toast when the panel was hidden, sent an OS
+// notification when the window was unfocused, and — for the OS notification —
+// awaited GetOidDetails, a bridge call into pkg/mib that takes the
+// package-level EXCLUSIVE gosmi mutex. Nothing rate-limited any of the three,
+// so an unauthenticated remote sender chose how often the renderer acquired
+// the lock that every MIB operation in the product needs.
+//
+// Leading edge plus a trailing summary: the first trap in a window is reported
+// at once, and the rest arrive as "and N more". Only the leading one performs
+// the OID lookup, which is what takes the rate control down to the lock.
+//
+// Three seconds for the in-app toast, which is cheap and lives for five; ten
+// for the OS notification, which the desktop queues and the operator dismisses
+// by hand.
+const trapToastGate = createBurstGate({
+  windowMs: 3000,
+  onSummary: (count) => {
+    notificationStore.add(get(_)('traps.moreTrapsReceived', { values: { count } }), 'info');
+  },
+});
+
+const nativeTrapGate = createBurstGate({
+  windowMs: 10000,
+  onSummary: (count) => {
+    sendNativeNotification('SnmpLens', get(_)('traps.moreTrapsReceived', { values: { count } }));
+  },
+});
 
 const STORAGE_KEY = 'trapHistory';
 const MAX_TRAPS_DEFAULT = 1000;
@@ -93,14 +124,17 @@ function createTrapStore() {
     const storeState = get(trapStore);
 
     // Show internal notification if panel is hidden
-    if (!storeState.isPanelVisible) {
+    if (!storeState.isPanelVisible && trapToastGate.offer()) {
       const t = get(_);
       notificationStore.add(t('traps.newTrapReceived', { values: { type: trap.pduType || 'Trap', source: trap.source } }), 'info');
     }
 
     // Send native OS notification (Windows toast / macOS / Linux)
     const settings = get(settingsStore);
-    if (settings.traps?.nativeNotifications && !storeState.isWindowFocused) {
+    // The gate is asked LAST, so a suppressed trap does not consume a window
+    // it was never eligible for — and, more to the point, so the GetOidDetails
+    // call below happens only for the one trap that is actually reported.
+    if (settings.traps?.nativeNotifications && !storeState.isWindowFocused && nativeTrapGate.offer()) {
       (async () => {
         const trapOidVar = trap.variables?.find(v =>
           v.oid === 'snmpTrapOID.0' ||

--- a/frontend/src/stores/updateStore.js
+++ b/frontend/src/stores/updateStore.js
@@ -51,6 +51,11 @@ function createUpdateStore() {
       update((s) => ({
         ...s,
         checking: false,
+        // A check that could not be answered is an ERROR, not "up to date".
+        // Go returns no error across the bridge — it returns UpdateInfo with
+        // the reason in .error — so this is the only place the difference
+        // exists.
+        error: info.error || null,
         currentVersion: strip(info.currentVersion) || s.currentVersion,
         available: !!info.available,
         latestVersion: strip(info.latestVersion),

--- a/frontend/src/utils/burst.js
+++ b/frontend/src/utils/burst.js
@@ -1,0 +1,96 @@
+// Rate control for anything a TRAP can trigger in the renderer.
+//
+// A trap arrives from the network with nobody authenticating it, and the Go
+// side is built to absorb a storm: the socket buffer was raised to 8 MiB and
+// 2000 events a second are journalled without loss. Every one of them is then
+// emitted to the window, so the renderer is offered the same rate — and it had
+// no limit of any kind. One toast per trap, one OS notification per trap, and
+// one bridge call per trap into GetOidDetails, which takes pkg/mib's
+// package-level exclusive gosmi mutex. So remote UDP traffic set the rate at
+// which the renderer held the lock every MIB operation in the product needs,
+// and the window whose job is to SHOW the flood is what stopped working.
+//
+// A gate is leading-edge with a trailing summary: the first event in a window
+// goes through immediately, because an operator should learn about a trap the
+// moment it arrives, and everything after it is counted and reported once as
+// "and N more". That is strictly more information than N identical toasts, and
+// it is bounded.
+//
+// now and schedule are injected so the tests can drive time rather than wait
+// for it.
+
+/**
+ * @param {object} opts
+ * @param {number} opts.windowMs how long one summary window lasts
+ * @param {(count: number) => void} opts.onSummary called with what was suppressed
+ * @param {() => number} [opts.now]
+ * @param {(fn: () => void, ms: number) => any} [opts.schedule]
+ * @param {(handle: any) => void} [opts.cancel]
+ */
+export function createBurstGate({ windowMs, onSummary, now, schedule, cancel }) {
+  const clock = now || (() => Date.now());
+  const later = schedule || ((fn, ms) => setTimeout(fn, ms));
+  const stop = cancel || ((h) => clearTimeout(h));
+
+  let windowEnds = 0;
+  let suppressed = 0;
+  let timer = null;
+
+  function flush() {
+    timer = null;
+    const n = suppressed;
+    suppressed = 0;
+    // The window is over: the next event leads a new one.
+    windowEnds = 0;
+    if (n > 0) onSummary(n);
+  }
+
+  return {
+    /**
+     * @returns {boolean} true when the caller should act on this event now.
+     */
+    offer() {
+      const t = clock();
+      if (t >= windowEnds) {
+        windowEnds = t + windowMs;
+        // Arm the trailing summary. Without it, the tail of a burst is simply
+        // never reported: the last events fall inside a window that nothing
+        // closes.
+        if (timer === null) timer = later(flush, windowMs);
+        return true;
+      }
+      suppressed++;
+      return false;
+    },
+
+    /** For teardown; a pending summary is dropped, not fired. */
+    reset() {
+      if (timer !== null) stop(timer);
+      timer = null;
+      suppressed = 0;
+      windowEnds = 0;
+    },
+
+    /** Test and diagnostic access. */
+    pending() {
+      return suppressed;
+    },
+  };
+}
+
+/**
+ * Keep the newest `max` entries of a list that grows from the front.
+ *
+ * Written once rather than four times, because the four places that needed it
+ * were four different lists fed by the same unauthenticated source.
+ *
+ * @template T
+ * @param {T[]} list newest first
+ * @param {number} max
+ * @returns {T[]} the same array when nothing was dropped, so a store update
+ *   that changes nothing does not force a re-render
+ */
+export function capNewestFirst(list, max) {
+  if (list.length <= max) return list;
+  return list.slice(0, max);
+}

--- a/frontend/tests/burst.test.mjs
+++ b/frontend/tests/burst.test.mjs
@@ -1,0 +1,138 @@
+// Nothing a TRAP can trigger in the renderer may run at the rate the network
+// chooses.
+//
+// The Go side is built to absorb a storm — the socket buffer was raised to
+// 8 MiB and 2000 events a second are journalled without loss — and every one of
+// them is emitted to the window. The renderer had no limit of any kind: one
+// toast per trap, one OS notification per trap, and one bridge call per trap
+// into GetOidDetails, which takes pkg/mib's package-level EXCLUSIVE gosmi
+// mutex. So an unauthenticated remote sender chose how often the renderer
+// acquired the lock every MIB operation in the product needs, and the window
+// whose job is to show the flood was what stopped working.
+//
+// The unit tests are the smaller half of this file. The structural check is
+// what stops it recurring: nothing fed by 'event:new' or 'newTrap' may append
+// to a list without a ceiling.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { createBurstGate, capNewestFirst } from '../src/utils/burst.js';
+
+const root = new URL('../src/', import.meta.url).pathname.replace(/^[/]([A-Za-z]:)/, '$1');
+
+let failures = 0;
+const check = (name, ok, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? ' — ' + extra : ''}`);
+  if (!ok) failures++;
+};
+
+function sources(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sources(path));
+    else if (entry.name.endsWith('.svelte') || entry.name.endsWith('.js')) out.push(path);
+  }
+  return out;
+}
+
+/* --- the gate --------------------------------------------------------------
+ * Time is driven rather than waited for, so the burst under test is the shape
+ * a real storm has: two thousand events inside one window. */
+{
+  let clock = 0;
+  const summaries = [];
+  let armed = null;
+  const gate = createBurstGate({
+    windowMs: 1000,
+    onSummary: (n) => summaries.push(n),
+    now: () => clock,
+    schedule: (fn) => { armed = fn; return 1; },
+    cancel: () => { armed = null; },
+  });
+
+  check('the first event goes through', gate.offer() === true);
+  let admitted = 0;
+  for (let i = 0; i < 2000; i++) if (gate.offer()) admitted++;
+  check('everything else inside the window is suppressed', admitted === 0, `${admitted} admitted`);
+  check('and it is counted, not discarded', gate.pending() === 2000, String(gate.pending()));
+
+  // The window closes and the tail is reported. Without the trailing summary
+  // the last events of a burst are simply never mentioned.
+  clock = 1000;
+  armed();
+  check('the tail of the burst is reported once', summaries.length === 1 && summaries[0] === 2000,
+    JSON.stringify(summaries));
+
+  check('the next event leads a new window', gate.offer() === true);
+  check('a window with nothing suppressed reports nothing', (() => {
+    clock = 2000;
+    armed();
+    return summaries.length === 1;
+  })(), JSON.stringify(summaries));
+
+  // Two thousand traps a second, for ten seconds: at most one report per
+  // window, which is what makes the toast list bounded no matter the rate.
+  clock = 3000;
+  const g2 = createBurstGate({
+    windowMs: 1000, onSummary: () => {}, now: () => clock,
+    schedule: () => 1, cancel: () => {},
+  });
+  let through = 0;
+  for (let sec = 0; sec < 10; sec++) {
+    clock = 3000 + sec * 1000;
+    for (let i = 0; i < 2000; i++) if (g2.offer()) through++;
+  }
+  check('20 000 traps over ten windows produce at most ten reports', through === 10, String(through));
+}
+
+/* --- the cap --------------------------------------------------------------- */
+{
+  const list = Array.from({ length: 10 }, (_, i) => i);
+  check('a short list is returned unchanged', capNewestFirst(list, 20) === list);
+  check('a long one keeps the newest', JSON.stringify(capNewestFirst(list, 3)) === '[0,1,2]',
+    JSON.stringify(capNewestFirst(list, 3)));
+  check('exactly at the limit is not a copy', capNewestFirst(list, 10) === list);
+}
+
+/* --- and what the codebase must do with it --------------------------------
+ * Every list fed by a Wails event a trap can raise needs a ceiling. Checked
+ * per FILE, which is coarse — but the failure it catches is a file that
+ * subscribes and never caps, which is what all four of them did. */
+{
+  const files = sources(root);
+  const LIVE = /EventsOn\(\s*['"](newTrap|event:new)['"]/;
+  const CAPPED = /capNewestFirst|MAX_LIVE_ITEMS|MAX_INCIDENTS|maxCount|MAX_TRAPS/;
+
+  const uncapped = [];
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8');
+    if (!LIVE.test(src)) continue;
+    if (!CAPPED.test(src)) uncapped.push(basename(file));
+  }
+  check('every list fed by a live trap event has a ceiling', uncapped.length === 0, uncapped.join(', '));
+
+  // The toast list is the one that had no ceiling at all, and it is not fed by
+  // an EventsOn of its own — it is fed by everything else.
+  const toasts = readFileSync(join(root, 'stores', 'notifications.js'), 'utf8');
+  check('the toast list has a ceiling', /MAX_TOASTS/.test(toasts));
+
+  // The OID lookup on the trap path is behind the gate. It is the expensive
+  // one: GetOidDetails takes pkg/mib's exclusive gosmi mutex.
+  const trapStore = readFileSync(join(root, 'stores', 'trapStore.js'), 'utf8');
+  // lastIndexOf, not indexOf: GetOidDetails also appears in the import at the
+  // top of the file, and comparing against that position made this check pass
+  // on nothing.
+  const gateAt = trapStore.indexOf('nativeTrapGate.offer()');
+  const lookupAt = trapStore.lastIndexOf('GetOidDetails(');
+  check('the per-trap OID lookup is behind a gate',
+    gateAt > 0 && lookupAt > 0 && gateAt < lookupAt, `gate@${gateAt} lookup@${lookupAt}`);
+
+  /* --- prove the checks can fail ----------------------------------------- */
+  const wouldFail = `EventsOn('event:new', (ev) => { items = [ev, ...items]; });`;
+  check('the detector: an uncapped live list is visible',
+    LIVE.test(wouldFail) && !CAPPED.test(wouldFail));
+  check('the detector: a capped one is not',
+    CAPPED.test(`EventsOn('newTrap', (t) => { list = capNewestFirst([t, ...list], 100); });`));
+}
+
+process.exit(failures ? 1 : 0);

--- a/pkg/mib/diagnose.go
+++ b/pkg/mib/diagnose.go
@@ -318,10 +318,45 @@ func describeNonMib(raw []byte) (summary, hint string, bad bool) {
 		return "the file is not valid UTF-8", "save it as UTF-8; a stray byte in a DESCRIPTION is enough to stop the parser", true
 	}
 	if !strings.Contains(strings.ToUpper(string(head)), "DEFINITIONS") {
-		return "no DEFINITIONS clause was found near the start of the file",
+		return noDefinitionsSummary,
 			"a MIB begins with `MODULE-NAME DEFINITIONS ::= BEGIN`; this file may be a fragment or a different format", true
 	}
 	return "", "", false
+}
+
+// noDefinitionsSummary is named because ImportRejection has to tell that answer
+// apart from the others: it is the only one describeNonMib reaches by looking
+// at a WINDOW rather than at the bytes themselves.
+const noDefinitionsSummary = "no DEFINITIONS clause was found near the start of the file"
+
+// ImportRejection says why a file must not be copied into the MIB directory,
+// or reports that it may be.
+//
+// This is a security boundary as much as a usability one. ImportMibFiles reads
+// any absolute path the renderer names and copies it in; MibEditorRead then
+// hands the content back. Those two calls together are an arbitrary-file-read
+// primitive over the bridge, and the only thing standing between them is what
+// is allowed to land in the directory. A private key, a password file, a
+// browser profile: none of them are a MIB, and none of them get in.
+//
+// It does NOT try to decide whether a MIB is VALID — a MIB with a syntax error
+// is exactly what the diagnosis feature exists for, and refusing those would
+// remove the reason someone imports a broken file in the first place.
+//
+// The DEFINITIONS check is re-run over the WHOLE file rather than
+// describeNonMib's first 4 KiB. That window is right for a diagnosis and too
+// strict for a gate: vendor MIBs routinely carry a licence header longer than
+// that, and refusing a real MIB is a worse failure here than accepting a text
+// file that happens to contain the word.
+func ImportRejection(raw []byte) (summary, hint string, reject bool) {
+	s, h, bad := describeNonMib(raw)
+	if !bad {
+		return "", "", false
+	}
+	if s == noDefinitionsSummary && strings.Contains(strings.ToUpper(string(raw)), "DEFINITIONS") {
+		return "", "", false
+	}
+	return s, h, true
 }
 
 // missingImports reports the modules an IMPORTS clause names that are not

--- a/pkg/notify/scrub_test.go
+++ b/pkg/notify/scrub_test.go
@@ -205,3 +205,61 @@ func TestEmailScrubsWhateverTheServerEchoes(t *testing.T) {
 		t.Errorf("nothing marked: %s", got)
 	}
 }
+
+// validate parses the SUBSTITUTED URL, so url.Parse's error quotes it — token
+// and all. That text goes into notify_outbox.last_error and into the
+// dead-letter event, which is routed to every OTHER destination: a credential
+// written to the database in the clear and forwarded off the machine, from a
+// URL with one stray character in it.
+//
+// Four returns above the transport were unscrubbed. This drives Send, so it
+// covers every path rather than the one the test author thought of.
+func TestTheWebhookCredentialNeverReachesAnErrorMessage(t *testing.T) {
+	const token = "xoxb-9f3a-SUPER-SECRET-TOKEN"
+
+	cases := []struct {
+		name string
+		cfg  WebhookConfig
+	}{
+		{
+			// A control character INSIDE the URL makes url.Parse fail and quote
+			// the whole thing, token and all. Inside, not at the end:
+			// resolvedURL trims the ends, so a trailing newline never reaches
+			// the parser — which is how the first version of this test managed
+			// to pass without the fix. Pasting a URL that a mail client wrapped
+			// is the ordinary way to arrive here.
+			"a URL that will not parse",
+			WebhookConfig{URL: "https://hooks.example.com/services/\n{{secret}}/post", Token: token},
+		},
+		{
+			"a scheme that is not http",
+			WebhookConfig{URL: "gopher://hooks.example.com/{{secret}}", Token: token},
+		},
+		{
+			"a URL with no host",
+			WebhookConfig{URL: "https:///{{secret}}", Token: token},
+		},
+		{
+			"plaintext http with a credential",
+			WebhookConfig{URL: "http://hooks.example.com/{{secret}}", Token: token},
+		},
+		{
+			"a host that does not resolve",
+			WebhookConfig{URL: "https://no-such-host.invalid/{{secret}}", Token: token, Timeout: 1},
+		},
+	}
+
+	for _, c := range cases {
+		err := WebhookSink{Config: c.cfg}.Send(events.Event{
+			ID: "e1", Severity: "minor", Summary: "trap",
+		}, "subject", "body")
+		if err == nil {
+			t.Errorf("%s: no error at all; this case proves nothing", c.name)
+			continue
+		}
+		if strings.Contains(err.Error(), token) {
+			t.Errorf("%s: the credential is in the error that reaches "+
+				"notify_outbox.last_error and every other sink:\n%v", c.name, err)
+		}
+	}
+}

--- a/pkg/notify/sink.go
+++ b/pkg/notify/sink.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"encoding/base64"
 	"os"
+	"strconv"
 	"strings"
 
 	"SnmpLens/pkg/events"
@@ -57,6 +58,66 @@ type SinkConfig struct {
 }
 
 var osHostname = os.Hostname
+
+// Destination names WHERE a sink sends, and is the identity a stored
+// credential is bound to.
+//
+// A sink's credential is write-only from the renderer by deliberate design:
+// ListSinks blanks Secret, and the settings form shows "configured" from
+// HasSecret without ever receiving the value. That control has one hole, and
+// it is the pair of methods that RESOLVE a credential by sink id while taking
+// the destination from whatever the caller sent — name an existing sink's id,
+// point the URL at your own server, receive the bearer token or the SMTP
+// password. The comment on NotifyTestSink used to accept this on the grounds
+// that a caller who can drive the renderer "could simply read the sink list
+// instead", which the adjacent ListSinks line disproves.
+//
+// So the rule is: a stored credential may be used only with the destination it
+// was stored against. What counts as the destination is per kind, and includes
+// the parts that decide whether the credential travels protected:
+//
+//   - webhook: the URL, EXACTLY as configured and NOT substituted. A URL may
+//     legitimately contain {{secret}} — Slack, Teams and Discord authenticate
+//     by the URL alone, so for those receivers the address IS the credential.
+//     Fingerprinting the substituted form would make every save look like a
+//     rebinding. The scheme is part of the string, so https to http is one.
+//   - email: host, port and encryption. The password goes to the SMTP server,
+//     so downgrading starttls to none on the same host puts it on the wire in
+//     the clear and is a rebinding for this purpose. AuthMethod is not here:
+//     "none" sends no password at all.
+//   - syslog: protocol and address. The credential is the mutual-TLS client
+//     KEY, which signs and is never transmitted, so this one cannot be
+//     exfiltrated by redirection — it is bound anyway, because a uniform rule
+//     is the one that still holds when a fourth kind is added.
+//
+// ok is false for a kind Build would refuse. The caller must treat that as
+// "cannot bind" rather than comparing two empty strings and finding them
+// equal.
+func Destination(cfg SinkConfig) (string, bool) {
+	norm := func(v string) string { return strings.ToLower(strings.TrimSpace(v)) }
+	switch cfg.Kind {
+	case SinkSyslog:
+		return SinkSyslog + "|" + norm(cfg.Syslog.Protocol) + "|" + norm(cfg.Syslog.Address), true
+	case SinkWebhook:
+		return SinkWebhook + "|" + strings.TrimSpace(cfg.Webhook.URL), true
+	case SinkEmail:
+		return SinkEmail + "|" + norm(cfg.Email.Host) + "|" +
+			strconv.Itoa(cfg.Email.Port) + "|" + norm(cfg.Email.Encryption), true
+	default:
+		return "", false
+	}
+}
+
+// SameDestination reports whether two configs send to the same place. A kind
+// nothing can build is never the same as anything, including itself.
+func SameDestination(a, b SinkConfig) bool {
+	da, ok := Destination(a)
+	if !ok {
+		return false
+	}
+	db, ok := Destination(b)
+	return ok && da == db
+}
 
 // Build turns a stored config into a live sink. secret is the sink's credential
 // (SMTP password, bearer token), supplied by the caller from secure storage.

--- a/pkg/notify/webhook.go
+++ b/pkg/notify/webhook.go
@@ -228,7 +228,22 @@ func (w WebhookSink) client(timeout time.Duration) (*http.Client, error) {
 }
 
 // Send posts one event.
-func (w WebhookSink) Send(e events.Event, subject, body string) error {
+func (w WebhookSink) Send(e events.Event, subject, body string) (err error) {
+	// Scrubbed on EVERY path, not on the ones somebody remembered.
+	//
+	// Four returns above the transport were unscrubbed, and the first of them
+	// is the one that matters: validate parses the SUBSTITUTED URL, so
+	// url.Parse's error quotes it — token and all — and that text goes into
+	// notify_outbox.last_error and into the dead-letter event, which is then
+	// routed to every OTHER destination. A credential written to the database
+	// in the clear and forwarded off the machine, from a URL with a stray
+	// character in it.
+	//
+	// The same shape as email.go's deferred scrub, and for the same reason: a
+	// rule each return statement has to remember is a rule that will be
+	// forgotten by the next one added.
+	defer func() { err = w.scrub(err) }()
+
 	if _, err := w.validate(); err != nil {
 		return err
 	}

--- a/pkg/secrets/execpath_test.go
+++ b/pkg/secrets/execpath_test.go
@@ -1,0 +1,52 @@
+package secrets
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The one exec site in this application that puts a credential on a command
+// line must not be resolved through $PATH.
+//
+// `exec.Command("security", …)` searches $PATH, and this call hands the
+// data-encryption key to whatever answers to the name. Reaching a GUI
+// application's PATH on macOS is not trivial, which is why this is cheap to
+// close rather than urgent to close.
+//
+// Checked over the SOURCE rather than by calling it, so it runs on all three
+// platforms CI builds. A darwin-only assertion would be verified on one runner
+// and the file is edited from any of them.
+func TestTheKeychainToolIsNotResolvedThroughPath(t *testing.T) {
+	src, err := os.ReadFile("protect_darwin.go")
+	if err != nil {
+		t.Fatalf("the macOS protector is gone or renamed; this check is out of date: %v", err)
+	}
+
+	// Any exec.Command whose first argument is a bare name — no slash — is the
+	// defect. The pattern deliberately does not name `security`: a second tool
+	// invoked the same way would have the same problem.
+	bare := regexp.MustCompile(`exec\.Command\(\s*"([^"/\\]+)"`)
+	if m := bare.FindAllStringSubmatch(string(src), -1); len(m) > 0 {
+		var names []string
+		for _, hit := range m {
+			names = append(names, hit[1])
+		}
+		t.Errorf("resolved through $PATH: %s", strings.Join(names, ", "))
+	}
+
+	// And the constant it does use is absolute.
+	if !strings.Contains(string(src), `securityTool = "/usr/bin/security"`) {
+		t.Error("securityTool is no longer the absolute path to the bundled tool")
+	}
+
+	// The detector: the pattern above must actually match the shape it is
+	// looking for, or this test passes on a file it never understood.
+	if !bare.MatchString(`exec.Command("security", "find-generic-password")`) {
+		t.Fatal("the detector does not match a bare-name exec; it proves nothing")
+	}
+	if bare.MatchString(`exec.Command("/usr/bin/security", "x")`) {
+		t.Fatal("the detector flags an absolute path; it would fail on the fix")
+	}
+}

--- a/pkg/secrets/protect_darwin.go
+++ b/pkg/secrets/protect_darwin.go
@@ -16,6 +16,20 @@ import (
 // darwin/universal.
 type keychainProtector struct{ service, account string }
 
+// securityTool is the ABSOLUTE path, deliberately.
+//
+// exec.Command with a bare name searches $PATH, and this is the one exec site
+// in the application that puts a credential on a command line: whatever ran
+// instead would be handed the data-encryption key as argv. `security` has
+// shipped at this path since Mac OS X 10.0, and a machine where it is missing
+// is one where the Keychain backend should fail rather than fall back to
+// whatever else answers to the name.
+//
+// The exec sites in pkg/network resolve `traceroute` and friends through PATH
+// too, and are a weaker version of the same thing: they pass a hostname, not a
+// secret. This one is fixed because the consequence is different in kind.
+const securityTool = "/usr/bin/security"
+
 func newProtector(dir string) keyProtector {
 	_ = dir
 	return &keychainProtector{service: "SnmpLens", account: "sink-secrets"}
@@ -30,7 +44,7 @@ func (p *keychainProtector) name() string { return "macos-keychain" }
 const keychainItemNotFound = 44
 
 func (p *keychainProtector) loadKey() ([]byte, error) {
-	out, err := exec.Command("security", "find-generic-password",
+	out, err := exec.Command(securityTool, "find-generic-password",
 		"-s", p.service, "-a", p.account, "-w").Output()
 	if err != nil {
 		var exit *exec.ExitError
@@ -47,7 +61,7 @@ func (p *keychainProtector) saveKey(key []byte) error {
 	// -U updates an existing item instead of failing. The secret is passed with
 	// -w on stdin-free form; `security` is exec'd directly, never through a
 	// shell, so it never reaches a shell history.
-	cmd := exec.Command("security", "add-generic-password",
+	cmd := exec.Command(securityTool, "add-generic-password",
 		"-s", p.service, "-a", p.account, "-w", encoded, "-U")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("keychain store: %w (%s)", err, strings.TrimSpace(string(out)))

--- a/pkg/snmp/client.go
+++ b/pkg/snmp/client.go
@@ -384,8 +384,23 @@ const redacted = "[redacted]"
 // formats "Community:%s" on every SENDING PACKET (marshal.go:159), and
 // unmarshalling logs "Parsed community %s" (marshal.go:1010).
 var (
-	communityField  = regexp.MustCompile(`Community:[^,]*`)
-	parsedCommunity = regexp.MustCompile(`Parsed community \S*`)
+	// gosnmp's SafeString prints "…, Community:%s, PDUType:%s, …", so the
+	// community is bounded by the NEXT FIELD NAME, not by the next comma. It
+	// used to be matched as `Community:[^,]*`, which is right until a community
+	// contains a comma — and then everything after it survived into the buffer
+	// the debug panel shows. A community is an arbitrary octet string; nothing
+	// stops an operator, or a trap sender, from putting a comma in one.
+	//
+	// Anchored first, loose second: the anchored pattern is exact for the shape
+	// gosnmp actually logs, and the loose one still covers any other line that
+	// names the field.
+	communityInPacket = regexp.MustCompile(`Community:.*?, PDUType:`)
+	communityField    = regexp.MustCompile(`Community:[^,
+]*`)
+	// "Parsed community %s" ends the line, so everything to the end of it is
+	// the value. `\S*` stopped at the first space and leaked the rest of a
+	// community containing one.
+	parsedCommunity = regexp.MustCompile(`Parsed community .*`)
 	// A raw packet, rendered by fmt as decimal bytes. gosnmp prints whole
 	// datagrams this way — "GET RESPONSE OK: %+v" on a []byte (marshal.go:313),
 	// and the same shape at "Last 4 Bytes" and "Enterprise" — and in SNMPv1 and
@@ -410,6 +425,7 @@ var (
 // shape the patterns do not know, which is the failure mode a gosnmp upgrade
 // would introduce silently.
 func scrubSecrets(msg string, secrets []string) string {
+	msg = communityInPacket.ReplaceAllString(msg, "Community:"+redacted+", PDUType:")
 	msg = communityField.ReplaceAllString(msg, "Community:"+redacted)
 	msg = parsedCommunity.ReplaceAllString(msg, "Parsed community "+redacted)
 	msg = byteDump.ReplaceAllStringFunc(msg, redactBytes)

--- a/pkg/snmp/debuglog_test.go
+++ b/pkg/snmp/debuglog_test.go
@@ -240,3 +240,55 @@ func TestTrapListenerLoggingIsScrubbedAndGated(t *testing.T) {
 		t.Errorf("a trap sender's community was buffered: %s", entries[0].Message)
 	}
 }
+
+// A community is an arbitrary octet string, and the redaction used to assume
+// it contained neither a comma nor a space.
+//
+// `Community:[^,]*` is right until a community has a comma in it, and gosnmp's
+// SafeString prints "…, Community:%s, PDUType:%s, …" on every sending packet —
+// so the tail survived into the ring buffer the debug panel shows. "Parsed
+// community \S*" had the same shape of bug with a space, on every received
+// packet, where the community belongs to whoever sent the trap.
+func TestTheCommunityIsRedactedWhateverIsInIt(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		mustNotBe []string
+	}{
+		{
+			"a comma in a sending packet",
+			"SENDING PACKET: Version:2c, MsgFlags:NoAuthNoPriv, Community:pub,lic,secret, PDUType:GetRequest, MsgID:1",
+			[]string{"lic", "secret"},
+		},
+		{
+			"a space in a parsed community",
+			"Parsed community hunter two three",
+			[]string{"two", "three"},
+		},
+		{
+			"the ordinary case still works",
+			"SENDING PACKET: Version:2c, Community:public, PDUType:GetRequest, MsgID:1",
+			[]string{"public"},
+		},
+	}
+
+	for _, c := range cases {
+		got := scrubSecrets(c.line, nil)
+		for _, leak := range c.mustNotBe {
+			if strings.Contains(got, leak) {
+				t.Errorf("%s: %q survived redaction:\n%s", c.name, leak, got)
+			}
+		}
+		// The line has to stay readable, or the debug panel loses its point.
+		if !strings.Contains(got, redacted) {
+			t.Errorf("%s: nothing was redacted at all: %s", c.name, got)
+		}
+	}
+
+	// The fields AFTER the community must survive: redacting to the end of the
+	// line would be safe and would also throw away what the log is read for.
+	got := scrubSecrets("Version:2c, Community:pub,lic, PDUType:GetRequest, MsgID:77", nil)
+	if !strings.Contains(got, "PDUType:GetRequest") || !strings.Contains(got, "MsgID:77") {
+		t.Errorf("redaction ate the rest of the packet: %s", got)
+	}
+}

--- a/pkg/snmp/informack_test.go
+++ b/pkg/snmp/informack_test.go
@@ -1,0 +1,134 @@
+package snmp
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/events"
+)
+
+// An INFORM must not be acknowledged unless it was durably journalled.
+//
+// The synchronous insert on the receive loop exists for exactly this reason:
+// gosnmp sends the acknowledgement after OnNewTrap returns, so acknowledging
+// before the write would be a lie. When the write FAILED, the acknowledgement
+// went out anyway — the same lie told at the one moment it matters, and the
+// sender then has no reason to retry.
+//
+// Driven end to end, sender to listener over a real socket, because the
+// property only exists at that layer: the suppression works by changing the
+// PDU type gosnmp reads after the handler returns, and only a real sender can
+// say whether an acknowledgement arrived.
+func TestAnInformIsNotAcknowledgedWhenTheJournalWriteFails(t *testing.T) {
+	c := NewClient(nil)
+	c.SetRecorder(events.RecorderFunc(func(events.Event, string) error {
+		return errors.New("database is locked")
+	}))
+
+	port := freePort(t)
+	if err := c.StartTrapListener(port, V3Params{}); err != nil {
+		t.Skipf("cannot bind a trap listener: %v", err)
+	}
+	defer c.StopTrapListener()
+	waitBound(t, c)
+
+	sender := NewClient(nil)
+	res := sender.SendInform("127.0.0.1", port, "public", "v2c", "1.3.6.1.6.3.1.1.5.3", nil)
+
+	if res.Acknowledged {
+		t.Fatal("the INFORM was acknowledged although it was never journalled; " +
+			"the sender has been told a confirmed notification was delivered and " +
+			"will not retry")
+	}
+}
+
+// The control, and the thing that makes the test above mean something: with
+// the journal working, the INFORM IS acknowledged. A change that broke
+// acknowledgement altogether would pass the test above.
+func TestAnInformIsAcknowledgedWhenTheJournalWriteSucceeds(t *testing.T) {
+	c := NewClient(nil)
+	c.SetRecorder(events.Nop{})
+
+	port := freePort(t)
+	if err := c.StartTrapListener(port, V3Params{}); err != nil {
+		t.Skipf("cannot bind a trap listener: %v", err)
+	}
+	defer c.StopTrapListener()
+	waitBound(t, c)
+
+	sender := NewClient(nil)
+	res := sender.SendInform("127.0.0.1", port, "public", "v2c", "1.3.6.1.6.3.1.1.5.3", nil)
+
+	if !res.Acknowledged {
+		t.Fatalf("a journalled INFORM was not acknowledged: %+v", res)
+	}
+}
+
+// This is the gosnmp behaviour the suppression depends on: the packet is
+// passed to the handler rather than copied, and the PDU type is read back
+// after the handler returns. gosnmp documents the assumption that a handler
+// will NOT alter it, so an upgrade may legitimately start passing a copy —
+// which would make the suppression a silent no-op and quietly restore the lie.
+//
+// Pinned here for the same reason trapbuf.go's reach into the socket is: the
+// upgrade should fail CI rather than change behaviour nobody is watching.
+func TestGosnmpStillLetsTheHandlerDeclineAnAcknowledgement(t *testing.T) {
+	c := NewClient(nil)
+	// A recorder that fails is what triggers the decline; if gosnmp started
+	// passing a copy, this listener would acknowledge anyway.
+	c.SetRecorder(events.RecorderFunc(func(events.Event, string) error {
+		return errors.New("journal unavailable")
+	}))
+
+	port := freePort(t)
+	if err := c.StartTrapListener(port, V3Params{}); err != nil {
+		t.Skipf("cannot bind a trap listener: %v", err)
+	}
+	defer c.StopTrapListener()
+	waitBound(t, c)
+
+	sender := NewClient(nil)
+	start := time.Now()
+	res := sender.SendInform("127.0.0.1", port, "public", "v2c", "1.3.6.1.6.3.1.1.5.3", nil)
+	elapsed := time.Since(start)
+
+	if res.Acknowledged {
+		t.Fatalf("gosnmp no longer honours a handler changing PDUType (answered in %v). "+
+			"An INFORM that could not be journalled is being acknowledged again; the "+
+			"suppression in declineToAcknowledge needs another mechanism.", elapsed)
+	}
+}
+
+// waitBound waits for the listener's socket, rather than sleeping. A send into
+// a port nothing is listening on would time out and look exactly like the
+// suppression working.
+//
+// Note what the listeners above are built with: NewClient(nil). handleTrap
+// emits the trap to the webview when it has a context, and the Wails runtime
+// answers a context it did not issue by ENDING THE PROCESS — which under test
+// looks like an unacknowledged INFORM, i.e. exactly the result being asserted.
+// The nil context takes the guarded emit branch instead.
+func waitBound(t *testing.T, c *Client) {
+	t.Helper()
+	// trapBound, not TrapListenerRunning(): the latter reports trapListener !=
+	// nil, which StartTrapListener sets on the CALLER's goroutine before the
+	// socket exists. Polling it returned immediately, the INFORM went into a
+	// port nothing was listening on yet, and the send timed out — which is the
+	// exact result the first test asserts. It passed without the fix, twice.
+	//
+	// trapBound is closed by the listener goroutine once gosnmp reports the
+	// socket up, and it is closed rather than sent to, so more than one waiter
+	// is safe.
+	c.trapMu.Lock()
+	bound := c.trapBound
+	c.trapMu.Unlock()
+	if bound == nil {
+		t.Fatal("the listener has no bound channel; StartTrapListener changed shape")
+	}
+	select {
+	case <-bound:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the trap listener never bound")
+	}
+}

--- a/pkg/snmp/informack_test.go
+++ b/pkg/snmp/informack_test.go
@@ -21,7 +21,7 @@ import (
 // PDU type gosnmp reads after the handler returns, and only a real sender can
 // say whether an acknowledgement arrived.
 func TestAnInformIsNotAcknowledgedWhenTheJournalWriteFails(t *testing.T) {
-	c := NewClient(nil)
+	c := newHeadlessClient()
 	c.SetRecorder(events.RecorderFunc(func(events.Event, string) error {
 		return errors.New("database is locked")
 	}))
@@ -33,7 +33,7 @@ func TestAnInformIsNotAcknowledgedWhenTheJournalWriteFails(t *testing.T) {
 	defer c.StopTrapListener()
 	waitBound(t, c)
 
-	sender := NewClient(nil)
+	sender := newHeadlessClient()
 	res := sender.SendInform("127.0.0.1", port, "public", "v2c", "1.3.6.1.6.3.1.1.5.3", nil)
 
 	if res.Acknowledged {
@@ -47,7 +47,7 @@ func TestAnInformIsNotAcknowledgedWhenTheJournalWriteFails(t *testing.T) {
 // the journal working, the INFORM IS acknowledged. A change that broke
 // acknowledgement altogether would pass the test above.
 func TestAnInformIsAcknowledgedWhenTheJournalWriteSucceeds(t *testing.T) {
-	c := NewClient(nil)
+	c := newHeadlessClient()
 	c.SetRecorder(events.Nop{})
 
 	port := freePort(t)
@@ -57,7 +57,7 @@ func TestAnInformIsAcknowledgedWhenTheJournalWriteSucceeds(t *testing.T) {
 	defer c.StopTrapListener()
 	waitBound(t, c)
 
-	sender := NewClient(nil)
+	sender := newHeadlessClient()
 	res := sender.SendInform("127.0.0.1", port, "public", "v2c", "1.3.6.1.6.3.1.1.5.3", nil)
 
 	if !res.Acknowledged {
@@ -74,7 +74,7 @@ func TestAnInformIsAcknowledgedWhenTheJournalWriteSucceeds(t *testing.T) {
 // Pinned here for the same reason trapbuf.go's reach into the socket is: the
 // upgrade should fail CI rather than change behaviour nobody is watching.
 func TestGosnmpStillLetsTheHandlerDeclineAnAcknowledgement(t *testing.T) {
-	c := NewClient(nil)
+	c := newHeadlessClient()
 	// A recorder that fails is what triggers the decline; if gosnmp started
 	// passing a copy, this listener would acknowledge anyway.
 	c.SetRecorder(events.RecorderFunc(func(events.Event, string) error {
@@ -88,7 +88,7 @@ func TestGosnmpStillLetsTheHandlerDeclineAnAcknowledgement(t *testing.T) {
 	defer c.StopTrapListener()
 	waitBound(t, c)
 
-	sender := NewClient(nil)
+	sender := newHeadlessClient()
 	start := time.Now()
 	res := sender.SendInform("127.0.0.1", port, "public", "v2c", "1.3.6.1.6.3.1.1.5.3", nil)
 	elapsed := time.Since(start)
@@ -104,11 +104,11 @@ func TestGosnmpStillLetsTheHandlerDeclineAnAcknowledgement(t *testing.T) {
 // a port nothing is listening on would time out and look exactly like the
 // suppression working.
 //
-// Note what the listeners above are built with: NewClient(nil). handleTrap
-// emits the trap to the webview when it has a context, and the Wails runtime
-// answers a context it did not issue by ENDING THE PROCESS — which under test
-// looks like an unacknowledged INFORM, i.e. exactly the result being asserted.
-// The nil context takes the guarded emit branch instead.
+// Note what the listeners above are built with: newHeadlessClient, which is
+// where the reason lives. handleTrap emits the trap to the webview when it has
+// a context, and the Wails runtime answers a context it did not issue by
+// ENDING THE PROCESS — which under test looks like an unacknowledged INFORM,
+// i.e. exactly the result being asserted.
 func waitBound(t *testing.T, c *Client) {
 	t.Helper()
 	// trapBound, not TrapListenerRunning(): the latter reports trapListener !=

--- a/pkg/snmp/trap.go
+++ b/pkg/snmp/trap.go
@@ -248,6 +248,41 @@ func (c *Client) recoverTrapHandler(addr *net.UDPAddr) {
 	}, "")
 }
 
+// declineToAcknowledge stops gosnmp sending an INFORM's acknowledgement.
+//
+// The whole reason the journal insert is SYNCHRONOUS is that gosnmp sends that
+// acknowledgement after this handler returns, so acknowledging a confirmed
+// notification before it is durably journalled would be a lie. When the insert
+// FAILED, the acknowledgement was sent anyway — the same lie, told at the one
+// moment it matters, and the sender then has no reason to retry.
+//
+// gosnmp decides by reading trap.PDUType after OnNewTrap returns, and
+// deliberately passes the packet rather than a copy ("we don't pass a copy
+// because the SnmpPacket type is somewhat large"), asking handlers not to
+// alter it. This alters it, which is acceptable on the same terms as the
+// socket-buffer reach in trapbuf.go and no others: it is FAIL-SOFT — a gosnmp
+// that starts passing a copy makes this a no-op and restores today's
+// behaviour, nothing breaks — and it is PINNED BY A TEST that drives a real
+// sender against a real listener, so an upgrade that changes it fails CI
+// rather than quietly resuming the lie.
+//
+// Measured before it was written: with the field left alone the sender was
+// acknowledged in 1 ms; with it changed the sender timed out after 900 ms and
+// would have retried. Retrying is the point — an INFORM exists so the sender
+// can know, and a duplicate journal entry after a transient failure costs
+// nothing next to a lost alert.
+//
+// A plain trap has no acknowledgement to withhold, so this only applies to an
+// INFORM; there the log line is all there is.
+func (c *Client) declineToAcknowledge(packet *gosnmp.SnmpPacket, source string, cause error) {
+	if packet == nil || packet.PDUType != gosnmp.InformRequest {
+		return
+	}
+	packet.PDUType = gosnmp.SNMPv2Trap
+	log.Printf("Not acknowledging the INFORM from %s: it could not be journalled (%v). "+
+		"The sender will retry.", source, cause)
+}
+
 func (c *Client) handleTrap(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 	defer c.recoverTrapHandler(addr)
 
@@ -291,7 +326,9 @@ func (c *Client) handleTrap(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
 	// the window closed — or simply before the frontend has subscribed — every
 	// received trap used to disappear with no error and no trace. Persisting
 	// first is what makes background trap collection possible at all.
-	c.recordTrap(source, ts, pduType, packet, vars)
+	if err := c.recordTrap(source, ts, pduType, packet, vars); err != nil {
+		c.declineToAcknowledge(packet, source, err)
+	}
 
 	// Guarded, the same way recordEvent guards its own emit: the runtime refuses
 	// a context it did not issue and takes the process with it. A client built
@@ -328,7 +365,10 @@ func trapOIDFrom(vars []Result) string {
 
 // recordTrap writes a received trap to the event journal. The full varbind list
 // goes to the payload side so listing the journal never reads it.
-func (c *Client) recordTrap(source, ts, pduType string, packet *gosnmp.SnmpPacket, vars []Result) {
+//
+// It REPORTS failure, because the caller has something to do about it: an
+// INFORM that was not journalled must not be acknowledged.
+func (c *Client) recordTrap(source, ts, pduType string, packet *gosnmp.SnmpPacket, vars []Result) error {
 	kind := events.KindTrapReceived
 	if pduType == "Inform" {
 		kind = events.KindTrapInform
@@ -368,7 +408,9 @@ func (c *Client) recordTrap(source, ts, pduType string, packet *gosnmp.SnmpPacke
 
 	if err := c.recorder.Record(ev, string(payload)); err != nil {
 		log.Printf("Failed to journal trap from %s: %v", source, err)
+		return err
 	}
+	return nil
 }
 
 // InformResult reports what came back from an INFORM.

--- a/pkg/snmp/trap.go
+++ b/pkg/snmp/trap.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"time"
@@ -197,7 +198,59 @@ func (c *Client) TrapListenerRunning() bool {
 	return c.trapListener != nil
 }
 
+// recoverTrapHandler contains a panic raised while handling one datagram.
+//
+// This is the only place in pkg/snmp where a panic can be reached by an
+// unauthenticated remote party, and it was the only background goroutine in
+// the application without a guard. gosnmp recovers inside its DECODER
+// (marshal.go and v3.go) and nowhere around OnNewTrap, and its receive loop is
+// one goroutine, so a panic anywhere below this line unwinds through
+// listenUDP and ends the process.
+//
+// Measured, with a handler that dereferences a nil PDU on the first trap:
+// unguarded the process died with "exit status 2" and never saw the second
+// trap; guarded it recovered and handled it. The cost of that crash is not one
+// datagram — it is every monitoring session, every threshold, the notification
+// dispatcher and the outbox drain, from a UDP packet nobody authenticated.
+//
+// Losing the trap is the right outcome here, and the reason it is acceptable
+// is that the panic happened before anything durable was written. What is NOT
+// acceptable is losing it silently, so the event says which source produced
+// it. DedupKey is per source: a device sending the same malformed varbind ten
+// thousand times must not become ten thousand major events.
+//
+// The journal write gets a guard of its own. A recover that panics is a
+// process kill with extra steps, and this one runs when the process is already
+// in a state nobody predicted.
+func (c *Client) recoverTrapHandler(addr *net.UDPAddr) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	source := "unknown"
+	if addr != nil && addr.IP != nil {
+		source = addr.IP.String()
+	}
+	log.Printf("PANIC while handling a trap from %s: %v\n%s", source, r, debug.Stack())
+
+	defer func() { _ = recover() }()
+	_ = c.recorder.Record(events.Event{
+		Ts:       time.Now().UTC().Format(time.RFC3339),
+		Category: events.CategorySystem,
+		Kind:     events.KindSystemListenerError,
+		Severity: events.SevMajor.String(),
+		State:    events.StateOneshot,
+		Source:   source,
+		DedupKey: "trap.panic|" + source,
+		TitleKey: "events.kind." + events.KindSystemListenerError,
+		Summary:  fmt.Sprintf("Dropped a trap from %s: the handler panicked (%v)", source, r),
+		Params:   map[string]any{"source": source},
+	}, "")
+}
+
 func (c *Client) handleTrap(packet *gosnmp.SnmpPacket, addr *net.UDPAddr) {
+	defer c.recoverTrapHandler(addr)
+
 	log.Printf("Received trap from %s (Version: %s)", addr.IP.String(), packet.Version)
 
 	vars := make([]Result, 0)

--- a/pkg/snmp/traprecover_test.go
+++ b/pkg/snmp/traprecover_test.go
@@ -1,0 +1,96 @@
+package snmp
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/events"
+)
+
+// A panic while handling one datagram must cost that datagram and nothing
+// else. gosnmp's receive loop is a single goroutine with a recover in its
+// DECODER and none around OnNewTrap, so an unguarded panic here unwinds
+// through listenUDP and ends the process — taking every monitoring session,
+// every threshold and the outbox drain with it, from a UDP packet nobody
+// authenticated.
+//
+// Measured with a probe before the guard existed: unguarded, the process died
+// with "exit status 2" and never received the second trap; guarded, it
+// recovered and handled it.
+func TestATrapHandlerPanicDoesNotEscape(t *testing.T) {
+	var got events.Event
+	c := NewClient(nil)
+	c.SetRecorder(events.RecorderFunc(func(e events.Event, _ string) error {
+		got = e
+		return nil
+	}))
+
+	addr := &net.UDPAddr{IP: net.ParseIP("10.0.0.99"), Port: 4242}
+	// A nil packet is the cheapest way to reach a nil dereference inside the
+	// handler. What matters is the SHAPE: any panic below this line, from a
+	// malformed varbind to a storage bug, arrives the same way.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("the panic escaped handleTrap: %v", r)
+			}
+		}()
+		c.handleTrap(nil, addr)
+	}()
+
+	// And it must not be silent: a dropped trap with nothing in the journal is
+	// indistinguishable from a trap that never arrived.
+	if got.Kind != events.KindSystemListenerError {
+		t.Fatalf("no system event was journalled: %+v", got)
+	}
+	if got.Source != "10.0.0.99" {
+		t.Errorf("the event does not name the source: %q", got.Source)
+	}
+	if got.Severity != events.SevMajor.String() {
+		t.Errorf("severity = %q, want major", got.Severity)
+	}
+	// Per source, so one device sending the same malformed varbind ten
+	// thousand times is one alert rather than ten thousand.
+	if got.DedupKey != "trap.panic|10.0.0.99" {
+		t.Errorf("DedupKey = %q", got.DedupKey)
+	}
+	if !strings.Contains(got.Summary, "10.0.0.99") {
+		t.Errorf("summary does not say which device: %q", got.Summary)
+	}
+}
+
+// The recovery path runs when the process is already in a state nobody
+// predicted, so it must not itself panic on a missing address or a recorder
+// that fails.
+func TestTheRecoveryPathSurvivesANilAddressAndAFailingRecorder(t *testing.T) {
+	c := NewClient(nil)
+	c.SetRecorder(events.RecorderFunc(func(events.Event, string) error {
+		panic("the journal is the thing that broke")
+	}))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("a panic escaped the recovery path: %v", r)
+		}
+	}()
+	c.handleTrap(nil, nil)
+}
+
+// The detector: without the guard this file would be describing nothing, so
+// pin that the panic it relies on is really there.
+func TestTheHandlerReallyPanicsOnThatInput(t *testing.T) {
+	var panicked bool
+	func() {
+		defer func() { panicked = recover() != nil }()
+		var p *packetProbe
+		_ = p.version()
+	}()
+	if !panicked {
+		t.Fatal("the probe no longer panics; the test above proves nothing")
+	}
+}
+
+type packetProbe struct{ v int }
+
+func (p *packetProbe) version() int { return p.v }

--- a/pkg/snmp/traprecover_test.go
+++ b/pkg/snmp/traprecover_test.go
@@ -1,12 +1,32 @@
 package snmp
 
 import (
+	"context"
 	"net"
 	"strings"
 	"testing"
 
 	"SnmpLens/pkg/events"
 )
+
+// newHeadlessClient builds a Client with NO Wails context.
+//
+// handleTrap emits every received trap to the webview when it has one, and the
+// Wails runtime answers a context it did not issue by ENDING THE PROCESS —
+// which under test looks like a trap that was never handled, or an INFORM that
+// was never acknowledged, i.e. exactly the results these tests assert. The
+// guarded branch in handleTrap is `if c.ctx != nil`, so the field has to be
+// nil, not a background context.
+//
+// Assigned rather than passed, because staticcheck refuses a literal nil
+// Context (SA1012) and it is right to: the reason this one is nil is a
+// property of the code under test, and it belongs in a comment rather than in
+// eight call sites.
+func newHeadlessClient() *Client {
+	c := NewClient(context.TODO())
+	c.ctx = nil
+	return c
+}
 
 // A panic while handling one datagram must cost that datagram and nothing
 // else. gosnmp's receive loop is a single goroutine with a recover in its
@@ -20,7 +40,7 @@ import (
 // recovered and handled it.
 func TestATrapHandlerPanicDoesNotEscape(t *testing.T) {
 	var got events.Event
-	c := NewClient(nil)
+	c := newHeadlessClient()
 	c.SetRecorder(events.RecorderFunc(func(e events.Event, _ string) error {
 		got = e
 		return nil
@@ -64,7 +84,7 @@ func TestATrapHandlerPanicDoesNotEscape(t *testing.T) {
 // predicted, so it must not itself panic on a missing address or a recorder
 // that fails.
 func TestTheRecoveryPathSurvivesANilAddressAndAFailingRecorder(t *testing.T) {
-	c := NewClient(nil)
+	c := newHeadlessClient()
 	c.SetRecorder(events.RecorderFunc(func(events.Event, string) error {
 		panic("the journal is the thing that broke")
 	}))

--- a/pkg/storage/deadcap_test.go
+++ b/pkg/storage/deadcap_test.go
@@ -1,0 +1,185 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/events"
+)
+
+// deadRows counts the given-up deliveries left in the outbox.
+func deadRows(t *testing.T, st *Storage) int {
+	t.Helper()
+	var n int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM notify_outbox WHERE state = 'dead'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// queueDead puts n given-up deliveries in the outbox, oldest first.
+func queueDead(t *testing.T, st *Storage, sinkID string, n int) []int64 {
+	t.Helper()
+	ids := make([]int64, 0, n)
+	for i := 0; i < n; i++ {
+		e := events.Event{
+			ID: fmt.Sprintf("evt-%s-%d", sinkID, i), Category: events.CategoryTrap,
+			Kind: events.KindTrapReceived, Severity: "minor",
+			Ts: time.Now().UTC().Format(time.RFC3339), Summary: "trap",
+		}
+		if err := st.EnqueueDeliveries(e, []string{sinkID}, "s", "b"); err != nil {
+			t.Fatal(err)
+		}
+		due, err := st.DueDeliveries(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(due) == 0 {
+			t.Fatalf("nothing due after queueing %d", i)
+		}
+		ids = append(ids, due[0].ID)
+		if err := st.MarkFailed(due[0].ID, "unreachable", time.Now().Add(time.Hour), true); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ids
+}
+
+// The outbox was the one table in the database with no ceiling at all.
+//
+// Retention deliberately does not cover dead rows — a dead letter is the only
+// record that a notification never arrived — and nothing else bounded them. A
+// trap flood routed to an unreachable collector produces one row per event per
+// sink, each holding the complete event JSON plus the rendered subject and
+// body, and every one of them ends up dead.
+func TestTheDeadLetterListHasACeiling(t *testing.T) {
+	st := newTestStorage(t)
+
+	queueDead(t, st, "sink-a", 12)
+	if got := deadRows(t, st); got != 12 {
+		t.Fatalf("%d dead rows before trimming, want 12", got)
+	}
+
+	removed, err := st.TrimDeadLetters(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != 7 {
+		t.Errorf("removed %d rows, want 7", removed)
+	}
+	if got := deadRows(t, st); got != 5 {
+		t.Errorf("%d dead rows kept, want 5", got)
+	}
+
+	// The NEWEST are the ones kept: an operator reading the delivery log wants
+	// what just failed, not what failed first.
+	rows, err := st.ListDeliveries("dead", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Compared as NUMBERS: "evt-sink-a-10" sorts before "evt-sink-a-7" as a
+	// string, which is how the first version of this assertion managed to fail
+	// on correct behaviour.
+	kept := map[int]bool{}
+	for _, r := range rows {
+		var i int
+		if _, err := fmt.Sscanf(r.EventID, "evt-sink-a-%d", &i); err != nil {
+			t.Fatalf("unexpected event id %q", r.EventID)
+		}
+		kept[i] = true
+	}
+	for i := 7; i < 12; i++ {
+		if !kept[i] {
+			t.Errorf("dead letter %d was discarded although it is among the newest five", i)
+		}
+	}
+	for i := 0; i < 7; i++ {
+		if kept[i] {
+			t.Errorf("dead letter %d survived although seven newer ones exist", i)
+		}
+	}
+
+	// Idempotent: running it again with nothing to do removes nothing.
+	if removed, err := st.TrimDeadLetters(5); err != nil || removed != 0 {
+		t.Errorf("a second trim removed %d rows (err %v)", removed, err)
+	}
+	// And a ceiling above the row count is a no-op, not a truncation.
+	if removed, err := st.TrimDeadLetters(1000); err != nil || removed != 0 {
+		t.Errorf("a ceiling above the count removed %d rows (err %v)", removed, err)
+	}
+}
+
+// A pending delivery is an alert still owed, and a delivered one is covered by
+// its own retention window. Neither may be caught by the dead-letter ceiling.
+func TestTheCeilingTouchesOnlyDeadRows(t *testing.T) {
+	st := newTestStorage(t)
+
+	// One pending, one sent, several dead.
+	e := events.Event{ID: "evt-pending", Category: events.CategoryTrap,
+		Kind: events.KindTrapReceived, Severity: "minor",
+		Ts: time.Now().UTC().Format(time.RFC3339), Summary: "trap"}
+	if err := st.EnqueueDeliveries(e, []string{"sink-b"}, "s", "b"); err != nil {
+		t.Fatal(err)
+	}
+	due, err := st.DueDeliveries(1)
+	if err != nil || len(due) == 0 {
+		t.Fatalf("nothing due: %v", err)
+	}
+	sent := due[0].ID
+	if err := st.MarkSent(sent); err != nil {
+		t.Fatal(err)
+	}
+
+	e2 := e
+	e2.ID = "evt-still-owed"
+	if err := st.EnqueueDeliveries(e2, []string{"sink-b"}, "s", "b"); err != nil {
+		t.Fatal(err)
+	}
+	queueDead(t, st, "sink-c", 6)
+
+	if _, err := st.TrimDeadLetters(2); err != nil {
+		t.Fatal(err)
+	}
+
+	var pending, sentLeft int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM notify_outbox WHERE state='pending'`).Scan(&pending); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM notify_outbox WHERE state='sent'`).Scan(&sentLeft); err != nil {
+		t.Fatal(err)
+	}
+	if pending != 1 {
+		t.Errorf("%d pending rows after the trim, want 1: an alert still owed was discarded", pending)
+	}
+	if sentLeft != 1 {
+		t.Errorf("%d sent rows after the trim, want 1", sentLeft)
+	}
+	if got := deadRows(t, st); got != 2 {
+		t.Errorf("%d dead rows, want 2", got)
+	}
+}
+
+// A failure is a write like any other, and it was the one write path that did
+// not say so — so the trimmer stopped exactly when the outbox was growing
+// fastest. A destination nothing can reach produces failures and no MarkSent
+// at all, so nothing ever ran retention again.
+func TestAFailedDeliveryDrivesTheTrimmer(t *testing.T) {
+	st := newTestStorage(t)
+
+	before := st.outboxWriteCount()
+	queueDead(t, st, "sink-d", 3)
+	after := st.outboxWriteCount()
+
+	if after-before != 3 {
+		t.Errorf("MarkFailed recorded %d outbox writes for 3 failures; the retention "+
+			"cadence never advances while a sink is down", after-before)
+	}
+}
+
+// outboxWriteCount reads the cadence counter under its lock.
+func (s *Storage) outboxWriteCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.outboxWrites
+}

--- a/pkg/storage/notify_store.go
+++ b/pkg/storage/notify_store.go
@@ -290,6 +290,12 @@ func (s *Storage) noteOutboxWrite() {
 		if err := s.TrimOutbox(OutboxRetention); err != nil {
 			log.Printf("storage: trimming the delivery outbox failed: %v", err)
 		}
+		if n, err := s.TrimDeadLetters(MaxDeadLetters); err != nil {
+			log.Printf("storage: capping the dead-letter list failed: %v", err)
+		} else if n > 0 {
+			log.Printf("storage: discarded %d dead letters beyond the newest %d; "+
+				"a destination has been failing long enough to fill the outbox", n, MaxDeadLetters)
+		}
 	}
 }
 
@@ -306,6 +312,11 @@ func (s *Storage) MarkFailed(id int64, errMsg string, nextTry time.Time, dead bo
 		SET attempts = attempts + 1, last_error = ?, next_try_at = ?, state = ?
 		WHERE id = ?`,
 		errMsg, nextTry.UTC().Format(time.RFC3339), state, id)
+	// A failure is a write like any other, and this was the one write path
+	// that did not say so. The trimmer therefore stopped exactly when the
+	// outbox was growing fastest: a sink nothing can reach produces failures
+	// and no MarkSent at all, so nothing ever ran retention again.
+	s.noteOutboxWrite()
 	return err
 }
 
@@ -333,8 +344,58 @@ func (s *Storage) RetryDelivery(id int64) error {
 // lost.
 const OutboxRetention = 14 * 24 * time.Hour
 
+// MaxDeadLetters caps how many given-up deliveries are kept.
+//
+// Retention deliberately does not cover dead rows — a dead letter is the only
+// record that a notification never arrived — and with nothing else bounding
+// them that made the outbox the one table in the database with no ceiling at
+// all. A trap flood routed to an unreachable collector produces one row per
+// event per sink, each holding the complete event JSON plus the rendered
+// subject and body, and every one of them ends up dead. That fills the disk,
+// and a full disk takes the event journal, the monitoring history and the
+// credential store with it.
+//
+// So the trade is explicit: the newest 5 000 are kept and older ones are
+// discarded, with a log line saying so. Five thousand is far more than an
+// operator will ever work through by hand, and the hundred-thousandth dead
+// letter from one broken relay carries no information the first hundred did
+// not. Losing the oldest few is a real loss; losing the database is a larger
+// one.
+//
+// The right answer to the underlying situation is a circuit breaker that stops
+// queueing for a destination that has been failing for hours. This is the
+// ceiling, not that.
+const MaxDeadLetters = 5000
+
+// TrimDeadLetters keeps the newest keep dead rows and reports how many it
+// removed.
+//
+// Ordered by id rather than created_at: id is AUTOINCREMENT, so it is the
+// insertion order exactly, and created_at is a text timestamp several rows can
+// share to the second.
+func (s *Storage) TrimDeadLetters(keep int) (int64, error) {
+	if keep < 0 {
+		keep = 0
+	}
+	res, err := s.db.Exec(`
+		DELETE FROM notify_outbox
+		WHERE state = 'dead'
+		  AND id <= COALESCE(
+		        (SELECT id FROM notify_outbox WHERE state = 'dead'
+		          ORDER BY id DESC LIMIT 1 OFFSET ?), -1)`, keep)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil
+	}
+	return n, nil
+}
+
 // TrimOutbox drops delivered rows older than the retention window. Dead letters
-// are deliberately excluded: they are kept until the operator deals with them.
+// are not covered here — they have their own ceiling, MaxDeadLetters, because
+// age is the wrong axis for a record the operator has not read yet.
 func (s *Storage) TrimOutbox(keepSentFor time.Duration) error {
 	cutoff := time.Now().Add(-keepSentFor).UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(`DELETE FROM notify_outbox WHERE state = 'sent' AND created_at < ?`, cutoff)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -671,15 +671,64 @@ func (s *Storage) GetSessionStats(sessionID string) (SessionStats, error) {
 }
 
 // Cleanup deletes data points older than the given duration. Returns count deleted.
-func (s *Storage) Cleanup(olderThan time.Duration) (int64, error) {
+func (s *Storage) Cleanup(olderThan time.Duration) (int64, []string, error) {
 	cutoff := time.Now().Add(-olderThan).UTC().Format(time.RFC3339)
 	result, err := s.db.Exec(`DELETE FROM data_points WHERE timestamp < ?`, cutoff)
 	if err != nil {
-		return 0, err
+		return 0, nil, err
 	}
-	// Also remove sessions with no data points that are inactive
-	s.db.Exec(`DELETE FROM sessions WHERE active = 0 AND id NOT IN (SELECT DISTINCT session_id FROM data_points)`)
-	return result.RowsAffected()
+	// Also remove sessions with no data points that are inactive.
+	//
+	// Their ids are RETURNED, because a session's community and v3 passphrases
+	// live in pkg/secrets under SessionRef(id) and not in this database — so a
+	// caller that deletes the row and nothing else leaves credentials behind
+	// under a key nothing will ever look up again. That was the defect in
+	// MonitorDeleteSession; deleting them in bulk here is the same defect at a
+	// larger scale, and the caller cannot fix it without knowing which ids went.
+	removed, err := s.deleteEmptyInactiveSessions()
+	if err != nil {
+		log.Printf("storage: cleanup could not remove empty sessions: %v", err)
+	}
+	n, err := result.RowsAffected()
+	return n, removed, err
+}
+
+// deleteEmptyInactiveSessions removes finished sessions that hold no data, and
+// says which ones it removed. Selected before the delete rather than after, in
+// one transaction, so the list matches what was actually removed.
+func (s *Storage) deleteEmptyInactiveSessions() ([]string, error) {
+	const where = `active = 0 AND id NOT IN (SELECT DISTINCT session_id FROM data_points)`
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	rows, err := tx.Query(`SELECT id FROM sessions WHERE ` + where)
+	if err != nil {
+		return nil, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, tx.Commit()
+	}
+	if _, err := tx.Exec(`DELETE FROM sessions WHERE ` + where); err != nil {
+		return nil, err
+	}
+	return ids, tx.Commit()
 }
 
 // ImportLocalStorageData imports legacy data from the frontend's localStorage migration.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -283,6 +283,12 @@ func Init(dbPath string) (*Storage, error) {
 
 	CREATE INDEX IF NOT EXISTS idx_ob_due ON notify_outbox(state, next_try_at);
 
+	-- Partial, for the dead-letter ceiling: idx_ob_due leads on state and then
+	-- next_try_at, which is the wrong order for "the newest N dead rows". The
+	-- same reasoning as the partial index behind the payload cap — the trimmer
+	-- runs on a write path and must not scan the table.
+	CREATE INDEX IF NOT EXISTS idx_ob_dead ON notify_outbox(id) WHERE state = 'dead';
+
 	-- How far routing has got through the event journal.
 	--
 	-- One row, enforced by the CHECK. It is written in the SAME transaction as

--- a/pkg/updater/apply.go
+++ b/pkg/updater/apply.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +27,34 @@ import (
 //
 // On a successful self-apply the application relaunches and quits, so callers
 // should not expect this method to return in that case.
+// releaseHosts are the hosts a GitHub release asset is served from.
+//
+// browser_download_url is github.com; the API also hands out
+// objects.githubusercontent.com for the same bytes, and both are accepted so a
+// change on GitHub's side does not break updating.
+var releaseHosts = map[string]bool{
+	"github.com":                           true,
+	"www.github.com":                       true,
+	"objects.githubusercontent.com":        true,
+	"release-assets.githubusercontent.com": true,
+}
+
+// checkReleaseHost refuses a download address that is not GitHub's.
+func checkReleaseHost(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("the release names a download address that cannot be parsed")
+	}
+	if !strings.EqualFold(u.Scheme, "https") {
+		return fmt.Errorf("refusing to open the download over %q; it must be https", u.Scheme)
+	}
+	if !releaseHosts[strings.ToLower(u.Hostname())] {
+		return fmt.Errorf("refusing to open a download from %q: a release asset is served "+
+			"from GitHub, and this address is not", u.Hostname())
+	}
+	return nil
+}
+
 func (s *Service) DownloadAndApply() error {
 	s.mu.Lock()
 	p := s.pending
@@ -37,7 +66,22 @@ func (s *Service) DownloadAndApply() error {
 	ctx := s.context()
 
 	// Fallback: let the OS/browser handle formats we can't self-apply.
+	//
+	// This path applies nothing — the operator downloads the .dmg or .deb over
+	// HTTPS and installs it by hand — so it is not the "install an unverified
+	// binary" the self-apply path would be. What it DOES do is send the
+	// operator to an address taken from the GitHub JSON, and that address is
+	// the only thing here nobody checks. Anyone able to change what the app
+	// reads back could point it at any host at all, and the operator would
+	// have every reason to trust the destination: the application sent them.
+	//
+	// The self-apply path does not need this, because a redirected asset fails
+	// the checksum from the signed manifest. This one has no such backstop, so
+	// the host is checked instead.
 	if p.mode == applyBrowser {
+		if err := checkReleaseHost(p.assetURL); err != nil {
+			return err
+		}
 		wruntime.BrowserOpenURL(ctx, p.assetURL)
 		return nil
 	}

--- a/pkg/updater/releasehost_test.go
+++ b/pkg/updater/releasehost_test.go
@@ -1,0 +1,52 @@
+package updater
+
+import (
+	"strings"
+	"testing"
+)
+
+// The browser path applies nothing — the operator downloads the .dmg or .deb
+// over HTTPS and installs it by hand — so it is not the "install an unverified
+// binary" the self-apply path would be. What it does do is send the operator to
+// an address taken from the GitHub JSON, and that address was the only thing
+// here nobody checked. Anyone able to change what the app reads back could
+// point it at any host, and the operator would have every reason to trust the
+// destination: the application sent them.
+//
+// The self-apply path needs none of this, because a redirected asset fails the
+// checksum from the signed manifest. This one has no such backstop.
+func TestOnlyAGitHubReleaseAddressIsOpened(t *testing.T) {
+	ok := []string{
+		"https://github.com/Wasabules/SnmpLens/releases/download/v1.5.0/SnmpLens-macos-universal.dmg",
+		"https://objects.githubusercontent.com/github-production-release-asset/1/2?X-Amz-Algorithm=x",
+		"https://release-assets.githubusercontent.com/github-production-release-asset/1/2",
+		"https://GitHub.com/Wasabules/SnmpLens/releases/download/v1.5.0/x.deb",
+	}
+	for _, u := range ok {
+		if err := checkReleaseHost(u); err != nil {
+			t.Errorf("a real release address was refused: %s (%v)", u, err)
+		}
+	}
+
+	bad := []struct {
+		url  string
+		says string
+	}{
+		{"https://github.evil.example/Wasabules/SnmpLens/releases/download/v1/x.dmg", "github.evil.example"},
+		{"https://attacker.example/SnmpLens-macos-universal.dmg", "attacker.example"},
+		{"http://github.com/Wasabules/SnmpLens/releases/download/v1/x.dmg", "http"},
+		{"file:///tmp/evil.dmg", "file"},
+		{"https://github.com.attacker.example/x.dmg", "github.com.attacker.example"},
+		{"://not a url", "parse"},
+	}
+	for _, c := range bad {
+		err := checkReleaseHost(c.url)
+		if err == nil {
+			t.Errorf("%s was accepted as a release address", c.url)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.says) {
+			t.Errorf("%s: the refusal does not say why: %v", c.url, err)
+		}
+	}
+}

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -43,6 +43,17 @@ type UpdateInfo struct {
 	// (self-replace or installer). When false the frontend offers a plain
 	// "Download" button that opens the browser.
 	CanSelfApply bool `json:"canSelfApply"`
+
+	// Error says why the check could not be answered.
+	//
+	// It exists because App.CheckForUpdate returns no error across the bridge:
+	// a failed check produced the zero value, Available was false, and the
+	// renderer said "You're on the latest version". Every reason a check fails
+	// — no network, GitHub rate-limiting, a proxy, a refused response — was
+	// reported to the operator as reassurance. In a product whose updates carry
+	// security fixes, "I could not ask" and "there is nothing new" are not the
+	// same answer, and the difference is exactly the one an operator needs.
+	Error string `json:"error,omitempty"`
 }
 
 // pending caches the details needed by DownloadAndApply between the check and


### PR DESCRIPTION
Eleven commits, each with the measurement that motivated it and a check that fails without it. Every item was verified in the code first — 139 of the audit's 232 refutation agents had failed, so the "reported, not verified" list was taken as a list of leads rather than of facts. All of them held.

## The three VERIFIED findings

**A stored sink credential is now bound to its destination.** `NotifyListSinks` blanks `Secret`; the store is write-only from the renderer by design. `NotifyTestSink` resolved a credential BY SINK ID while taking the destination from the caller — name an existing sink's id, point the URL at your own server, receive the bearer token. Its comment accepted this on the grounds that a caller "could simply read the sink list instead", which the adjacent line disproves. `NotifySaveSink` was the same defect, durable, and was not in the audit. Measured with two real HTTP receivers: the attacker's records zero requests.

**A vendor archive can no longer replace a bundled MIB.** `ensureStandardMibs` restores only files that are ABSENT, so a replaced `SNMPv2-SMI` was never repaired and MIB resolution stayed broken across restarts.

**The macOS keychain tool is resolved by absolute path.** The one exec site that puts a credential on a command line.

## The trap handler cannot take the process down

gosnmp recovers inside its decoder and nowhere around `OnNewTrap`, and its receive loop is one goroutine. Probed: unguarded the process died with `exit status 2` and never saw the second trap. The cost of that crash is every monitoring session, every threshold and the outbox drain, from a UDP packet nobody authenticated.

## The five the audit said to look at first

- **The watermark could pass a batch that was never written.** `settle` ran before `EnqueueRouted`. Reproduced: the second flush recorded the watermark at 20, past seqs 10 and 11 whose deliveries were never written — neither delivered nor replayed.
- **An INFORM is no longer acknowledged when the journal write failed.** Measured: 1 ms acknowledged with the PDU type left alone, 900 ms timeout with it changed. Reached the same way `trapbuf.go` reaches into gosnmp: fail-soft, and pinned by a test that drives a real sender.
- **The outbox has a ceiling.** `MarkFailed` never called the trimmer, so retention stopped exactly when the outbox grew fastest — measured at zero outbox writes for three failures. The newest 5 000 dead letters are kept; pending rows are untouched.
- **Only a MIB gets into the MIB directory**, plus a size cap. This narrows the arbitrary-file-read primitive; it does not close it, and the commit says why.
- **A trap flood no longer takes the window that shows it.** Four uncapped lists, and one `GetOidDetails` per trap into pkg/mib's exclusive gosmi mutex.

## Five from the tail

- The router **spun at 1244 failed transactions in 300 ms** and shutdown took the whole 5 s grace period. Now 1 attempt and ~0.2 s.
- A **community containing a comma** survived redaction into the debug panel.
- The **webhook token** reached `notify_outbox.last_error` and every other sink through `url.Parse`'s error.
- **Session credentials** outlived their session, on the single delete and in retention.
- A **failed update check** was reported as "You're on the latest version".

## Verification

`go vet`, `go test -race -count=1 ./...` (13 packages), `cd frontend && npm test`, `npm run build` — all clean locally. CI runs the same on three platforms.

## Not in this PR

Authenticode/notarisation (money and calendar), the Linux AES key beside its ciphertext (a trade-off CLAUDE.md already documents), an environment protection rule on the Ed25519 secret (a repository setting), the macOS/.deb update paths that open a URL unverified, the receiver's raw bytes in the dead-letter summary, and a corrupt `monitoring.db` silently disabling journalling.
