### PR TITLE
SECURITY.md, and the signing key behind an environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,24 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-24.04
+
+    # The signing key lives behind an environment, not loose in the repository.
+    #
+    # UPDATER_PRIVATE_KEY is the key every installed copy trusts: verify.go
+    # holds the matching public key compiled into the binary, there is one of
+    # them, and there is no revocation story. As a plain repository secret it
+    # was readable by any workflow run this repository can start, which
+    # includes every `v*` tag push. Moving it to an environment means the run
+    # has to be admitted before the secret is materialised.
+    #
+    # This declaration is only half of it: the environment must also carry a
+    # protection rule (a required reviewer, or a branch/tag policy) in
+    # Settings -> Environments -> release. Without one, GitHub creates the
+    # environment on first use and admits every run, which is exactly today's
+    # behaviour — so the setting is what makes this real, and the workflow
+    # cannot assert it.
+    environment: release
+
     permissions:
       contents: write
       # Build provenance: id-token for the OIDC token that proves the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,81 @@
+# Security policy
+
+SnmpLens holds credentials for network equipment and runs on the workstation
+that can reach it. Reports are welcome and are treated as the priority they
+deserve.
+
+The full policy — what the application does with credentials, what it never
+writes down, how releases are signed, and what is deliberately *not* treated as
+a vulnerability — is published at **<https://snmplens.com/security.html>**.
+This file is the short form GitHub reads; that page is the source of truth, and
+anything here that disagrees with it is a mistake in here.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.** Use GitHub's private vulnerability
+reporting on this repository: **Security → Report a vulnerability**. It opens a
+thread visible only to the maintainers.
+
+What makes a report actionable:
+
+- the version and the platform;
+- what an attacker gains, and what access they need to start;
+- steps to reproduce — a failing test is the clearest possible form.
+
+This project is maintained in someone's own time, so please do not expect a
+same-day answer. Reports are acknowledged, and a fix ships in a release whose
+notes describe the problem.
+
+## Supported versions
+
+Fixes go into the next release from `main`. There are no long-term support
+branches: the application updates itself, and the answer to "am I affected" is
+normally "update".
+
+| Version | Supported |
+| --- | --- |
+| Latest release | Yes |
+| Anything older | No — update |
+
+## Verifying what you downloaded
+
+Every release carries a SHA-256 manifest signed with Ed25519. The in-app
+updater verifies that signature against a key compiled into the binary *before*
+it trusts the manifest, and refuses an update whose signature is missing rather
+than applying it. The manifest's first line names its own tag, so an older
+signed manifest cannot be replayed in place of a current one.
+
+By hand:
+
+```sh
+gh release download v1.5.0 -p 'SnmpLens-checksums.txt*'
+sha256sum -c SnmpLens-checksums.txt --ignore-missing
+```
+
+And independently of anyone holding the release key, provenance is attested by
+the workflow that built the artifacts:
+
+```sh
+gh attestation verify SnmpLens-windows-amd64-setup.exe --repo Wasabules/SnmpLens
+```
+
+## Out of scope
+
+These are known, deliberate, and documented on the security page. A report
+about one of them will be closed with a pointer to it, not because it is
+unwelcome but because it is already answered.
+
+- **SNMP v1 and v2c send the community string in the clear.** That is the
+  protocol. SnmpLens supports them because networks still use them; use v3
+  where you can.
+- **Anonymous Mode is a display mask, not encryption.** The underlying data is
+  unchanged and an export contains real values.
+- **The credential store defends against a copied profile and against other
+  accounts on the machine — not against code already running as you.** While
+  the application runs, credentials are in its memory in the clear, because
+  every request builder needs them.
+- **A SET writes to live equipment, with no confirmation step.** That is by
+  design; a dialog is not a control, and it is defeated by the same script that
+  would have issued the SET directly.
+- **Findings from a scanner with no demonstrated impact.** Say what an attacker
+  gains and how they start.

