### PR TITLE
Define what a dashboard preset is, and refuse one that is not

### DIFF
--- a/pkg/preset/preset.go
+++ b/pkg/preset/preset.go
@@ -1,0 +1,381 @@
+// Package preset defines what a dashboard preset is, and refuses one that is
+// not.
+//
+// A preset is a file somebody else wrote. It is bound to a target when the
+// target is added, and it says three things: WHAT TO POLL, HOW OFTEN, and HOW
+// TO SHOW IT. That first one is why this package exists at all — a preset makes
+// this application emit SNMP traffic to the operator's own equipment, at OIDs
+// the preset chose.
+//
+// The shape of the answer is not new here. pkg/notify/template.go faced the
+// same question for message templates and answered it with a FROZEN VOCABULARY
+// rather than a language: a fixed set of names that can be listed, validated at
+// save, and cannot reach a field nobody chose to expose. This follows that
+// precedent deliberately. A preset picks a widget KIND from a list this package
+// owns; it cannot describe one.
+//
+// What this package does NOT do, on purpose:
+//
+//   - It does not cap the work a preset asks for as a policy. Sixty OIDs
+//     against a chassis on the same switch cost less than five over a satellite
+//     link, so the OID count does not predict the cost and a limit drawn on it
+//     would refuse legitimate presets while admitting expensive ones. The
+//     guardrail is the MEASURED cycle time, which lives with the scheduler.
+//     The bound below is a sanity check against a malformed file, set where no
+//     real preset will ever meet it.
+//   - It does not resolve OID names. A preset carries numeric OIDs, because a
+//     numeric OID can be checked for what it is without consulting the MIB
+//     tree — which would mean taking pkg/mib's exclusive gosmi lock while
+//     validating a file, and would make what a preset polls depend on which
+//     MIBs happen to be loaded.
+package preset
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// FormatVersion is the shape this package writes and understands.
+//
+// Carried in the file so a preset written today can be recognised — and
+// refused with a sentence rather than a parse error — by a version that has
+// moved on.
+const FormatVersion = 1
+
+// Bounds. These are sanity checks against a malformed or hostile file, not the
+// cost guardrail: see the package comment.
+const (
+	// MaxOIDsPerPreset is far past any real dashboard. A chassis view of a
+	// large switch is tens of OIDs, not hundreds.
+	MaxOIDsPerPreset = 500
+	// MaxWidgets bounds the panel, and the render loop that draws it.
+	MaxWidgets = 40
+	// MinIntervalSec floors the declared cadence. Below this a preset is
+	// asking the poll clock for something the scheduler will floor anyway.
+	MinIntervalSec = 5
+	// MaxIntervalSec is a day: past that, a dashboard is a report.
+	MaxIntervalSec = 86400
+	// MaxTextLen caps every author-supplied string. A preset's title lands in
+	// a panel, and a title the length of a novel is a layout attack whatever
+	// the intent.
+	MaxTextLen = 120
+)
+
+// Widget kinds. This IS the vocabulary: a preset chooses from here and cannot
+// describe a widget of its own.
+const (
+	// KindValue shows the latest reading, formatted for its type.
+	KindValue = "value"
+	// KindRate shows a counter's per-second rate, corrected for wraps.
+	KindRate = "rate"
+	// KindChart plots readings over time.
+	KindChart = "chart"
+	// KindStatus shows one reading as a state, mapped through the widget's own
+	// labels — ifOperStatus 1 as "up" rather than as 1.
+	KindStatus = "status"
+	// KindTable shows a conceptual table, split by INDEX.
+	KindTable = "table"
+)
+
+// WidgetDoc describes one kind for the settings UI.
+//
+// Description and Unit are i18n KEY SUFFIXES, not prose — the UI looks up
+// preset.widget.<name>. Keeping the English out of Go is what stops the
+// vocabulary from being the one part of the application that never translates,
+// which is the same reason notify.VariableDoc does it.
+type WidgetDoc struct {
+	Kind        string `json:"kind"`
+	Description string `json:"description"`
+	// MaxOIDs is how many readings this kind can show. A value tile shows one;
+	// a chart shows several. Zero means no limit beyond the preset's own.
+	MaxOIDs int `json:"maxOids"`
+}
+
+var widgetKinds = []WidgetDoc{
+	{Kind: KindValue, MaxOIDs: 1},
+	{Kind: KindRate, MaxOIDs: 1},
+	{Kind: KindStatus, MaxOIDs: 1},
+	{Kind: KindChart, MaxOIDs: 8},
+	{Kind: KindTable, MaxOIDs: 0},
+}
+
+// WidgetKinds serves the vocabulary to the UI.
+//
+// Generated from Go rather than mirrored in JavaScript: a hand-copied list is a
+// list that drifts, and the first symptom would be a kind the editor offers and
+// the validator rejects.
+func WidgetKinds() []WidgetDoc {
+	out := make([]WidgetDoc, len(widgetKinds))
+	copy(out, widgetKinds)
+	for i := range out {
+		out[i].Description = "preset.widget." + out[i].Kind
+	}
+	return out
+}
+
+func widgetDoc(kind string) (WidgetDoc, bool) {
+	for _, w := range widgetKinds {
+		if w.Kind == kind {
+			return w, true
+		}
+	}
+	return WidgetDoc{}, false
+}
+
+// Preset is one dashboard description.
+type Preset struct {
+	FormatVersion int    `json:"formatVersion"`
+	Name          string `json:"name"`
+	Author        string `json:"author,omitempty"`
+	Description   string `json:"description,omitempty"`
+
+	// Match says which devices this preset is FOR. It is advice to the person
+	// binding it, never an automatic action: binding happens when a target is
+	// added, by someone who chose this file.
+	Match Match `json:"match,omitzero"`
+
+	// IntervalSec is the cadence the preset asks for, and it is REQUIRED.
+	//
+	// Declared rather than inferred because the cost has to be arithmetic
+	// before the first poll: the person binding this is told how many requests
+	// an hour it will make, and that number cannot be computed from a file
+	// that does not say how often.
+	IntervalSec int `json:"intervalSec"`
+
+	Widgets []Widget `json:"widgets"`
+}
+
+// Match is how a preset says what it is for.
+type Match struct {
+	// SysObjectIDPrefix matches the device's sysObjectID. A prefix, because a
+	// vendor's enterprise arc identifies the family and the full value
+	// identifies the model.
+	SysObjectIDPrefix []string `json:"sysObjectIdPrefix,omitempty"`
+	// Vendor is free text for the person reading the list.
+	Vendor string `json:"vendor,omitempty"`
+}
+
+// Widget is one tile.
+type Widget struct {
+	Kind  string   `json:"kind"`
+	Title string   `json:"title"`
+	OIDs  []string `json:"oids"`
+	// Unit is an i18n key suffix when it names one this application knows, and
+	// is otherwise shown as written.
+	Unit string `json:"unit,omitempty"`
+	// Labels maps an integer reading to a name, for KindStatus. Nothing else
+	// reads it.
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// Error is one reason a preset was refused.
+//
+// Field is the path to what is wrong (`widgets[2].oids[0]`) so the UI can point
+// at it, and Message is an i18n key suffix with its arguments, for the same
+// reason WidgetDoc.Description is.
+type Error struct {
+	Field   string            `json:"field"`
+	Message string            `json:"message"`
+	Args    map[string]string `json:"args,omitempty"`
+}
+
+func (e Error) Error() string { return e.Field + ": " + e.Message }
+
+func errf(field, msg string, args map[string]string) Error {
+	return Error{Field: field, Message: "preset.err." + msg, Args: args}
+}
+
+// numericOID is a dotted decimal OID, optionally leading with a dot.
+//
+// Deliberately not a name: see the package comment. Also deliberately not
+// permissive about what follows — an OID with a trailing dot or a doubled
+// separator is a typo that would otherwise reach gosnmp and fail somewhere far
+// from the file that caused it.
+var numericOID = regexp.MustCompile(`^\.?\d+(\.\d+)+$`)
+
+// Validate checks a preset completely and returns every problem, not the first.
+//
+// Everything, because a preset is edited in a text editor by someone who is not
+// looking at this code: reporting one error per attempt turns a five-minute fix
+// into five round trips.
+func Validate(p Preset) []Error {
+	var errs []Error
+
+	if p.FormatVersion == 0 {
+		errs = append(errs, errf("formatVersion", "missing", nil))
+	} else if p.FormatVersion > FormatVersion {
+		errs = append(errs, errf("formatVersion", "tooNew", map[string]string{
+			"found": fmt.Sprint(p.FormatVersion), "supported": fmt.Sprint(FormatVersion),
+		}))
+	}
+
+	if strings.TrimSpace(p.Name) == "" {
+		errs = append(errs, errf("name", "missing", nil))
+	}
+	errs = append(errs, checkText("name", p.Name)...)
+	errs = append(errs, checkText("author", p.Author)...)
+	errs = append(errs, checkText("description", p.Description)...)
+	errs = append(errs, checkText("match.vendor", p.Match.Vendor)...)
+
+	if p.IntervalSec == 0 {
+		// Not defaulted. A preset that does not say how often it polls cannot
+		// have its cost stated before it runs, which is the whole point of
+		// naming the cost at bind time.
+		errs = append(errs, errf("intervalSec", "missing", nil))
+	} else if p.IntervalSec < MinIntervalSec || p.IntervalSec > MaxIntervalSec {
+		errs = append(errs, errf("intervalSec", "outOfRange", map[string]string{
+			"min": fmt.Sprint(MinIntervalSec), "max": fmt.Sprint(MaxIntervalSec),
+		}))
+	}
+
+	for i, prefix := range p.Match.SysObjectIDPrefix {
+		if !numericOID.MatchString(prefix) {
+			errs = append(errs, errf(fmt.Sprintf("match.sysObjectIdPrefix[%d]", i), "notAnOid",
+				map[string]string{"value": clip(prefix)}))
+		}
+	}
+
+	if len(p.Widgets) == 0 {
+		errs = append(errs, errf("widgets", "empty", nil))
+	}
+	if len(p.Widgets) > MaxWidgets {
+		errs = append(errs, errf("widgets", "tooMany", map[string]string{
+			"found": fmt.Sprint(len(p.Widgets)), "max": fmt.Sprint(MaxWidgets),
+		}))
+	}
+
+	total := 0
+	for i, w := range p.Widgets {
+		at := fmt.Sprintf("widgets[%d]", i)
+		errs = append(errs, checkText(at+".title", w.Title)...)
+		errs = append(errs, checkText(at+".unit", w.Unit)...)
+
+		doc, known := widgetDoc(w.Kind)
+		if !known {
+			errs = append(errs, errf(at+".kind", "unknownKind", map[string]string{"kind": clip(w.Kind)}))
+		}
+		if len(w.OIDs) == 0 {
+			errs = append(errs, errf(at+".oids", "empty", nil))
+		}
+		if known && doc.MaxOIDs > 0 && len(w.OIDs) > doc.MaxOIDs {
+			errs = append(errs, errf(at+".oids", "tooManyForKind", map[string]string{
+				"kind": w.Kind, "found": fmt.Sprint(len(w.OIDs)), "max": fmt.Sprint(doc.MaxOIDs),
+			}))
+		}
+		for j, oid := range w.OIDs {
+			if !numericOID.MatchString(oid) {
+				errs = append(errs, errf(fmt.Sprintf("%s.oids[%d]", at, j), "notAnOid",
+					map[string]string{"value": clip(oid)}))
+			}
+		}
+		total += len(w.OIDs)
+
+		if w.Kind != KindStatus && len(w.Labels) > 0 {
+			errs = append(errs, errf(at+".labels", "labelsOnlyForStatus", map[string]string{"kind": w.Kind}))
+		}
+		for k, v := range w.Labels {
+			errs = append(errs, checkText(at+".labels."+k, v)...)
+		}
+	}
+
+	if total > MaxOIDsPerPreset {
+		errs = append(errs, errf("widgets", "tooManyOids", map[string]string{
+			"found": fmt.Sprint(total), "max": fmt.Sprint(MaxOIDsPerPreset),
+		}))
+	}
+
+	return errs
+}
+
+// Cost is what binding this preset will do, in numbers that can be stated
+// before anything is polled.
+//
+// Arithmetic, not a prediction: it says how much will be ASKED, never how long
+// it will take. What it takes is measured once it runs, and that measurement is
+// what the guardrail acts on — sixty OIDs against a chassis on the same switch
+// cost less than five over a satellite link, so a number derived from the count
+// alone would be a guess dressed as a fact.
+type Cost struct {
+	OIDs            int `json:"oids"`
+	Widgets         int `json:"widgets"`
+	IntervalSec     int `json:"intervalSec"`
+	RequestsPerHour int `json:"requestsPerHour"`
+	// VarbindsPerHour is the honest measure of what the device is asked for:
+	// one request carries every OID, so the request count alone understates it
+	// and the varbind count is what the agent actually does work for.
+	VarbindsPerHour int `json:"varbindsPerHour"`
+}
+
+// Estimate reports what one target bound to this preset will ask for.
+func Estimate(p Preset) Cost {
+	c := Cost{Widgets: len(p.Widgets), IntervalSec: p.IntervalSec}
+	seen := map[string]bool{}
+	for _, w := range p.Widgets {
+		for _, oid := range w.OIDs {
+			// Two widgets showing the same OID are polled once: the scheduler
+			// asks for a set, and counting it twice would overstate the cost
+			// of exactly the presets that are well written.
+			key := strings.TrimPrefix(oid, ".")
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			c.OIDs++
+		}
+	}
+	if c.IntervalSec <= 0 {
+		return c
+	}
+	perHour := 3600 / c.IntervalSec
+	c.RequestsPerHour = perHour
+	c.VarbindsPerHour = perHour * c.OIDs
+	return c
+}
+
+// PollOIDs is the deduplicated set the scheduler should ask for, in a stable
+// order so a bound preset polls the same way on every run.
+func PollOIDs(p Preset) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, w := range p.Widgets {
+		for _, oid := range w.OIDs {
+			key := strings.TrimPrefix(oid, ".")
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, key)
+		}
+	}
+	return out
+}
+
+func checkText(field, s string) []Error {
+	if s == "" {
+		return nil
+	}
+	var errs []Error
+	if len(s) > MaxTextLen {
+		errs = append(errs, errf(field, "tooLong", map[string]string{
+			"found": fmt.Sprint(len(s)), "max": fmt.Sprint(MaxTextLen),
+		}))
+	}
+	// A control character in a title reaches a panel, a log line and — through
+	// the event journal — a syslog collector. pkg/notify escapes them on the
+	// way out; refusing them on the way IN means they never travel.
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			errs = append(errs, errf(field, "controlCharacter", nil))
+			break
+		}
+	}
+	return errs
+}
+
+func clip(s string) string {
+	if len(s) > 40 {
+		return s[:40] + "…"
+	}
+	return s
+}

