### PR TITLE
Move the updater key into the release environment, without reading it

### DIFF
--- a/.github/workflows/move-updater-key.yml
+++ b/.github/workflows/move-updater-key.yml
@@ -1,0 +1,120 @@
+# Move UPDATER_PRIVATE_KEY from a repository secret into the release environment.
+#
+# THIS WORKFLOW IS A ONE-SHOT. Run it once, confirm, then delete the file, the
+# repository secret and the PAT. It is left in the repository only long enough
+# to be run.
+#
+# WHY IT EXISTS. The signing key is the one every installed copy trusts:
+# pkg/updater/verify.go holds the matching public key compiled into the binary,
+# there is exactly one of them, and there is no revocation story. As a plain
+# REPOSITORY secret it is readable by any workflow this repository can run —
+# including one added later, or one edited in a pull request. Moving it into the
+# `release` environment means only a job that declares that environment, and
+# passes its `v*` tag policy, can obtain it.
+#
+# WHY IT IS A WORKFLOW AND NOT A COPY-PASTE. A GitHub Actions secret is
+# write-only once stored: there is no way to read the value back, not even for
+# the repository owner. So the only thing that can move it is something that
+# already has it — a workflow run.
+#
+# WHAT IT COSTS, STATED PLAINLY. The value passes through a GitHub-hosted
+# ephemeral runner. That is the same runner that already receives it on every
+# release, so this is not a new class of exposure. It is never printed: the
+# checks below report lengths and a yes/no, never the value, and GitHub masks
+# registered secrets in logs regardless.
+name: Move the updater key into the release environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "move" to confirm. Read the header of this file first.'
+        required: true
+        default: ''
+
+permissions: {}
+
+jobs:
+  move:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Refuse unless explicitly confirmed
+        if: ${{ inputs.confirm != 'move' }}
+        run: |
+          echo '::error::Type "move" in the confirm field to run this.' >&2
+          exit 1
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      # Prove the secret is the key the shipped binaries actually trust, BEFORE
+      # copying it anywhere. An Ed25519 private key contains its public half, so
+      # this is arithmetic rather than a network call — and it is the one check
+      # that a write-only secret otherwise makes impossible. Copying a wrong or
+      # truncated value into the environment and finding out at the next release
+      # is the failure worth spending thirty seconds to avoid.
+      - name: The secret matches the public key compiled into the binary
+        env:
+          UPDATER_PRIVATE_KEY: ${{ secrets.UPDATER_PRIVATE_KEY }}
+        run: |
+          if [ -z "${UPDATER_PRIVATE_KEY}" ]; then
+            echo '::error::UPDATER_PRIVATE_KEY is not set as a repository secret; nothing to move.' >&2
+            exit 1
+          fi
+          echo "The secret is ${#UPDATER_PRIVATE_KEY} characters long (a valid key is 128 hexadecimal characters)."
+
+          derived=$(go run ./tools/updatersign pubkey)
+          embedded=$(grep -oE 'updaterPublicKey = "[^"]+"' pkg/updater/verify.go | cut -d'"' -f2)
+
+          echo "embedded in verify.go : ${embedded}"
+          echo "derived from secret   : ${derived}"
+
+          if [ "${derived}" != "${embedded}" ]; then
+            echo '::error::The secret is NOT the key installed copies trust. Every signature it makes would be refused. Nothing was copied.' >&2
+            exit 1
+          fi
+          echo 'They match. This is the right key.'
+
+      # gh needs a token that can write secrets. GITHUB_TOKEN cannot, whatever
+      # permissions are granted to it — secret management is outside its scope
+      # by design, which is the correct design.
+      - name: Copy it into the release environment
+        env:
+          GH_TOKEN: ${{ secrets.SECRET_ADMIN_TOKEN }}
+          UPDATER_PRIVATE_KEY: ${{ secrets.UPDATER_PRIVATE_KEY }}
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo '::error::SECRET_ADMIN_TOKEN is not set. See the header of this file.' >&2
+            exit 1
+          fi
+          # printf, not echo: no trailing newline, so the stored value is exactly
+          # the stored value. (updatersign trims whitespace anyway; this is so
+          # the two secrets are byte-identical rather than nearly so.)
+          printf '%s' "${UPDATER_PRIVATE_KEY}" \
+            | gh secret set UPDATER_PRIVATE_KEY --env release --repo "${GITHUB_REPOSITORY}"
+          echo 'Written to the release environment.'
+
+      # Names only. There is no API that returns a secret's value, which is the
+      # whole point — so this confirms placement, not content. Content was
+      # confirmed by the public-key check above.
+      - name: Confirm where it now lives
+        env:
+          GH_TOKEN: ${{ secrets.SECRET_ADMIN_TOKEN }}
+        run: |
+          echo 'Secrets in the release environment:'
+          gh api "repos/${GITHUB_REPOSITORY}/environments/release/secrets" --jq '.secrets[].name' | sed 's/^/  /'
+          echo
+          echo 'Secrets still at repository level:'
+          gh api "repos/${GITHUB_REPOSITORY}/actions/secrets" --jq '.secrets[].name' | sed 's/^/  /'
+          echo
+          echo 'Now, by hand and in this order:'
+          echo '  1. Settings -> Secrets and variables -> Actions: delete the repository UPDATER_PRIVATE_KEY.'
+          echo '  2. Delete SECRET_ADMIN_TOKEN, and revoke the PAT itself.'
+          echo '  3. Delete .github/workflows/move-updater-key.yml.'

