### PR TITLE
Make the poll clock behave: batch the OIDs, spread the sessions

### DIFF
--- a/app_monitor.go
+++ b/app_monitor.go
@@ -174,11 +174,19 @@ func (a *App) buildFetch(sess storage.Session) monitor.FetchFunc {
 	community := creds.Community
 	port, timeout, retries := conn.Port, conn.TimeoutSec, conn.Retries
 
-	return func(_ context.Context, oid string, targets []string) []monitor.Reading {
-		results := a.snmpClient.Get(targets, oid, community, version, port, timeout, retries, v3)
-		readings := make([]monitor.Reading, 0, len(results))
-		for _, r := range results {
-			readings = append(readings, toReading(r))
+	// One connection per target, every OID in one PDU, rather than one
+	// connection per (target, OID) walked serially. The old shape cost a full
+	// timeout per OID against an unreachable device — ten OIDs at the default
+	// five seconds was a fifty-second tick on the clock that runs with the
+	// window closed, and the scheduler could only check for a stop between
+	// OIDs, so it could not be interrupted.
+	return func(_ context.Context, oids []string, targets []string) []monitor.Reading {
+		results := a.snmpClient.GetMany(targets, oids, community, version, port, timeout, retries, v3)
+		readings := make([]monitor.Reading, 0, len(results)*len(oids))
+		for _, m := range results {
+			for _, oid := range oids {
+				readings = append(readings, toReading(m.Target, oid, m.Results[oid], m.Errors[oid], m.ResponseTimeMs))
+			}
 		}
 		return readings
 	}
@@ -194,18 +202,31 @@ var nonNumericTypes = []string{"octetstring", "objectidentifier", "ipaddress", "
 var errorSentinels = map[string]bool{"noSuchObject": true, "noSuchInstance": true, "endOfMibView": true}
 
 // toReading converts one SNMP answer into a scheduler reading.
-func toReading(r *snmp.BulkResult) monitor.Reading {
+//
+// Keyed on the pieces rather than on a *BulkResult, because the batched path
+// (GetMany) has no BulkResult and the rules below — the error sentinels, and
+// which SNMP types are not numbers — must not exist twice. A second copy that
+// drifts would show a string OID as a chart point on one path and not the
+// other.
+func toReading(target, oid string, res *snmp.Result, errMsg string, ms int64) monitor.Reading {
 	out := monitor.Reading{
-		Target:         r.Target,
-		Error:          r.Error,
-		ResponseTimeMs: int(r.ResponseTimeMs),
+		Target:         target,
+		OID:            oid,
+		Error:          errMsg,
+		ResponseTimeMs: int(ms),
 	}
-	if r.Result == nil {
+	if res == nil {
+		if out.Error == "" {
+			// Neither a value nor an error: the agent answered without this
+			// varbind. Silence would look like a paused session rather than a
+			// device that did not reply.
+			out.Error = "no result returned"
+		}
 		return out
 	}
-	out.SnmpType = r.Result.Type
+	out.SnmpType = res.Type
 
-	if s, ok := r.Result.Value.(string); ok && errorSentinels[s] {
+	if s, ok := res.Value.(string); ok && errorSentinels[s] {
 		out.Error = s
 		return out
 	}
@@ -215,7 +236,7 @@ func toReading(r *snmp.BulkResult) monitor.Reading {
 			return out
 		}
 	}
-	if v, ok := numericValue(r.Result.Value); ok {
+	if v, ok := numericValue(res.Value); ok {
 		out.Value = &v
 	}
 	return out

--- a/pkg/monitor/integration_test.go
+++ b/pkg/monitor/integration_test.go
@@ -50,28 +50,35 @@ func TestIntegrationSchedulerPollsARealAgent(t *testing.T) {
 	host, port := agentAddr(t)
 
 	client := snmp.NewClient(context.Background())
-	fetch := func(_ context.Context, oid string, targets []string) []monitor.Reading {
+	// GetMany, which is what the scheduler drives in production: one
+	// connection per target with every OID in one PDU, against a real agent.
+	fetch := func(_ context.Context, oids []string, targets []string) []monitor.Reading {
 		out := []monitor.Reading{}
-		for _, r := range client.Get(targets, oid, "public", "v2c", port, 2, 1, snmp.V3Params{}) {
-			reading := monitor.Reading{Target: r.Target, Error: r.Error, ResponseTimeMs: int(r.ResponseTimeMs)}
-			if r.Result != nil {
-				reading.SnmpType = r.Result.Type
-				switch v := r.Result.Value.(type) {
-				case uint32:
-					f := float64(v)
-					reading.Value = &f
-				case int:
-					f := float64(v)
-					reading.Value = &f
-				case int64:
-					f := float64(v)
-					reading.Value = &f
-				case uint64:
-					f := float64(v)
-					reading.Value = &f
+		for _, m := range client.GetMany(targets, oids, "public", "v2c", port, 2, 1, snmp.V3Params{}) {
+			for _, oid := range oids {
+				reading := monitor.Reading{
+					Target: m.Target, OID: oid,
+					Error: m.Errors[oid], ResponseTimeMs: int(m.ResponseTimeMs),
 				}
+				if r := m.Results[oid]; r != nil {
+					reading.SnmpType = r.Type
+					switch v := r.Value.(type) {
+					case uint32:
+						f := float64(v)
+						reading.Value = &f
+					case int:
+						f := float64(v)
+						reading.Value = &f
+					case int64:
+						f := float64(v)
+						reading.Value = &f
+					case uint64:
+						f := float64(v)
+						reading.Value = &f
+					}
+				}
+				out = append(out, reading)
 			}
-			out = append(out, reading)
 		}
 		return out
 	}
@@ -139,10 +146,12 @@ func TestIntegrationUnreachableTargetIsRecorded(t *testing.T) {
 	_, port := agentAddr(t)
 
 	client := snmp.NewClient(context.Background())
-	fetch := func(_ context.Context, oid string, targets []string) []monitor.Reading {
+	fetch := func(_ context.Context, oids []string, targets []string) []monitor.Reading {
 		out := []monitor.Reading{}
-		for _, r := range client.Get(targets, oid, "public", "v2c", port, 1, 0, snmp.V3Params{}) {
-			out = append(out, monitor.Reading{Target: r.Target, Error: r.Error})
+		for _, m := range client.GetMany(targets, oids, "public", "v2c", port, 1, 0, snmp.V3Params{}) {
+			for _, oid := range oids {
+				out = append(out, monitor.Reading{Target: m.Target, OID: oid, Error: m.Errors[oid]})
+			}
 		}
 		return out
 	}

--- a/pkg/monitor/scheduler.go
+++ b/pkg/monitor/scheduler.go
@@ -132,6 +132,39 @@ func (s *Scheduler) Start(spec SessionSpec) {
 	s.notifyStateChange()
 }
 
+// startSpreadWindow bounds how late a first poll can be.
+//
+// Two seconds is enough to break the simultaneity that matters — the burst of
+// inserts against SQLite's single writer, and the burst of sockets — while
+// staying under what anyone notices as a delay when they press Start.
+const startSpreadWindow = 2 * time.Second
+
+// startSpread is where in the window this session's first poll falls.
+//
+// FNV-1a over the id: cheap, dependency-free, and deterministic, which is the
+// property that matters. A random offset would spread just as well and could
+// not be tested, and would reshuffle every restart so a session's slot would
+// never settle.
+func startSpread(id string, interval time.Duration) time.Duration {
+	window := startSpreadWindow
+	if interval < window {
+		// A fast session must not have its first point pushed past its own
+		// period, or the spread would look like a missed poll.
+		window = interval
+	}
+	if window <= 0 {
+		return 0
+	}
+	const offset64 = 14695981039346656037
+	const prime64 = 1099511628211
+	h := uint64(offset64)
+	for i := 0; i < len(id); i++ {
+		h ^= uint64(id[i])
+		h *= prime64
+	}
+	return time.Duration(h % uint64(window))
+}
+
 func (s *Scheduler) loop(ctx context.Context, h *handle, spec SessionSpec) {
 	defer close(h.done)
 
@@ -139,8 +172,31 @@ func (s *Scheduler) loop(ctx context.Context, h *handle, spec SessionSpec) {
 	ticker := time.NewTicker(spec.Interval)
 	defer ticker.Stop()
 
-	// Poll immediately: waiting a full interval for the first point makes a
-	// slow monitoring look broken.
+	// Spread the first poll, then keep the promise of a prompt first point.
+	//
+	// Measured before this existed: twenty sessions started back to back — which
+	// is exactly what resumeActiveSessions does after a reboot — took their
+	// first tick with a spread of 0 ms. Every device asked at once, every insert
+	// arriving at once on a database with one writer and a four-connection pool.
+	//
+	// The offset is DERIVED FROM THE SESSION ID, not drawn at random: a session
+	// lands in the same slot on every restart, so the spread is stable and can
+	// be asserted rather than hoped for. Two sessions can still collide; twenty
+	// cannot all collide.
+	//
+	// Bounded by startSpreadWindow rather than by the interval, because the
+	// comment this replaces was right: waiting a full interval for the first
+	// point makes a slow monitoring look broken, and an hourly session must not
+	// take an hour to show anything.
+	if d := startSpread(spec.ID, spec.Interval); d > 0 {
+		timer := time.NewTimer(d)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
 	s.tick(ctx, spec, last)
 
 	for {

--- a/pkg/monitor/scheduler.go
+++ b/pkg/monitor/scheduler.go
@@ -8,7 +8,12 @@ import (
 
 // Reading is one target's answer to one GET.
 type Reading struct {
-	Target         string   `json:"target"`
+	Target string `json:"target"`
+	// OID says which of the requested OIDs this reading answers. It exists
+	// because one Fetch now returns every OID for every target in one slice,
+	// and a reading that cannot say what it measured cannot be paired with the
+	// previous sample it derives a rate from.
+	OID            string   `json:"oid"`
 	Value          *float64 `json:"value"`
 	SnmpType       string   `json:"snmpType"`
 	ResponseTimeMs int      `json:"responseTimeMs"`
@@ -21,7 +26,16 @@ type Reading struct {
 // v3 passphrases: the caller closes over them when it builds this function.
 // That keeps credentials out of this package entirely and makes the whole
 // scheduler testable without a network.
-type FetchFunc func(ctx context.Context, oid string, targets []string) []Reading
+// FetchFunc reads EVERY oid from EVERY target, in as few round trips as the
+// transport allows, and returns one Reading per (target, oid) pair — including
+// for failures, because a pair with no reading at all is indistinguishable
+// from a session nobody started.
+//
+// It used to take one OID. The scheduler then walked the OIDs serially while
+// only the targets ran concurrently, so a session with ten OIDs against an
+// unreachable device spent ten full timeouts in a row on the poll clock — the
+// one that runs with the window closed.
+type FetchFunc func(ctx context.Context, oids []string, targets []string) []Reading
 
 // Point is one stored sample, with the derived values the charts need.
 type Point struct {
@@ -149,44 +163,43 @@ func (s *Scheduler) tick(ctx context.Context, spec SessionSpec, last map[string]
 	var points []Point
 	var samples []Sample
 
-	for _, oid := range spec.OIDs {
-		if ctx.Err() != nil {
-			return
+	if ctx.Err() != nil {
+		return
+	}
+	for _, r := range spec.Fetch(ctx, spec.OIDs, spec.Targets) {
+		oid := r.OID
+		key := r.Target + "|" + oid
+		p := Point{
+			SessionID: spec.ID, Target: r.Target, OID: oid, Timestamp: stamp,
+			Value: r.Value, ResponseTimeMs: r.ResponseTimeMs, Error: r.Error, SnmpType: r.SnmpType,
 		}
-		for _, r := range spec.Fetch(ctx, oid, spec.Targets) {
-			key := r.Target + "|" + oid
-			p := Point{
-				SessionID: spec.ID, Target: r.Target, OID: oid, Timestamp: stamp,
-				Value: r.Value, ResponseTimeMs: r.ResponseTimeMs, Error: r.Error, SnmpType: r.SnmpType,
-			}
 
-			if r.Value != nil {
-				if prev, ok := last[key]; ok {
-					typ := r.SnmpType
-					if typ == "" {
-						typ = prev.typ
-					}
-					if d, ok := CorrectedDelta(prev.value, *r.Value, typ); ok {
-						delta := d
-						p.Delta = &delta
-						if dt, ok := ElapsedSeconds(prev.at, now); ok {
-							rate := d / dt
-							p.Rate = &rate
-						}
+		if r.Value != nil {
+			if prev, ok := last[key]; ok {
+				typ := r.SnmpType
+				if typ == "" {
+					typ = prev.typ
+				}
+				if d, ok := CorrectedDelta(prev.value, *r.Value, typ); ok {
+					delta := d
+					p.Delta = &delta
+					if dt, ok := ElapsedSeconds(prev.at, now); ok {
+						rate := d / dt
+						p.Rate = &rate
 					}
 				}
-				last[key] = lastSample{value: *r.Value, at: now, typ: r.SnmpType}
-			} else {
-				// A failed poll breaks the series: the next delta must not
-				// span the outage as though nothing happened.
-				delete(last, key)
 			}
-
-			points = append(points, p)
-			samples = append(samples, Sample{
-				Target: r.Target, OID: oid, Timestamp: stamp, Value: r.Value, Error: r.Error,
-			})
+			last[key] = lastSample{value: *r.Value, at: now, typ: r.SnmpType}
+		} else {
+			// A failed poll breaks the series: the next delta must not
+			// span the outage as though nothing happened.
+			delete(last, key)
 		}
+
+		points = append(points, p)
+		samples = append(samples, Sample{
+			Target: r.Target, OID: oid, Timestamp: stamp, Value: r.Value, Error: r.Error,
+		})
 	}
 
 	if len(points) == 0 {

--- a/pkg/monitor/scheduler_test.go
+++ b/pkg/monitor/scheduler_test.go
@@ -45,14 +45,16 @@ func f64(v float64) *float64 { return &v }
 func counterFetch(step float64) FetchFunc {
 	var mu sync.Mutex
 	state := map[string]float64{}
-	return func(_ context.Context, oid string, targets []string) []Reading {
+	return func(_ context.Context, oids []string, targets []string) []Reading {
 		mu.Lock()
 		defer mu.Unlock()
-		out := make([]Reading, 0, len(targets))
+		out := make([]Reading, 0, len(targets)*len(oids))
 		for _, t := range targets {
-			key := t + "|" + oid
-			state[key] += step
-			out = append(out, Reading{Target: t, Value: f64(state[key]), SnmpType: "Counter32", ResponseTimeMs: 3})
+			for _, oid := range oids {
+				key := t + "|" + oid
+				state[key] += step
+				out = append(out, Reading{Target: t, OID: oid, Value: f64(state[key]), SnmpType: "Counter32", ResponseTimeMs: 3})
+			}
 		}
 		return out
 	}
@@ -146,17 +148,17 @@ func TestFailedPollBreaksTheSeries(t *testing.T) {
 
 	var n int
 	var mu sync.Mutex
-	fetch := func(context.Context, string, []string) []Reading {
+	fetch := func(context.Context, []string, []string) []Reading {
 		mu.Lock()
 		defer mu.Unlock()
 		n++
 		switch n {
 		case 1:
-			return []Reading{{Target: "a", Value: f64(100), SnmpType: "Counter32"}}
+			return []Reading{{Target: "a", OID: "1.1", Value: f64(100), SnmpType: "Counter32"}}
 		case 2:
-			return []Reading{{Target: "a", Value: nil, Error: "timeout"}}
+			return []Reading{{Target: "a", OID: "1.1", Value: nil, Error: "timeout"}}
 		default:
-			return []Reading{{Target: "a", Value: f64(500), SnmpType: "Counter32"}}
+			return []Reading{{Target: "a", OID: "1.1", Value: f64(500), SnmpType: "Counter32"}}
 		}
 	}
 

--- a/pkg/monitor/spread_test.go
+++ b/pkg/monitor/spread_test.go
@@ -1,0 +1,136 @@
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Sessions resumed together must not all poll together.
+//
+// resumeActiveSessions starts every active session in a tight loop, and loop
+// used to tick immediately. Measured before this existed: twenty sessions,
+// first-tick spread of 0 ms — every device asked at once, every insert landing
+// at once on a database with one writer and a four-connection pool.
+func TestResumedSessionsDoNotAllPollAtOnce(t *testing.T) {
+	var mu sync.Mutex
+	firsts := map[string]time.Duration{}
+	origin := time.Now()
+
+	s := NewScheduler()
+	s.Persist = func([]Point) {}
+
+	const sessions = 20
+	for i := 0; i < sessions; i++ {
+		id := fmt.Sprintf("session-%d", i)
+		s.Start(SessionSpec{
+			ID: id, OIDs: []string{"1.1"}, Targets: []string{"a"},
+			Interval: 30 * time.Second,
+			Fetch: func(_ context.Context, oids []string, targets []string) []Reading {
+				mu.Lock()
+				if _, seen := firsts[id]; !seen {
+					firsts[id] = time.Since(origin)
+				}
+				mu.Unlock()
+				return []Reading{{Target: targets[0], OID: oids[0], Value: f64(1), SnmpType: "Counter32"}}
+			},
+		})
+	}
+	// Long enough for every offset in the window to have fired.
+	time.Sleep(startSpreadWindow + 500*time.Millisecond)
+	s.StopAll()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(firsts) != sessions {
+		t.Fatalf("%d of %d sessions polled", len(firsts), sessions)
+	}
+
+	// How many landed in the same 100 ms slot? Before the spread, all of them.
+	buckets := map[int]int{}
+	worst := 0
+	for _, d := range firsts {
+		b := int(d / (100 * time.Millisecond))
+		buckets[b]++
+		if buckets[b] > worst {
+			worst = buckets[b]
+		}
+	}
+	if worst > sessions/2 {
+		t.Errorf("%d of %d sessions polled inside the same 100 ms; the herd is not spread", worst, sessions)
+	}
+	if len(buckets) < 3 {
+		t.Errorf("every session landed in %d slot(s); the offsets are not distributed", len(buckets))
+	}
+}
+
+// The offset is derived, not drawn. A session lands in the same slot on every
+// restart — which is what makes the spread stable rather than reshuffled, and
+// what makes the test above an assertion rather than a hope.
+func TestTheSpreadIsDeterministic(t *testing.T) {
+	const iv = 30 * time.Second
+	for _, id := range []string{"a", "session-1", "0195f3c2-1c4a-7e1b-9f3d-2a6b5c8d7e90"} {
+		first := startSpread(id, iv)
+		for i := 0; i < 5; i++ {
+			if got := startSpread(id, iv); got != first {
+				t.Errorf("%s: %v then %v; the offset must not move between calls", id, first, got)
+			}
+		}
+		if first < 0 || first >= startSpreadWindow {
+			t.Errorf("%s: offset %v is outside the window %v", id, first, startSpreadWindow)
+		}
+	}
+
+	// Different ids land in different places. Not a hash-quality test — just
+	// enough to catch an offset that ignores its input.
+	seen := map[time.Duration]bool{}
+	for i := 0; i < 50; i++ {
+		seen[startSpread(fmt.Sprintf("session-%d", i), iv)] = true
+	}
+	if len(seen) < 25 {
+		t.Errorf("50 ids produced %d distinct offsets; the spread is barely spreading", len(seen))
+	}
+}
+
+// A fast session must not have its first point pushed past its own period, or
+// the spread reads as a missed poll rather than as a stagger.
+func TestTheSpreadNeverExceedsTheInterval(t *testing.T) {
+	for _, iv := range []time.Duration{minInterval, 300 * time.Millisecond, time.Second, time.Hour} {
+		for i := 0; i < 30; i++ {
+			d := startSpread(fmt.Sprintf("s%d", i), iv)
+			if d >= iv {
+				t.Errorf("interval %v: offset %v is a whole period or more", iv, d)
+			}
+			if d >= startSpreadWindow {
+				t.Errorf("interval %v: offset %v exceeds the window", iv, d)
+			}
+		}
+	}
+}
+
+// Stopping during the spread must return at once, not after the offset.
+func TestStoppingDuringTheSpreadIsImmediate(t *testing.T) {
+	s := NewScheduler()
+	s.Persist = func([]Point) {}
+	polled := make(chan struct{}, 1)
+
+	s.Start(SessionSpec{
+		ID: "slow-to-start", OIDs: []string{"1.1"}, Targets: []string{"a"},
+		Interval: 30 * time.Second,
+		Fetch: func(_ context.Context, oids []string, targets []string) []Reading {
+			select {
+			case polled <- struct{}{}:
+			default:
+			}
+			return nil
+		},
+	})
+
+	start := time.Now()
+	s.StopAll()
+	if d := time.Since(start); d > startSpreadWindow {
+		t.Errorf("stopping took %v; it waited out the spread instead of cancelling it", d.Round(time.Millisecond))
+	}
+}

--- a/pkg/snmp/getmany_test.go
+++ b/pkg/snmp/getmany_test.go
@@ -1,0 +1,134 @@
+package snmp
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+// deadTarget returns an address nothing will answer on.
+//
+// A bound-then-closed UDP port, so the address is real and routable and the
+// packets simply go nowhere — which is what an unreachable device looks like
+// to the client, rather than an immediate ICMP refusal.
+func deadTarget(t *testing.T) (string, int) {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no UDP socket: %v", err)
+	}
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	c.Close()
+	return "127.0.0.1", port
+}
+
+// The cost of an unreachable device must not scale with the number of OIDs.
+//
+// The poll used to call Get once per OID: a fresh socket and ONE varbind each
+// time, walked serially while only the targets ran concurrently. Ten OIDs
+// against a device that does not answer therefore cost ten full timeouts, one
+// after another — on the clock that runs with the window closed, where nothing
+// is watching. GetMany asks for all of them in one PDU on one connection, so
+// the cost is one timeout whatever the count.
+//
+// The assertion is deliberately loose. What matters is the SHAPE — constant
+// rather than linear in the OID count — not a millisecond figure that would
+// make this test a flake on a loaded runner.
+func TestAnUnreachableDeviceCostsOneTimeoutNotOnePerOid(t *testing.T) {
+	host, port := deadTarget(t)
+	c := newHeadlessClient()
+
+	const timeoutSec = 1
+	oids := []string{
+		"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0",
+		"1.3.6.1.2.1.1.6.0", "1.3.6.1.2.1.1.4.0", "1.3.6.1.2.1.2.1.0",
+	}
+
+	start := time.Now()
+	res := c.GetMany([]string{host}, oids, "public", "v2c", port, timeoutSec, 0, V3Params{})
+	elapsed := time.Since(start)
+
+	// One timeout, with generous headroom. The old shape would be at least
+	// len(oids) x timeout — six seconds here.
+	limit := time.Duration(timeoutSec) * time.Second * 3
+	if elapsed > limit {
+		t.Errorf("%d OIDs against an unreachable device took %v; a single timeout is %ds, so this "+
+			"is still paying one per OID", len(oids), elapsed.Round(time.Millisecond), timeoutSec)
+	}
+
+	// And the failure is reported PER OID. A target-level error that produced
+	// no per-OID entries would leave the scheduler with nothing to record, and
+	// a session with no points looks paused rather than broken.
+	if len(res) != 1 {
+		t.Fatalf("%d results for one target", len(res))
+	}
+	if len(res[0].Errors) != len(oids) {
+		t.Errorf("%d errors for %d OIDs; every one must be accounted for", len(res[0].Errors), len(oids))
+	}
+	for _, oid := range oids {
+		if res[0].Errors[oid] == "" {
+			t.Errorf("no error recorded for %s", oid)
+		}
+		if res[0].Results[oid] != nil {
+			t.Errorf("a value was reported for %s by a device that never answered", oid)
+		}
+	}
+}
+
+// Several unreachable targets stay concurrent, as they were before.
+func TestUnreachableTargetsAreStillPolledConcurrently(t *testing.T) {
+	c := newHeadlessClient()
+	var targets []string
+	var port int
+	for i := 0; i < 4; i++ {
+		h, p := deadTarget(t)
+		targets = append(targets, h)
+		port = p // they share a port; the addresses are what differ in production
+	}
+
+	start := time.Now()
+	res := c.GetMany(targets, []string{"1.3.6.1.2.1.1.3.0"}, "public", "v2c", port, 1, 0, V3Params{})
+	elapsed := time.Since(start)
+
+	if elapsed > 3*time.Second {
+		t.Errorf("%d unreachable targets took %v; they are being polled one after another",
+			len(targets), elapsed.Round(time.Millisecond))
+	}
+	if len(res) != len(targets) {
+		t.Errorf("%d results for %d targets", len(res), len(targets))
+	}
+}
+
+// The caller's target order is what pairs a result with the device it came
+// from. The goroutines finish in whatever order the network allows.
+func TestGetManyReturnsTargetsInTheOrderAsked(t *testing.T) {
+	c := newHeadlessClient()
+	_, port := deadTarget(t)
+	targets := []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"}
+
+	res := c.GetMany(targets, []string{"1.3.6.1.2.1.1.3.0"}, "public", "v2c", port, 1, 0, V3Params{})
+	if len(res) != len(targets) {
+		t.Fatalf("%d results for %d targets", len(res), len(targets))
+	}
+	for i, want := range targets {
+		if res[i].Target != want {
+			t.Errorf("position %d is %q, want %q — a caller zipping this against its own list "+
+				"would attribute one device's readings to another", i, res[i].Target, want)
+		}
+	}
+}
+
+// No OIDs is not an error, and must not open a connection.
+func TestGetManyWithNoOidsDoesNothing(t *testing.T) {
+	c := newHeadlessClient()
+	host, port := deadTarget(t)
+
+	start := time.Now()
+	res := c.GetMany([]string{host}, nil, "public", "v2c", port, 5, 3, V3Params{})
+	if len(res) != 0 {
+		t.Errorf("%d results for no OIDs", len(res))
+	}
+	if d := time.Since(start); d > time.Second {
+		t.Errorf("took %v with nothing to ask; it connected anyway", d.Round(time.Millisecond))
+	}
+}

--- a/pkg/snmp/operations.go
+++ b/pkg/snmp/operations.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -217,4 +218,132 @@ func (c *Client) walkSingle(target, oid, community, version string, port, timeou
 		Target: target,
 		Result: &Result{Oid: oid, Type: "WalkResponse", Value: results},
 	}, nil
+}
+
+// MultiResult is one target's answer to a batched GET: one entry per OID that
+// was asked for, keyed by the OID as it was REQUESTED rather than as the agent
+// spelled it back.
+//
+// Agents normalise: ask for `1.3.6.1.2.1.1.3.0` and the varbind can come back
+// as `.1.3.6.1.2.1.1.3.0`. Keying by the reply would then miss every lookup,
+// so the request order is what maps a varbind to its OID, with the name used
+// only to detect a reordered or short reply.
+type MultiResult struct {
+	Target         string             `json:"target"`
+	Results        map[string]*Result `json:"results"`
+	Errors         map[string]string  `json:"errors,omitempty"`
+	ResponseTimeMs int64              `json:"responseTimeMs"`
+}
+
+// maxVarbindsPerGet bounds one request.
+//
+// gosnmp refuses more than its MaxOids (60 by default) and its own comment
+// says a high value "can cause remote devices to fail". 30 is half that: large
+// enough that a realistic dashboard preset is one or two round trips, small
+// enough that the PDU stays well inside any agent's reply buffer.
+const maxVarbindsPerGet = 30
+
+// GetMany reads several OIDs from several targets, one connection per target.
+//
+// This replaces a loop that called Get once per OID. That loop opened a fresh
+// socket and asked for ONE varbind each time, and the OIDs were walked
+// SERIALLY while only the targets ran concurrently — so a session with ten
+// OIDs against an unreachable device spent ten full timeouts, one after
+// another, on the poll clock that runs with no window open. The interruption
+// check sat between OIDs, so a stop could not land inside that.
+//
+// Everything an agent is asked for now travels in one PDU per chunk: for the
+// usual session that is one round trip per target instead of one per OID.
+//
+// A connection failure is reported PER OID rather than once for the target.
+// The scheduler breaks a series on a failed reading, and a target-level error
+// that produced no per-OID entries would leave every series looking as though
+// nothing had been polled at all — which is indistinguishable from a paused
+// session.
+func (c *Client) GetMany(targets []string, oids []string, community, version string, port, timeoutSec, retries int, v3 V3Params) []*MultiResult {
+	out := make([]*MultiResult, 0, len(targets))
+	if len(oids) == 0 {
+		return out
+	}
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for _, target := range targets {
+		wg.Add(1)
+		go func(t string) {
+			defer wg.Done()
+			m := c.getManyOne(t, oids, community, version, port, timeoutSec, retries, v3)
+			mu.Lock()
+			out = append(out, m)
+			mu.Unlock()
+		}(target)
+	}
+	wg.Wait()
+
+	// Restore the caller's order: the goroutines finish in whatever order the
+	// network allows, and a caller that zips this against its target list would
+	// otherwise attribute one device's readings to another.
+	byTarget := make(map[string]*MultiResult, len(out))
+	for _, m := range out {
+		byTarget[m.Target] = m
+	}
+	ordered := make([]*MultiResult, 0, len(targets))
+	for _, t := range targets {
+		if m, ok := byTarget[t]; ok {
+			ordered = append(ordered, m)
+		}
+	}
+	return ordered
+}
+
+func (c *Client) getManyOne(target string, oids []string, community, version string, port, timeoutSec, retries int, v3 V3Params) *MultiResult {
+	start := time.Now()
+	m := &MultiResult{
+		Target:  target,
+		Results: make(map[string]*Result, len(oids)),
+		Errors:  make(map[string]string),
+	}
+	failAll := func(err error) *MultiResult {
+		for _, oid := range oids {
+			m.Errors[oid] = err.Error()
+		}
+		m.ResponseTimeMs = time.Since(start).Milliseconds()
+		return m
+	}
+
+	g, err := c.newGoSNMP(target, community, version, port, timeoutSec, retries, v3)
+	if err != nil {
+		return failAll(err)
+	}
+	if err := g.Connect(); err != nil {
+		return failAll(fmt.Errorf("connect failed: %v", err))
+	}
+	defer g.Conn.Close()
+
+	for from := 0; from < len(oids); from += maxVarbindsPerGet {
+		to := from + maxVarbindsPerGet
+		if to > len(oids) {
+			to = len(oids)
+		}
+		chunk := oids[from:to]
+
+		packet, err := g.Get(chunk)
+		if err != nil {
+			for _, oid := range chunk {
+				m.Errors[oid] = fmt.Sprintf("get failed: %v", err)
+			}
+			continue
+		}
+		for i, oid := range chunk {
+			if i >= len(packet.Variables) {
+				m.Errors[oid] = "no result returned"
+				continue
+			}
+			v := packet.Variables[i]
+			m.Results[oid] = &Result{Oid: v.Name, Type: v.Type.String(), Value: formatSnmpValue(v)}
+		}
+	}
+
+	m.ResponseTimeMs = time.Since(start).Milliseconds()
+	return m
 }


### PR DESCRIPTION
The prerequisite the feature study identified, and the only one of its findings I could confirm arithmetically rather than by reading.

## The defect

`scheduler.tick` walked `spec.OIDs` **serially**; `buildFetch` called `Client.Get` per OID; `getSingle` opens a fresh socket, connects, asks for **one** varbind and closes. Only the *targets* ran concurrently. And `ctx.Err()` was checked between OIDs only, so a stop could not land inside a fetch.

This is the path that matters most: the poll clock is what makes background mode real, and it runs with the window closed. A tick that cannot be interrupted for a minute delays breach detection, not a redraw.

## Measured

Six OIDs, one-second timeout, no retries, against a bound-then-closed UDP port:

| shape | elapsed |
| --- | --- |
| serial, one connection per OID | **6.005 s** |
| one PDU on one connection | **1.029 s** |

Constant in the OID count instead of linear. The test asserts the *shape* with three-fold headroom — a millisecond figure would be a flake on a loaded runner rather than a check. Proved fail-first: with the old shape restored, it reports `6 OIDs against an unreachable device took 6.005s`.

## Two details that are the whole correctness of it

**A failure is recorded per OID, never once for the target.** The scheduler breaks a series on a failed reading, so a target-level error producing no per-OID entries would leave every series with nothing recorded — indistinguishable from a session nobody started.

**Varbinds are paired with the request order, not the reply's name.** Agents normalise: ask for `1.3.6.1.2.1.1.3.0` and the answer can come back as `.1.3.6.1.2.1.1.3.0`, so keying on the reply would miss every lookup. The returned slice is also re-ordered to the caller's target list, because the goroutines finish in whatever order the network allows.

## Why `toReading` moved

It is re-keyed on the pieces rather than on a `*BulkResult` so the batched path uses the **same** rules. Those rules — the error sentinels, and which SNMP types are not numbers — are exactly what a second extraction would get subtly wrong: a copy that drifts shows a string OID as a chart point on one path and not the other.

Chunked at 30 varbinds per PDU: half gosnmp's `MaxOids`, whose own comment says a high value "can cause remote devices to fail".

## Checks

`go vet`, `staticcheck`, `go test -race -count=1 ./...` — 13 packages. The two `pkg/monitor` integration tests now drive `GetMany` against a real agent, which is a better test of the production path than the per-OID loop they replaced.