--- a/tools/check-assets.mjs
+++ b/tools/check-assets.mjs
@@ -100,3 +100,47 @@ if (untracked.length) {
 
 if (absent.length || untracked.length) process.exit(1);
 console.log('Every one of them is in the repository.');
+
+// SECURITY.md and the published policy must keep pointing at each other.
+//
+// They are two files saying the same thing to two audiences: GitHub reads
+// SECURITY.md to fill in "Report a vulnerability", and docs/security.html is
+// what a reader or a procurement questionnaire is sent to. The failure is not
+// that either goes missing — it is that one is edited and the other is not,
+// and a researcher then follows a link to a policy that no longer says what
+// the repository says. Cheap to check, and impossible to notice by hand.
+// The phrase is matched across whitespace: both files wrap their prose, and
+// the first run of this check failed on 'private vulnerability' ending a line
+// in SECURITY.md. A check that a line break can defeat is worse than none.
+const policyUrl = 'https://snmplens.com/security.html';
+const problems = [];
+
+const securityMd = join(repo, 'SECURITY.md');
+if (!existsSync(securityMd)) {
+  problems.push("SECURITY.md is missing - GitHub's Report a vulnerability entry point is empty.");
+} else {
+  const md = readFileSync(securityMd, 'utf8');
+  if (!md.includes(policyUrl)) {
+    problems.push(`SECURITY.md no longer links ${policyUrl}, so the short form and the full policy have drifted apart.`);
+  }
+  // Both must name the same reporting channel. There is no email address on
+  // purpose: the channel is GitHub's private reporting, and inventing a second
+  // one is how a report ends up somewhere nobody reads.
+  if (!/private\s+vulnerability\s+reporting/i.test(md)) {
+    problems.push('SECURITY.md no longer names the private vulnerability reporting channel.');
+  }
+}
+
+const policyPage = join(docs, 'security.html');
+if (!existsSync(policyPage)) {
+  problems.push('docs/security.html is missing, but SECURITY.md sends readers to it.');
+} else if (!/private\s+vulnerability\s+reporting/i.test(readFileSync(policyPage, 'utf8'))) {
+  problems.push('docs/security.html no longer names the private vulnerability reporting channel.');
+}
+
+if (problems.length) {
+  console.error(''); console.error('Security policy:');
+  for (const line of problems) console.error(`  ${line}`);
+  process.exit(1);
+}
+console.log('SECURITY.md and docs/security.html agree on where to report.');


### PR DESCRIPTION
Two audit findings, plus one setting that is yours rather than mine.

## SECURITY.md

It was absent, so GitHub's **Report a vulnerability** entry point was empty and a researcher's fallback was a public issue — on a tool that holds community strings and v3 passphrases for network equipment.

The private reporting channel it names **is** enabled on the repository (`private-vulnerability-reporting` → `{"enabled": true}`). I checked rather than assumed: a policy that sends people to a closed door is worse than no policy.

It deliberately does **not** restate `docs/security.html`. That page is the source of truth and says far more than a short form should; this file is what GitHub reads, and it links out. No email address, because there is none — inventing a second channel is how a report reaches somewhere nobody watches.

The part that earns its place is the out-of-scope list: v1/v2c sending the community in the clear is the protocol, Anonymous Mode is a display mask, the credential store does not defend against code already running as you, and a SET writes to live equipment with no confirmation *by design*. Each is already reasoned about in the codebase, so a report about one is answered with a pointer rather than a debate.

Every verification command is checked against what a release actually publishes — the assets really are `SnmpLens-checksums.txt` and `.sig`, and `SnmpLens-windows-amd64-setup.exe` really is in `attest-build-provenance`'s `subject-path`, so the `gh attestation verify` example works.

## The signing key

`UPDATER_PRIVATE_KEY` is the key every installed copy trusts: one key, compiled into the binary by `verify.go`, no revocation story. As a plain repository secret it was readable by any run this repository can start — which includes every `v*` tag push. The `release` job now declares `environment: release`.

**Half of this is a setting I cannot make.** The environment needs a protection rule — a required reviewer, or a tag policy — under **Settings → Environments → release**. Without one, GitHub creates the environment on first use and admits every run, which is exactly today's behaviour. The workflow comment says so, so the declaration is not mistaken for the control.

## Keeping the two policies together

`check-assets.mjs` now fails when `SECURITY.md` stops linking the published policy, when either file stops naming the reporting channel, or when either goes missing. The failure worth catching is not either disappearing — it is one being edited and the other not.

The phrase is matched across whitespace because the first run of this check **failed on its own author**: "private vulnerability" ended a line in `SECURITY.md`. A check a line break can defeat is worse than none.

Both failure modes were reproduced before the fix: pointing `SECURITY.md` at another URL, and removing it entirely, each fail the check with the right message.