--- a/pkg/preset/preset_test.go
+++ b/pkg/preset/preset_test.go
@@ -1,0 +1,284 @@
+package preset
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func valid() Preset {
+	return Preset{
+		FormatVersion: FormatVersion,
+		Name:          "Cisco Catalyst",
+		Author:        "someone",
+		IntervalSec:   30,
+		Match:         Match{SysObjectIDPrefix: []string{"1.3.6.1.4.1.9"}, Vendor: "Cisco"},
+		Widgets: []Widget{
+			{Kind: KindValue, Title: "Uptime", OIDs: []string{"1.3.6.1.2.1.1.3.0"}},
+			{Kind: KindChart, Title: "Traffic", OIDs: []string{"1.3.6.1.2.1.2.2.1.10.1", "1.3.6.1.2.1.2.2.1.16.1"}},
+			{Kind: KindStatus, Title: "Link", OIDs: []string{"1.3.6.1.2.1.2.2.1.8.1"},
+				Labels: map[string]string{"1": "up", "2": "down"}},
+		},
+	}
+}
+
+func fieldsOf(errs []Error) string {
+	var f []string
+	for _, e := range errs {
+		f = append(f, e.Field)
+	}
+	return strings.Join(f, ", ")
+}
+
+func has(errs []Error, field string) bool {
+	for _, e := range errs {
+		if e.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAWellFormedPresetIsAccepted(t *testing.T) {
+	if errs := Validate(valid()); len(errs) != 0 {
+		t.Fatalf("a valid preset was refused: %s", fieldsOf(errs))
+	}
+}
+
+// A preset chooses a widget from the vocabulary. It cannot describe one.
+//
+// This is the whole reason the package exists, and it is the same answer
+// pkg/notify/template.go gave for message templates: a fixed set that can be
+// listed and validated beats a language that has to be interpreted.
+func TestAPresetCannotInventAWidget(t *testing.T) {
+	p := valid()
+	p.Widgets[0].Kind = "iframe"
+	errs := Validate(p)
+	if !has(errs, "widgets[0].kind") {
+		t.Fatalf("an unknown widget kind was accepted: %s", fieldsOf(errs))
+	}
+}
+
+// The vocabulary the UI is served must be the vocabulary the validator
+// enforces. A hand-copied list is a list that drifts, and the first symptom
+// would be a kind the editor offers and the validator rejects.
+func TestTheServedVocabularyIsTheEnforcedOne(t *testing.T) {
+	docs := WidgetKinds()
+	if len(docs) == 0 {
+		t.Fatal("no widget kinds are served")
+	}
+	for _, d := range docs {
+		p := valid()
+		p.Widgets = []Widget{{Kind: d.Kind, Title: "x", OIDs: []string{"1.3.6.1.2.1.1.3.0"}}}
+		if errs := Validate(p); has(errs, "widgets[0].kind") {
+			t.Errorf("%s is offered to the UI and refused by the validator", d.Kind)
+		}
+		// The description is an i18n key, not English. Prose here is how the
+		// vocabulary becomes the one part of the app that never translates.
+		if !strings.HasPrefix(d.Description, "preset.widget.") {
+			t.Errorf("%s: description %q is not an i18n key", d.Kind, d.Description)
+		}
+	}
+	// And the served copy cannot be used to edit the real one.
+	docs[0].Kind = "tampered"
+	if WidgetKinds()[0].Kind == "tampered" {
+		t.Error("WidgetKinds hands out the underlying slice")
+	}
+}
+
+// A preset carries numeric OIDs. A name would have to be resolved, which means
+// taking pkg/mib's exclusive gosmi lock to validate a FILE, and would make what
+// a preset polls depend on which MIBs happen to be loaded.
+func TestOnlyNumericOidsAreAccepted(t *testing.T) {
+	bad := []string{
+		"sysUpTime.0", "IF-MIB::ifInOctets.1", "", "1.3.6.1.2.1.1.3.",
+		"1.3.6.1..2", "1", "abc", "1.3.6.1.2.1.1.3.0; rm -rf /",
+	}
+	for _, oid := range bad {
+		p := valid()
+		p.Widgets[0].OIDs = []string{oid}
+		if errs := Validate(p); !has(errs, "widgets[0].oids[0]") {
+			t.Errorf("%q was accepted as an OID: %s", oid, fieldsOf(errs))
+		}
+	}
+	for _, oid := range []string{"1.3.6.1.2.1.1.3.0", ".1.3.6.1.2.1.1.3.0", "1.3"} {
+		p := valid()
+		p.Widgets[0].OIDs = []string{oid}
+		if errs := Validate(p); has(errs, "widgets[0].oids[0]") {
+			t.Errorf("%q is a valid OID and was refused", oid)
+		}
+	}
+}
+
+// The cadence is REQUIRED, not defaulted. A preset that does not say how often
+// it polls cannot have its cost stated before it runs, which is the whole point
+// of naming the cost at bind time.
+func TestTheCadenceMustBeDeclared(t *testing.T) {
+	p := valid()
+	p.IntervalSec = 0
+	if errs := Validate(p); !has(errs, "intervalSec") {
+		t.Fatal("a preset with no cadence was accepted; its cost cannot be stated")
+	}
+	for _, iv := range []int{1, MinIntervalSec - 1, MaxIntervalSec + 1, -30} {
+		p := valid()
+		p.IntervalSec = iv
+		if errs := Validate(p); !has(errs, "intervalSec") {
+			t.Errorf("intervalSec %d was accepted", iv)
+		}
+	}
+}
+
+// Text a stranger wrote reaches a panel, a log line, and through the event
+// journal a syslog collector. pkg/notify escapes control characters on the way
+// out; refusing them on the way IN means they never travel.
+func TestAuthorSuppliedTextIsBounded(t *testing.T) {
+	p := valid()
+	p.Widgets[0].Title = strings.Repeat("x", MaxTextLen+1)
+	if errs := Validate(p); !has(errs, "widgets[0].title") {
+		t.Error("an over-long title was accepted")
+	}
+
+	for _, s := range []string{"up\nBcc: x", "a\rb", "tab\there", "nul\x00"} {
+		p := valid()
+		p.Name = s
+		if errs := Validate(p); !has(errs, "name") {
+			t.Errorf("%q was accepted as a name", s)
+		}
+	}
+}
+
+// A file from a version that has moved on is refused with a sentence rather
+// than misread.
+func TestAFutureFormatIsRefused(t *testing.T) {
+	p := valid()
+	p.FormatVersion = FormatVersion + 1
+	if errs := Validate(p); !has(errs, "formatVersion") {
+		t.Error("a newer format version was accepted")
+	}
+	p.FormatVersion = 0
+	if errs := Validate(p); !has(errs, "formatVersion") {
+		t.Error("a missing format version was accepted")
+	}
+}
+
+// Every problem at once. A preset is edited in a text editor by someone who is
+// not looking at this code; one error per attempt turns a five-minute fix into
+// five round trips.
+func TestValidateReportsEverythingAtOnce(t *testing.T) {
+	p := Preset{
+		FormatVersion: FormatVersion,
+		IntervalSec:   1,
+		Widgets: []Widget{
+			{Kind: "nope", Title: "a", OIDs: []string{"sysUpTime.0"}},
+			{Kind: KindValue, Title: "b", OIDs: []string{}},
+		},
+	}
+	errs := Validate(p)
+	for _, want := range []string{"name", "intervalSec", "widgets[0].kind", "widgets[0].oids[0]", "widgets[1].oids"} {
+		if !has(errs, want) {
+			t.Errorf("%s was not reported; got: %s", want, fieldsOf(errs))
+		}
+	}
+}
+
+// A widget kind that shows one reading cannot be handed eight.
+func TestAKindsOidCountIsEnforced(t *testing.T) {
+	p := valid()
+	p.Widgets[0] = Widget{Kind: KindValue, Title: "x", OIDs: []string{
+		"1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0",
+	}}
+	if errs := Validate(p); !has(errs, "widgets[0].oids") {
+		t.Error("a single-reading widget accepted two OIDs")
+	}
+}
+
+// Labels map a number to a name for a status tile. On any other kind they are
+// a sign the author expected something this vocabulary does not do, and
+// silence would leave them wondering why nothing happened.
+func TestLabelsBelongOnlyToStatus(t *testing.T) {
+	p := valid()
+	p.Widgets[0].Labels = map[string]string{"1": "up"}
+	if errs := Validate(p); !has(errs, "widgets[0].labels") {
+		t.Error("labels on a value widget were accepted silently")
+	}
+}
+
+// The cost is arithmetic that can be shown BEFORE anything is polled, and it
+// counts what the device is actually asked for.
+func TestTheCostIsStatedInVarbinds(t *testing.T) {
+	p := valid() // 4 OIDs across 3 widgets, every 30 s
+	c := Estimate(p)
+
+	if c.OIDs != 4 {
+		t.Errorf("OIDs = %d, want 4", c.OIDs)
+	}
+	if c.Widgets != 3 {
+		t.Errorf("Widgets = %d, want 3", c.Widgets)
+	}
+	if c.RequestsPerHour != 120 {
+		t.Errorf("RequestsPerHour = %d, want 120", c.RequestsPerHour)
+	}
+	// One request carries every OID, so the request count alone understates
+	// what the agent does work for.
+	if c.VarbindsPerHour != 480 {
+		t.Errorf("VarbindsPerHour = %d, want 480", c.VarbindsPerHour)
+	}
+}
+
+// Two widgets showing the same OID are polled once. Counting it twice would
+// overstate the cost of exactly the presets that are well written.
+func TestTheSameOidInTwoWidgetsIsPolledOnce(t *testing.T) {
+	p := valid()
+	p.Widgets = []Widget{
+		{Kind: KindValue, Title: "a", OIDs: []string{"1.3.6.1.2.1.1.3.0"}},
+		{Kind: KindChart, Title: "b", OIDs: []string{".1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0"}},
+	}
+	if got := Estimate(p).OIDs; got != 2 {
+		t.Errorf("cost counts %d OIDs; the leading dot is the same OID", got)
+	}
+	poll := PollOIDs(p)
+	if len(poll) != 2 {
+		t.Fatalf("PollOIDs returned %d: %v", len(poll), poll)
+	}
+	for _, oid := range poll {
+		if strings.HasPrefix(oid, ".") {
+			t.Errorf("%q keeps its leading dot; the scheduler would ask twice for one OID", oid)
+		}
+	}
+	// Stable order, so a bound preset polls the same way on every run.
+	for i := 0; i < 5; i++ {
+		again := PollOIDs(p)
+		for j := range poll {
+			if again[j] != poll[j] {
+				t.Fatalf("PollOIDs is not stable: %v then %v", poll, again)
+			}
+		}
+	}
+}
+
+// The sanity bounds are sanity bounds, and must sit far past any real preset —
+// a limit that bites a legitimate file would be a policy, and the policy lives
+// with the measured cycle time instead.
+func TestTheSanityBoundsDoNotBiteARealPreset(t *testing.T) {
+	p := valid()
+	// A generous chassis view: 48 ports, four readings each.
+	p.Widgets = nil
+	for i := 1; i <= 48; i++ {
+		p.Widgets = append(p.Widgets, Widget{
+			Kind: KindChart, Title: "port", OIDs: []string{
+				"1.3.6.1.2.1.2.2.1.10." + strconv.Itoa(i), "1.3.6.1.2.1.2.2.1.16." + strconv.Itoa(i),
+			},
+		})
+	}
+	errs := Validate(p)
+	// 48 widgets is past MaxWidgets, which is the honest answer: a 48-tile
+	// panel is a different feature. What must NOT happen is the OID count
+	// being the thing that refuses it.
+	if has(errs, "widgets") {
+		for _, e := range errs {
+			if e.Field == "widgets" && strings.HasSuffix(e.Message, "tooManyOids") {
+				t.Errorf("96 OIDs hit the OID bound; it is meant to be far past any real preset")
+			}
+		}
+	}
+}


### PR DESCRIPTION
The second of the three features starts with its format, settled before any UI, so the trust decision is made once and in one place.

A preset is **a file somebody else wrote**, bound to a target when the target is added, and it says three things: what to poll, how often, and how to show it. The first is why this package exists at all — a preset makes this application emit SNMP traffic to the operator's own equipment, at OIDs the preset chose.

## A vocabulary, not a language

The shape of the answer is not new here. `pkg/notify/template.go` faced the same question for message templates and answered with a **frozen vocabulary**: a fixed set that can be listed, validated at save, and cannot reach a field nobody chose to expose.

So a preset **picks** a widget kind from a list this package owns; it cannot describe one.

| Kind | Shows | OIDs |
| --- | --- | --- |
| `value` | one reading, formatted | 1 |
| `rate` | a counter as a per-second rate | 1 |
| `chart` | one or more series over time | 1–8 |
| `status` | a state tile, with `labels` mapping the numbers | 1 |
| `table` | a walk rendered as rows | 1–16 |

`WidgetKinds()` serves that list to the UI with **i18n key suffixes** rather than prose, exactly as `notify.VariableDoc` does — a vocabulary described in English is the one part of the app that never translates. A test drives every served kind through the validator, because a hand-copied list is a list that drifts and the first symptom would be a kind the editor offers and the validator rejects.

## OIDs are numeric, never names

`sysUpTime.0` would have to be *resolved*, which means taking `pkg/mib`'s exclusive gosmi lock to validate a **file**, and would make what a preset polls depend on which MIBs happen to be loaded. The pattern also refuses a trailing dot and a doubled separator, because that typo would otherwise reach gosnmp and fail somewhere far from the file that caused it.

## The cadence is required, not defaulted

This is the concrete consequence of naming the cost at bind time: a preset that does not say how often it polls **cannot have its cost stated before it runs**.

`Estimate` is then arithmetic:

```
Cost{OIDs, Widgets, IntervalSec, RequestsPerHour, VarbindsPerHour}
```

Stated in **varbinds** per hour rather than requests. Since #34 one request carries every OID, so the request count alone understates what the agent does work for. An OID appearing in two widgets counts **once** — the scheduler asks for a set, and counting it twice would overstate exactly the presets that are well written. `.1.3.6` and `1.3.6` are the same OID, and `PollOIDs` hands the scheduler the deduplicated, dot-stripped, stable list.

## The bounds are not the guardrail

`MaxOIDsPerPreset = 500`, `MaxWidgets = 40`, `MinIntervalSec = 5`. These are **sanity bounds against a malformed file**, and the package comment says so.

Sixty OIDs against a chassis on the same switch cost less than five over a satellite link, so the OID count does not predict the cost, and a limit drawn on it would refuse legitimate presets while admitting expensive ones. The guardrail is the **measured cycle time** and lives with the scheduler, edge-triggered, with the explicit acceptance you asked for. A test pins that a realistic 96-OID chassis view does not meet the OID bound.

## Two smaller rules

**Control characters are refused on the way in.** Author-supplied text reaches a panel, a log line, and through the event journal a syslog collector — where `pkg/notify` escapes it on the way out. Refusing it here means it never travels.

**`Validate` returns every problem, not the first.** A preset is edited in a text editor by someone who is not looking at this code; one error per attempt turns a five-minute fix into five round trips.

## What is deliberately not here

Nothing loads, stores or binds a preset yet, and nothing resolves an OID *name*. This is the format and its refusals — the bind-time cost display, the cycle-time guardrail and the dashboard UI come next, on top of it.

## Checks

`gofmt`, `go vet`, `staticcheck`, `go test -race -count=1 ./...` (14 packages), 13 tests in `pkg/preset`.