--- a/tools/updatersign/main.go
+++ b/tools/updatersign/main.go
@@ -14,6 +14,15 @@
 //
 // which writes path/to/file.sig (base64-encoded Ed25519 signature). With no
 // key set, signing is skipped so unsigned builds keep working.
+//
+// Ask which public key the configured secret corresponds to:
+//
+//	UPDATER_PRIVATE_KEY=<hex> go run ./tools/updatersign pubkey
+//
+// An Ed25519 private key CONTAINS its public half, so this needs no network and
+// no other input. It exists because a GitHub Actions secret is write-only once
+// stored — you cannot read it back to check it is the key the shipped binaries
+// trust. This answers that question without ever printing the private half.
 package main
 
 import (
@@ -38,6 +47,8 @@ func main() {
 			usage()
 		}
 		sign(os.Args[2])
+	case "pubkey":
+		pubkey()
 	default:
 		usage()
 	}
@@ -53,6 +64,36 @@ func keygen() {
 	fmt.Println()
 	fmt.Println("Private key — add as GitHub secret UPDATER_PRIVATE_KEY (keep secret!):")
 	fmt.Println("  " + hex.EncodeToString(priv))
+}
+
+// pubkey prints the public half of the configured private key.
+//
+// Compare it with updaterPublicKey in pkg/updater/verify.go: if they differ,
+// the secret is not the key installed copies trust, and every signature it
+// makes will be refused by the updater it is meant to satisfy.
+func pubkey() {
+	key := loadKey()
+	fmt.Println(base64.StdEncoding.EncodeToString([]byte(ed25519.PrivateKey(key).Public().(ed25519.PublicKey))))
+}
+
+// loadKey reads and validates UPDATER_PRIVATE_KEY, or exits.
+//
+// The error says the LENGTH it found and never the value: this runs in CI, and
+// a private key in a log line is the failure this whole mechanism exists to
+// prevent.
+func loadKey() []byte {
+	keyHex := strings.TrimSpace(os.Getenv("UPDATER_PRIVATE_KEY"))
+	if keyHex == "" {
+		fatal(fmt.Errorf("UPDATER_PRIVATE_KEY is not set"))
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		fatal(fmt.Errorf("UPDATER_PRIVATE_KEY is not hexadecimal (%d characters)", len(keyHex)))
+	}
+	if len(key) != ed25519.PrivateKeySize {
+		fatal(fmt.Errorf("UPDATER_PRIVATE_KEY decodes to %d bytes, want %d", len(key), ed25519.PrivateKeySize))
+	}
+	return key
 }
 
 func sign(path string) {
@@ -78,7 +119,7 @@ func sign(path string) {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: updatersign keygen | sign <file>")
+	fmt.Fprintln(os.Stderr, "usage: updatersign keygen | sign <file> | pubkey")
 	os.Exit(2)
 }
 


### PR DESCRIPTION
The previous PR gave the `release` job `environment: release` and the environment a `v*` tag policy. **That half is inert while the secret stays at repository level** — the job reads it either way, and so could any other workflow.

The obvious fix is to retype the value into the environment. It is not available: an Actions secret is **write-only** once stored, not readable even by the repository owner, and the copy kept at generation time is gone. The only thing that can move it is something that already holds it — a workflow run.

## What it is not

**Not a rotation.** `pkg/updater/verify.go` compiles exactly one public key into every binary, with no key id and no revocation. A release signed with a new key is refused by every installed copy that has not passed through the changeover release; anyone skipping that version reinstalls by hand. Copying keeps the key those copies already trust, and leaves the successor-key design as the separate piece of work it is.

## The check that makes it safe

Before copying anything, the run proves the secret **is** that key:

```
embedded in verify.go : svOWbkIuFQTiebt+DKzaohFFdeANV8NjcdX3cQiybPw=
derived from secret   : <derived from UPDATER_PRIVATE_KEY>
```

`updatersign pubkey` is new and derives the public half locally — an Ed25519 private key contains it, so this is arithmetic rather than a lookup. It is the one check a write-only secret otherwise makes impossible, and it catches a truncated or wrong value here instead of at the next release.

Verified locally in both directions: a foreign key is rejected, and a key derives back to its own public half byte for byte. `sign`'s "no key, skip signing" behaviour is untouched, so local builds still work without a key.

## What it costs, stated in the file rather than implied

The value passes through a GitHub-hosted ephemeral runner — the same runner that already receives it on every release, so not a new class of exposure. It is never printed: errors report **lengths**, never values, and GitHub masks registered secrets in logs regardless.

`GITHUB_TOKEN` cannot manage secrets whatever permissions it is granted, so this needs a PAT in `SECRET_ADMIN_TOKEN`. The final step prints the secret names in both places and the three things to delete afterwards: the repository secret, the PAT, and this workflow file.

It is `workflow_dispatch` only and refuses to run unless `move` is typed in the confirm field.
