### PR TITLE
Name what a preset costs while it runs, and let the operator answer

### DIFF
--- a/app_monitor.go
+++ b/app_monitor.go
@@ -149,7 +149,59 @@ func (a *App) initScheduler() {
 	}
 
 	s.OnStateChange = a.refreshTrayStatus
+
+	// The guardrail's report. Two destinations, because the two questions are
+	// different: the journal answers "what happened while I was away" for an
+	// operator running with no window open, and the renderer is what actually
+	// ASKS — a slowdown the user is expected to accept explicitly has to be put
+	// in front of them.
+	s.OnOverrun = func(o monitor.Overrun) {
+		sev, detail := events.SevWarning, fmt.Sprintf(
+			"%q asks for a reading every %s but a round costs %s, so it now polls every %s "+
+				"(%d OIDs across %d target(s))",
+			o.Name, msText(o.IntervalMs), msText(o.CycleMs), msText(o.EffectiveMs), o.OIDs, o.Targets)
+		switch {
+		case o.Recovered:
+			sev = events.SevInfo
+			detail = fmt.Sprintf("%q is keeping up again and is back to a reading every %s",
+				o.Name, msText(o.IntervalMs))
+		case o.Accepted:
+			detail = fmt.Sprintf(
+				"%q asks for a reading every %s but a round costs %s; the slowdown has been "+
+					"accepted, so the cadence is unchanged", o.Name, msText(o.IntervalMs), msText(o.CycleMs))
+		}
+		_ = a.recordEvent(events.Event{
+			Category: events.CategorySystem,
+			Kind:     events.KindSystemInfo,
+			Severity: sev.String(),
+			TitleKey: "events.kind." + events.KindSystemInfo,
+			Params:   map[string]any{"detail": detail},
+			Summary:  detail,
+		}, "")
+		if a.ctx != nil {
+			runtime.EventsEmit(a.ctx, "monitor:overrun", o)
+		}
+	}
+
 	a.scheduler = s
+}
+
+// msText renders a millisecond count the way an operator reads a cadence.
+func msText(ms int) string {
+	return (time.Duration(ms) * time.Millisecond).Round(100 * time.Millisecond).String()
+}
+
+// MonitorAcceptSlow is the operator answering the overrun report: keep the
+// cadence I chose, I accept that it slows things down.
+//
+// It applies to the running session only. Nothing persists it, on purpose — a
+// decision about how hard to work THIS machine is not one to inherit silently
+// after a restart on another one.
+func (a *App) MonitorAcceptSlow(sessionID string) {
+	if a.scheduler == nil {
+		return
+	}
+	a.scheduler.AcceptSlow(sessionID)
 }
 
 // buildFetch closes over the connection so the scheduler never sees a
@@ -180,8 +232,11 @@ func (a *App) buildFetch(sess storage.Session) monitor.FetchFunc {
 	// five seconds was a fifty-second tick on the clock that runs with the
 	// window closed, and the scheduler could only check for a stop between
 	// OIDs, so it could not be interrupted.
-	return func(_ context.Context, oids []string, targets []string) []monitor.Reading {
-		results := a.snmpClient.GetMany(targets, oids, community, version, port, timeout, retries, v3)
+	return func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
+		// The poll's context reaches the wire. Chunking is serial within a
+		// target, so without it a stop waited for every remaining chunk's
+		// timeout — measured at 12.0 s for 90 OIDs against a silent device.
+		results := a.snmpClient.GetMany(ctx, targets, oids, community, version, port, timeout, retries, v3)
 		readings := make([]monitor.Reading, 0, len(results)*len(oids))
 		for _, m := range results {
 			for _, oid := range oids {

--- a/frontend/src/MonitorPanel.svelte
+++ b/frontend/src/MonitorPanel.svelte
@@ -6,7 +6,7 @@
   import { settingsStore } from './stores/settingsStore';
   import { notificationStore } from './stores/notifications';
   import { getTargetsAsArray } from './utils/targets';
-  import { formatTimeShort } from './utils/formatting';
+  import { formatTimeShort, formatCadence } from './utils/formatting';
   import { anonMode, anonymizeIp } from './utils/anonymize';
   import { targetLabels } from './stores/targetLabels';
   import { mibStore } from './stores/mibStore';
@@ -617,6 +617,34 @@
             </div>
           </div>
 
+          {#if session.overrun}
+            <div class="overrun-banner" role="status">
+              <Icon name="triangle-alert" size={14} />
+              <div class="overrun-text">
+                <strong>{$_('monitor.overrunTitle')}</strong>
+                {#if session.overrun.accepted}
+                  {$_('monitor.overrunAccepted', { values: {
+                    interval: formatCadence(session.overrun.intervalMs),
+                    cycle: formatCadence(session.overrun.cycleMs),
+                  } })}
+                {:else}
+                  {$_('monitor.overrunBody', { values: {
+                    interval: formatCadence(session.overrun.intervalMs),
+                    cycle: formatCadence(session.overrun.cycleMs),
+                    effective: formatCadence(session.overrun.effectiveMs),
+                  } })}
+                {/if}
+              </div>
+              {#if !session.overrun.accepted}
+                <button
+                  class="btn btn-small"
+                  title={$_('monitor.overrunAcceptHint')}
+                  on:click={() => pollingStore.acceptSlow(session.id)}
+                >{$_('monitor.overrunAccept')}</button>
+              {/if}
+            </div>
+          {/if}
+
           {#if !collapsed[session.id]}
           {#if showStats[session.id] && sessionStats[session.id]}
             <div class="stats-panel">
@@ -905,6 +933,24 @@
     border-radius: 6px;
     overflow: hidden;
     background-color: var(--bg-lighter-color);
+  }
+
+  /* The one thing on this card that asks a question rather than showing a
+     number, so it is the one thing that is not the card's own colour. */
+  .overrun-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.5rem 0.75rem;
+    border-top: 1px solid var(--border-color);
+    background-color: var(--warning-subtle);
+    color: var(--warning-color);
+    font-size: 0.82rem;
+  }
+
+  .overrun-text {
+    flex: 1;
+    min-width: 0;
   }
 
   .session-header {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -403,6 +403,11 @@
     "informNoAck": "keine Antwort vom Empfänger"
   },
   "monitor": {
+    "overrunTitle": "Takt nicht einhaltbar.",
+    "overrunBody": "Diese Sitzung verlangt alle {interval} einen Messwert, doch ein Durchlauf kostet {cycle}. Sie fragt jetzt alle {effective} ab, damit die Anwendung nicht durchgehend arbeitet.",
+    "overrunAccepted": "Diese Sitzung verlangt alle {interval} einen Messwert, und ein Durchlauf kostet {cycle}. Sie haben die Verlangsamung akzeptiert, der Takt bleibt unverändert.",
+    "overrunAccept": "Meinen Takt behalten",
+    "overrunAcceptHint": "Trotzdem im gewählten Takt abfragen. Die Anwendung arbeitet dann ununterbrochen und das Gerät wird ohne Pause befragt.",
     "live": "LIVE",
     "liveHint": "Wieder den neuesten Messwerten folgen (Zoomen oder Verschieben pausiert die Verfolgung)",
     "timebaseAll": "Alles",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -403,6 +403,11 @@
     "informNoAck": "no response from the receiver"
   },
   "monitor": {
+    "overrunTitle": "Cannot keep up.",
+    "overrunBody": "This session asks for a reading every {interval}, but one round costs {cycle}. It now polls every {effective}, so the application is not working the whole time.",
+    "overrunAccepted": "This session asks for a reading every {interval} and one round costs {cycle}. You accepted the slowdown, so the cadence is unchanged.",
+    "overrunAccept": "Keep my cadence",
+    "overrunAcceptHint": "Poll at the cadence you chose anyway. The application will then be working continuously and the device asked without pause.",
     "live": "LIVE",
     "liveHint": "Follow the newest samples again (zooming or panning pauses tracking)",
     "timebaseAll": "All",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -403,6 +403,11 @@
     "informNoAck": "sin respuesta del receptor"
   },
   "monitor": {
+    "overrunTitle": "Cadencia insostenible.",
+    "overrunBody": "Esta sesión pide una lectura cada {interval}, pero una ronda cuesta {cycle}. Ahora consulta cada {effective}, para que la aplicación no trabaje sin parar.",
+    "overrunAccepted": "Esta sesión pide una lectura cada {interval} y una ronda cuesta {cycle}. Ha aceptado la ralentización, así que la cadencia no cambia.",
+    "overrunAccept": "Mantener mi cadencia",
+    "overrunAcceptHint": "Consultar de todos modos con la cadencia elegida. La aplicación trabajará entonces de forma continua y se interrogará al equipo sin pausa.",
     "live": "LIVE",
     "liveHint": "Volver a seguir las últimas muestras (ampliar o desplazar pausa el seguimiento)",
     "timebaseAll": "Todo",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -403,6 +403,11 @@
     "informNoAck": "aucune réponse du récepteur"
   },
   "monitor": {
+    "overrunTitle": "Cadence intenable.",
+    "overrunBody": "Cette session demande une lecture toutes les {interval}, mais un tour coûte {cycle}. Elle interroge désormais toutes les {effective}, pour que l'application ne travaille pas en permanence.",
+    "overrunAccepted": "Cette session demande une lecture toutes les {interval} et un tour coûte {cycle}. Vous avez accepté le ralentissement : la cadence reste inchangée.",
+    "overrunAccept": "Garder ma cadence",
+    "overrunAcceptHint": "Interroger malgré tout à la cadence choisie. L'application travaillera alors en continu et l'équipement sera sollicité sans pause.",
     "live": "LIVE",
     "liveHint": "Suivre à nouveau les dernières mesures (zoomer ou déplacer met le suivi en pause)",
     "timebaseAll": "Tout",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -403,6 +403,11 @@
     "informNoAck": "接收方无响应"
   },
   "monitor": {
+    "overrunTitle": "无法保持该频率。",
+    "overrunBody": "此会话要求每 {interval} 采集一次，但一轮需要 {cycle}。现已改为每 {effective} 轮询一次，以免应用持续满负荷运行。",
+    "overrunAccepted": "此会话要求每 {interval} 采集一次，而一轮需要 {cycle}。您已接受由此带来的变慢，频率保持不变。",
+    "overrunAccept": "保持我的频率",
+    "overrunAcceptHint": "仍按所选频率轮询。应用将持续工作，设备也会被不间断地查询。",
     "live": "实时",
     "liveHint": "重新跟随最新采样（缩放或平移会暂停跟随）",
     "timebaseAll": "全部",

--- a/frontend/src/stores/pollingStore.js
+++ b/frontend/src/stores/pollingStore.js
@@ -9,6 +9,7 @@ import {
   MonitorLoadSessions,
   MonitorLoadSessionData,
   MonitorDeleteSession,
+  MonitorAcceptSlow,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 import { settingsStore } from './settingsStore';
@@ -85,6 +86,20 @@ function createPollingStore() {
       if (results.length > cap) results = results.slice(-cap);
       return { ...s, results, running: true };
     }));
+  });
+
+  // The poll clock reporting that a session cannot run as fast as it says.
+  //
+  // Edge-triggered in Go: one message when a session stops keeping up and one
+  // when it starts again, never one per tick. The decision is the operator's,
+  // so this is kept ON THE SESSION and rendered as a banner rather than raised
+  // as a toast — a toast is gone by the time anyone reads it, and what is being
+  // asked is a choice, not a notice.
+  EventsOn('monitor:overrun', (o) => {
+    if (!o || !o.sessionId) return;
+    update((sessions) => sessions.map((s) => (
+      s.id === o.sessionId ? { ...s, overrun: o.recovered ? null : o } : s
+    )));
   });
 
   // A point with neither a value nor an error came back as a type that cannot
@@ -327,8 +342,25 @@ function createPollingStore() {
   // Deferred initialization
   setTimeout(initFromBackend, 300);
 
+  // The operator's answer: keep the cadence I chose. Applied optimistically so
+  // the banner changes the moment it is clicked — Go has already decided, and
+  // the call cannot be refused.
+  async function acceptSlow(sessionId) {
+    update((sessions) => sessions.map((s) => (
+      s.id === sessionId && s.overrun
+        ? { ...s, overrun: { ...s.overrun, accepted: true, effectiveMs: s.overrun.intervalMs } }
+        : s
+    )));
+    try {
+      await MonitorAcceptSlow(sessionId);
+    } catch (e) {
+      console.error('MonitorAcceptSlow failed', e);
+    }
+  }
+
   return {
     subscribe,
+    acceptSlow,
     startPolling,
     resumeSession,
     stopPolling,

--- a/frontend/src/utils/formatting.js
+++ b/frontend/src/utils/formatting.js
@@ -35,6 +35,26 @@ export function formatDuration(ms) {
 }
 
 /**
+ * A poll PERIOD, as an operator reads one.
+ *
+ * Not formatDuration: that is for a measurement and answers "600.00s" where a
+ * cadence is read as "10 min". The unit is chosen from the size, and the
+ * decimal is dropped once it stops carrying information.
+ * @param {number} ms
+ * @returns {string}
+ */
+export function formatCadence(ms) {
+  const n = Number(ms);
+  if (!isFinite(n)) return '—';
+  if (n < 1000) return `${Math.round(n)} ms`;
+  const s = n / 1000;
+  if (s < 60) return `${Number(s.toFixed(s < 10 ? 1 : 0))} s`;
+  const m = s / 60;
+  if (m < 60) return `${Number(m.toFixed(m < 10 ? 1 : 0))} min`;
+  return `${Number((m / 60).toFixed(1))} h`;
+}
+
+/**
  * Format SNMP TimeTicks (hundredths of a second) to human-readable duration.
  * e.g. 1099992310 → "127d 3h 46m 23s"
  * @param {number} centiseconds

--- a/frontend/tests/polling.smoke.mjs
+++ b/frontend/tests/polling.smoke.mjs
@@ -11,7 +11,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-const calls = { created: [], started: [], stopped: [], saved: [] };
+const calls = { created: [], started: [], stopped: [], saved: [], accepted: [] };
 const handlers = {};
 
 globalThis.__stub = {
@@ -23,6 +23,7 @@ globalThis.__stub = {
   MonitorLoadSessions: async () => [],
   MonitorLoadSessionData: async () => [],
   MonitorDeleteSession: async () => {},
+  MonitorAcceptSlow: async (id) => { calls.accepted.push(id); },
   EventsOn: (name, fn) => { handlers[name] = fn; },
   // The settings store now seals its credentials through the bridge, and
   // pollingStore imports it. A store that is present and empty is the shape
@@ -43,6 +44,7 @@ export const MonitorSaveDataPoints = (...a) => s.MonitorSaveDataPoints(...a);
 export const MonitorLoadSessions = (...a) => s.MonitorLoadSessions(...a);
 export const MonitorLoadSessionData = (...a) => s.MonitorLoadSessionData(...a);
 export const MonitorDeleteSession = (...a) => s.MonitorDeleteSession(...a);
+export const MonitorAcceptSlow = (...a) => s.MonitorAcceptSlow(...a);
 export const EventsOn = (...a) => s.EventsOn(...a);
 export const ListMibFiles = async () => [];
 export const SettingsKeyStatus = (...a) => s.SettingsKeyStatus(...a);
@@ -188,6 +190,38 @@ check('the session reads as stopped', !!s && s.running === false);
   const source = readFileSync(new URL('../src/stores/pollingStore.js', import.meta.url), 'utf8');
   const uses = (source.match(/map\(normalisePoint\)/g) || []).length;
   check('both the live and the restored path go through it', uses === 2, String(uses));
+}
+
+// The guardrail's report, and the operator's answer to it.
+//
+// Go widens a session that cannot poll as fast as it promised and says so once.
+// That message has to reach the SESSION and stay there: it asks a question, and
+// a toast is gone before anyone reads it.
+{
+  check('the store subscribed to the overrun report', typeof handlers['monitor:overrun'] === 'function');
+
+  handlers['monitor:overrun']({
+    sessionId: id, name: 'smoke', intervalMs: 5000, cycleMs: 7400,
+    effectiveMs: 14800, oids: 2, targets: 2, accepted: false, recovered: false,
+  });
+  let o = get(pollingStore).find((x) => x.id === id).overrun;
+  check('the report landed on the session', !!o && o.cycleMs === 7400, JSON.stringify(o));
+
+  // Another session's report must not appear on this one.
+  handlers['monitor:overrun']({ sessionId: 'other', cycleMs: 1, effectiveMs: 2, intervalMs: 3 });
+  o = get(pollingStore).find((x) => x.id === id).overrun;
+  check('reports are routed by session id', o.cycleMs === 7400);
+
+  await pollingStore.acceptSlow(id);
+  o = get(pollingStore).find((x) => x.id === id).overrun;
+  check('accepting reached Go', calls.accepted.includes(id), JSON.stringify(calls.accepted));
+  check('and the banner says so at once rather than after the next round',
+    o.accepted === true && o.effectiveMs === o.intervalMs, JSON.stringify(o));
+
+  // Recovery clears it: the question has stopped being asked.
+  handlers['monitor:overrun']({ sessionId: id, intervalMs: 5000, cycleMs: 900, effectiveMs: 5000, recovered: true });
+  o = get(pollingStore).find((x) => x.id === id).overrun;
+  check('recovering takes the banner away', o === null, JSON.stringify(o));
 }
 
 process.exit(failures ? 1 : 0);

--- a/pkg/monitor/integration_test.go
+++ b/pkg/monitor/integration_test.go
@@ -52,9 +52,9 @@ func TestIntegrationSchedulerPollsARealAgent(t *testing.T) {
 	client := snmp.NewClient(context.Background())
 	// GetMany, which is what the scheduler drives in production: one
 	// connection per target with every OID in one PDU, against a real agent.
-	fetch := func(_ context.Context, oids []string, targets []string) []monitor.Reading {
+	fetch := func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
 		out := []monitor.Reading{}
-		for _, m := range client.GetMany(targets, oids, "public", "v2c", port, 2, 1, snmp.V3Params{}) {
+		for _, m := range client.GetMany(ctx, targets, oids, "public", "v2c", port, 2, 1, snmp.V3Params{}) {
 			for _, oid := range oids {
 				reading := monitor.Reading{
 					Target: m.Target, OID: oid,
@@ -146,9 +146,9 @@ func TestIntegrationUnreachableTargetIsRecorded(t *testing.T) {
 	_, port := agentAddr(t)
 
 	client := snmp.NewClient(context.Background())
-	fetch := func(_ context.Context, oids []string, targets []string) []monitor.Reading {
+	fetch := func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
 		out := []monitor.Reading{}
-		for _, m := range client.GetMany(targets, oids, "public", "v2c", port, 1, 0, snmp.V3Params{}) {
+		for _, m := range client.GetMany(ctx, targets, oids, "public", "v2c", port, 1, 0, snmp.V3Params{}) {
 			for _, oid := range oids {
 				out = append(out, monitor.Reading{Target: m.Target, OID: oid, Error: m.Errors[oid]})
 			}

--- a/pkg/monitor/overrun.go
+++ b/pkg/monitor/overrun.go
@@ -1,0 +1,188 @@
+package monitor
+
+import "time"
+
+// The guardrail: what happens when a session cannot poll as fast as it says.
+//
+// A preset is a file somebody else wrote, and it declares a cadence. Bind three
+// of them to a switch over a WAN link and the honest outcome is not an error —
+// it is a session whose poll round takes longer than its own period. Go's
+// ticker COALESCES the ticks it missed, so the loop is never idle: it finishes
+// a round and the next one is already due. The device is asked continuously,
+// the inserts never stop arriving on a database with a single writer, and
+// nothing anywhere says a word. The session simply stops meaning what it says —
+// "every 30 s" becomes "as fast as it can", which is a different product.
+//
+// Three rules carry this, and each is a defect in the version without it.
+//
+// THE MEASUREMENT IS THE CYCLE, NOT THE OID COUNT. Sixty OIDs against a chassis
+// on the same switch cost less than five over a satellite link, so no count
+// drawn on a preset predicts what it costs here — a bound on OIDs would refuse
+// legitimate presets while admitting expensive ones. That is why pkg/preset's
+// limits are sanity bounds and say so: the policy is this file.
+//
+// A CYCLE SPENT WAITING FOR A DEVICE THAT IS DOWN IS NOT EVIDENCE OF LOAD.
+// An unreachable target costs wall-clock and almost nothing else, and it is
+// precisely the moment monitoring matters: backing off there would slow down
+// the reachability detection during the outage it exists to report. So a round
+// where half the readings or more came back as errors counts neither way.
+//
+// RECOVERY IS JUDGED AGAINST THE REQUESTED INTERVAL, NEVER THE EFFECTIVE ONE.
+// Once backed off, every cycle fits the widened period trivially — judging
+// against it would recover on the next round, overrun again, and flap forever,
+// one report per tick. The hysteresis is the other half: a cycle has to fit in
+// HALF the requested interval to count as recovered, so a session sitting on
+// the boundary settles instead of oscillating.
+
+const (
+	// One slow round is a retransmit, not a condition. Three in a row is a
+	// condition.
+	overrunStreak = 3
+	recoverStreak = 3
+
+	// Recovered means comfortably inside, not barely inside.
+	recoverDivisor = 2
+
+	// The back-off targets a 50% duty cycle: half the time on the wire and in
+	// the database, half the time idle. Slowing to exactly the cycle time would
+	// leave the loop as busy as it was.
+	backoffHeadroom = 2
+
+	// And it is capped, so a monitoring can never quietly become hourly — and
+	// so that recovery, which is measured in cycles, stays timely: at eight
+	// times the interval, three good rounds are 24 periods away at worst, not
+	// an afternoon.
+	maxBackoffFactor = 8
+)
+
+// Overrun says a session cannot poll as fast as it promised, and what the
+// scheduler did about it. Milliseconds rather than time.Duration because this
+// struct exists to be REPORTED — it crosses the bridge and lands in the event
+// journal, where a nanosecond count is not a number anyone reads.
+type Overrun struct {
+	SessionID string `json:"sessionId"`
+	Name      string `json:"name"`
+	// What the session asked for.
+	IntervalMs int `json:"intervalMs"`
+	// What one round actually costs, measured end to end: the fetch, the
+	// persist, the threshold evaluation and the emit.
+	CycleMs int `json:"cycleMs"`
+	// What it polls at now. Equal to IntervalMs when the operator has accepted
+	// the slowdown, or when this edge is the recovery.
+	EffectiveMs int `json:"effectiveMs"`
+	OIDs        int `json:"oids"`
+	Targets     int `json:"targets"`
+	// Accepted: the operator was shown this and chose to keep the cadence.
+	Accepted bool `json:"accepted"`
+	// Recovered: this edge is the return to normal, not the departure from it.
+	Recovered bool `json:"recovered"`
+}
+
+// cycleStat is one poll round, measured.
+type cycleStat struct {
+	dur      time.Duration
+	readings int
+	failed   int
+}
+
+// evidence reports whether this round says anything about LOAD.
+//
+// A round with no readings at all measured nothing. A round where half the
+// readings or more are errors measured a timeout, and a timeout is the device
+// being unreachable rather than this application being overloaded.
+func (c cycleStat) evidence() bool {
+	return c.readings > 0 && c.failed*2 < c.readings
+}
+
+// overrunGuard is the state of one session's guardrail. Pure: it holds no
+// clock, takes no lock and touches nothing outside itself, so the whole policy
+// is testable without waiting for anything.
+type overrunGuard struct {
+	interval    time.Duration
+	accepted    bool
+	over, under int
+	engaged     bool
+	cycle       time.Duration
+	effective   time.Duration
+}
+
+func newOverrunGuard(interval time.Duration, accepted bool) *overrunGuard {
+	return &overrunGuard{interval: interval, accepted: accepted, effective: interval}
+}
+
+// observe feeds one round in and returns the edge to report, or nil.
+//
+// One report per EPISODE, not per tick: an operator who left a preset running
+// overnight must find one line saying it could not keep up, not four thousand.
+// The scheduler still widens further, silently, if a session gets worse while
+// already engaged — the number in the first report is what it cost then, and
+// re-reporting every degradation is the flapping this avoids.
+func (g *overrunGuard) observe(c cycleStat) *Overrun {
+	if !c.evidence() {
+		return nil
+	}
+
+	if c.dur > g.interval {
+		g.under = 0
+		g.over++
+		if !g.engaged && g.over >= overrunStreak {
+			g.engaged = true
+			g.cycle = c.dur
+			g.effective = g.backoff(c.dur)
+			return g.edge(false)
+		}
+		if g.engaged && c.dur > g.cycle {
+			g.cycle = c.dur
+			g.effective = g.backoff(c.dur)
+		}
+		return nil
+	}
+
+	g.over = 0
+	// Against the REQUESTED interval. See the note at the top of this file.
+	if c.dur*recoverDivisor > g.interval {
+		return nil
+	}
+	g.under++
+	if g.engaged && g.under >= recoverStreak {
+		g.engaged = false
+		g.cycle = c.dur
+		g.effective = g.interval
+		return g.edge(true)
+	}
+	return nil
+}
+
+// accept is the operator saying "yes, I know, keep the cadence I chose".
+//
+// It undoes the back-off immediately rather than at the next round, because the
+// next round can be eight intervals away — waiting it out would make the button
+// look broken.
+func (g *overrunGuard) accept() {
+	g.accepted = true
+	g.effective = g.interval
+}
+
+func (g *overrunGuard) backoff(cycle time.Duration) time.Duration {
+	if g.accepted {
+		return g.interval
+	}
+	d := cycle * backoffHeadroom
+	if capped := g.interval * maxBackoffFactor; d > capped {
+		d = capped
+	}
+	if d < g.interval {
+		d = g.interval
+	}
+	return d
+}
+
+func (g *overrunGuard) edge(recovered bool) *Overrun {
+	return &Overrun{
+		IntervalMs:  int(g.interval / time.Millisecond),
+		CycleMs:     int(g.cycle / time.Millisecond),
+		EffectiveMs: int(g.effective / time.Millisecond),
+		Accepted:    g.accepted,
+		Recovered:   recovered,
+	}
+}

--- a/pkg/monitor/overrun_test.go
+++ b/pkg/monitor/overrun_test.go
@@ -1,0 +1,371 @@
+package monitor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func fits(d time.Duration) cycleStat { return cycleStat{dur: d, readings: 4} }
+
+func timeouts(d time.Duration) cycleStat {
+	return cycleStat{dur: d, readings: 4, failed: 4}
+}
+
+// Three rounds that do not fit is a condition. One is a retransmit.
+func TestOneSlowRoundIsNotAnOverrun(t *testing.T) {
+	g := newOverrunGuard(time.Second, false)
+	if o := g.observe(fits(2 * time.Second)); o != nil {
+		t.Fatal("one slow round engaged the guardrail")
+	}
+	if o := g.observe(fits(100 * time.Millisecond)); o != nil {
+		t.Fatal("a fast round reported something")
+	}
+	// The streak restarts: two slow rounds either side of a fast one is not
+	// three in a row.
+	g.observe(fits(2 * time.Second))
+	if o := g.observe(fits(2 * time.Second)); o != nil {
+		t.Fatal("the streak did not restart after a round that fitted")
+	}
+	if o := g.observe(fits(2 * time.Second)); o == nil {
+		t.Fatal("three rounds in a row did not engage the guardrail")
+	}
+}
+
+// What it does about it: widen the period so the loop is idle half the time.
+func TestEngagingWidensThePeriodAndSaysSo(t *testing.T) {
+	g := newOverrunGuard(time.Second, false)
+	var edge *Overrun
+	for i := 0; i < overrunStreak; i++ {
+		edge = g.observe(fits(1500 * time.Millisecond))
+	}
+	if edge == nil {
+		t.Fatal("no edge was reported")
+	}
+	if edge.IntervalMs != 1000 || edge.CycleMs != 1500 {
+		t.Errorf("the report does not say what happened: %+v", edge)
+	}
+	if edge.EffectiveMs != 3000 {
+		t.Errorf("EffectiveMs = %d, want 3000 (twice the cycle: half the time idle)", edge.EffectiveMs)
+	}
+	if edge.Recovered || edge.Accepted {
+		t.Errorf("a departure was reported as a recovery or as accepted: %+v", edge)
+	}
+	if g.effective != 3*time.Second {
+		t.Errorf("the guard polls at %v, not the period it reported", g.effective)
+	}
+}
+
+// One line in the journal, not four thousand.
+func TestOneReportPerEpisode(t *testing.T) {
+	g := newOverrunGuard(time.Second, false)
+	reports := 0
+	for i := 0; i < 50; i++ {
+		if g.observe(fits(1500*time.Millisecond)) != nil {
+			reports++
+		}
+	}
+	if reports != 1 {
+		t.Fatalf("%d reports for one episode", reports)
+	}
+	// It still widens further, silently, if the session gets worse.
+	g.observe(fits(4 * time.Second))
+	if g.effective != 8*time.Second {
+		t.Errorf("effective = %v; a worse cycle did not widen the period", g.effective)
+	}
+}
+
+// The back-off is capped, so a monitoring can never quietly become hourly and
+// recovery, which is counted in rounds, stays reachable.
+func TestTheBackoffIsCapped(t *testing.T) {
+	g := newOverrunGuard(10*time.Second, false)
+	for i := 0; i < overrunStreak; i++ {
+		g.observe(fits(10 * time.Minute))
+	}
+	if want := 10 * time.Second * maxBackoffFactor; g.effective != want {
+		t.Errorf("effective = %v, want the cap %v", g.effective, want)
+	}
+}
+
+// A cycle spent waiting for a device that is not answering measures the
+// network, not this application. Backing off there would slow the reachability
+// detection down at the exact moment monitoring matters.
+//
+// Measured, so the shape is not hypothetical: 30 OIDs against a silent agent
+// cost 4.0 s at the default two-second timeout with one retry, and 60 OIDs cost
+// 8.0 s — comfortably past any interval a preset may declare.
+func TestTimeoutsAreNotEvidenceOfLoad(t *testing.T) {
+	g := newOverrunGuard(time.Second, false)
+	for i := 0; i < 20; i++ {
+		if o := g.observe(timeouts(8 * time.Second)); o != nil {
+			t.Fatalf("round %d: an unreachable device engaged the load guardrail", i)
+		}
+	}
+	if g.engaged {
+		t.Error("the guardrail engaged on timeouts")
+	}
+	// Half failing is still not evidence; a majority answering is.
+	g2 := newOverrunGuard(time.Second, false)
+	for i := 0; i < overrunStreak; i++ {
+		g2.observe(cycleStat{dur: 8 * time.Second, readings: 4, failed: 2})
+	}
+	if g2.engaged {
+		t.Error("half the readings failing was read as load")
+	}
+	g3 := newOverrunGuard(time.Second, false)
+	for i := 0; i < overrunStreak; i++ {
+		g3.observe(cycleStat{dur: 2 * time.Second, readings: 4, failed: 1})
+	}
+	if !g3.engaged {
+		t.Error("a mostly-answering round was not counted as load")
+	}
+	// A round that produced no readings at all measured nothing.
+	g4 := newOverrunGuard(time.Second, false)
+	for i := 0; i < overrunStreak; i++ {
+		g4.observe(cycleStat{dur: 8 * time.Second})
+	}
+	if g4.engaged {
+		t.Error("a round with no readings was read as load")
+	}
+}
+
+// Recovery is judged against the REQUESTED interval. Judged against the widened
+// one, every round fits trivially and the guard flaps: recover, overrun,
+// recover, one report per tick, forever.
+func TestRecoveryIsJudgedAgainstTheRequestedInterval(t *testing.T) {
+	g := newOverrunGuard(time.Second, false)
+	for i := 0; i < overrunStreak; i++ {
+		g.observe(fits(1500 * time.Millisecond))
+	}
+	if !g.engaged {
+		t.Fatal("setup: the guard did not engage")
+	}
+
+	// 1.2 s fits comfortably inside the 3 s effective period and is still an
+	// overrun of the second the session promised.
+	for i := 0; i < 10; i++ {
+		if o := g.observe(fits(1200 * time.Millisecond)); o != nil {
+			t.Fatalf("round %d recovered against the widened period: %+v", i, o)
+		}
+	}
+
+	// Barely inside the requested interval is not recovered either: hysteresis
+	// is what stops a session on the boundary oscillating.
+	for i := 0; i < 10; i++ {
+		if o := g.observe(fits(900 * time.Millisecond)); o != nil {
+			t.Fatalf("round %d recovered on a cycle that barely fits: %+v", i, o)
+		}
+	}
+
+	var edge *Overrun
+	for i := 0; i < recoverStreak; i++ {
+		edge = g.observe(fits(200 * time.Millisecond))
+	}
+	if edge == nil {
+		t.Fatal("comfortably fast rounds never recovered")
+	}
+	if !edge.Recovered || edge.EffectiveMs != 1000 {
+		t.Errorf("the recovery does not restore the requested cadence: %+v", edge)
+	}
+	if g.effective != time.Second {
+		t.Errorf("the guard still polls at %v", g.effective)
+	}
+}
+
+// Accepting is the operator's decision, and it is about the CADENCE, not about
+// silence: the report still fires, because that is what asks them.
+func TestAcceptingKeepsTheCadenceAndStillReports(t *testing.T) {
+	g := newOverrunGuard(time.Second, true)
+	var edge *Overrun
+	for i := 0; i < overrunStreak; i++ {
+		edge = g.observe(fits(5 * time.Second))
+	}
+	if edge == nil {
+		t.Fatal("an accepted session reported nothing at all")
+	}
+	if !edge.Accepted || edge.EffectiveMs != 1000 {
+		t.Errorf("an accepted session was slowed down anyway: %+v", edge)
+	}
+	if g.effective != time.Second {
+		t.Errorf("effective = %v; acceptance did not keep the cadence", g.effective)
+	}
+}
+
+// Answering the report restores the cadence at once, because the next round can
+// be eight periods away and a button that takes eight periods looks broken.
+func TestAcceptingWhileBackedOffTakesEffectImmediately(t *testing.T) {
+	g := newOverrunGuard(time.Second, false)
+	for i := 0; i < overrunStreak; i++ {
+		g.observe(fits(4 * time.Second))
+	}
+	if g.effective == time.Second {
+		t.Fatal("setup: the guard did not back off")
+	}
+	g.accept()
+	if g.effective != time.Second {
+		t.Fatalf("effective = %v after accepting, want the requested second", g.effective)
+	}
+	// And it stays accepted for the rest of the session.
+	for i := 0; i < overrunStreak; i++ {
+		g.observe(fits(4 * time.Second))
+	}
+	if g.effective != time.Second {
+		t.Errorf("effective = %v; the guard backed off again after being accepted", g.effective)
+	}
+}
+
+/* --- the scheduler end ---------------------------------------------------- */
+
+// The guardrail on the real clock: a session whose round does not fit reports
+// once and starts polling at the widened period.
+func TestASlowSessionIsReportedAndSlowedDown(t *testing.T) {
+	// At minInterval, the floor: a fast session is where a round that does not
+	// fit is easiest to produce, and the floor is what a preset at
+	// pkg/preset's MinIntervalSec would land near on a slow link.
+	const interval = minInterval
+	const round = 300 * time.Millisecond
+
+	var mu sync.Mutex
+	var starts []time.Time
+	var edges []Overrun
+
+	s := NewScheduler()
+	s.Persist = func([]Point) {}
+	s.OnOverrun = func(o Overrun) {
+		mu.Lock()
+		edges = append(edges, o)
+		mu.Unlock()
+	}
+	s.Start(SessionSpec{
+		ID: "slow", Name: "slow", OIDs: []string{"1.1"}, Targets: []string{"a"},
+		Interval: interval,
+		Fetch: func(_ context.Context, oids, targets []string) []Reading {
+			mu.Lock()
+			starts = append(starts, time.Now())
+			mu.Unlock()
+			time.Sleep(round)
+			v := 1.0
+			return []Reading{{Target: targets[0], OID: oids[0], Value: &v, SnmpType: "Counter32"}}
+		},
+	})
+	time.Sleep(3 * time.Second)
+	s.StopAll()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(edges) != 1 {
+		t.Fatalf("%d reports, want exactly one: %+v", len(edges), edges)
+	}
+	e := edges[0]
+	if e.SessionID != "slow" || e.Name != "slow" || e.OIDs != 1 || e.Targets != 1 {
+		t.Errorf("the report does not identify the session: %+v", e)
+	}
+	if e.EffectiveMs <= e.IntervalMs {
+		t.Errorf("reported effective %d ms is not wider than the %d ms asked for", e.EffectiveMs, e.IntervalMs)
+	}
+
+	// And the widening is real, not just reported. Before it, the ticker
+	// coalesces and the next round starts the moment the last one ends.
+	if len(starts) < overrunStreak+1 {
+		t.Fatalf("only %d rounds ran; the test is too short to see the change", len(starts))
+	}
+	gap := starts[len(starts)-1].Sub(starts[len(starts)-2])
+	if gap < round+30*time.Millisecond {
+		t.Errorf("the last gap was %v, no wider than the round itself: the loop is still saturated",
+			gap.Round(time.Millisecond))
+	}
+}
+
+// A cancelled round must not be stored. Once the fetch honours the context, what
+// it returns on a stop is one error per OID — persisting those breaks every
+// series, and the evaluator reads them as a device that stopped answering.
+func TestACancelledRoundIsNotPersisted(t *testing.T) {
+	entered := make(chan struct{})
+	var mu sync.Mutex
+	persisted := 0
+
+	s := NewScheduler()
+	s.Persist = func(p []Point) {
+		mu.Lock()
+		persisted += len(p)
+		mu.Unlock()
+	}
+	s.Start(SessionSpec{
+		ID: "cancelled", OIDs: []string{"1.1"}, Targets: []string{"a"},
+		Interval: time.Hour,
+		Fetch: func(ctx context.Context, oids, targets []string) []Reading {
+			close(entered)
+			<-ctx.Done()
+			// What a cancelled GetMany answers: an error for every OID.
+			return []Reading{{Target: targets[0], OID: oids[0], Error: "context canceled"}}
+		},
+	})
+	<-entered
+	s.Stop("cancelled")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if persisted != 0 {
+		t.Fatalf("%d points from a cancelled round reached storage", persisted)
+	}
+}
+
+// The operator's answer reaches the running loop: the cadence they chose comes
+// back, without restarting the session and losing the baselines every rate is
+// derived from.
+func TestAcceptSlowRestoresTheCadenceOfARunningSession(t *testing.T) {
+	const interval = minInterval
+	const round = 300 * time.Millisecond
+
+	var mu sync.Mutex
+	var starts []time.Time
+	reported := make(chan struct{}, 1)
+
+	s := NewScheduler()
+	s.Persist = func([]Point) {}
+	s.OnOverrun = func(o Overrun) {
+		select {
+		case reported <- struct{}{}:
+		default:
+		}
+	}
+	s.Start(SessionSpec{
+		ID: "answered", OIDs: []string{"1.1"}, Targets: []string{"a"},
+		Interval: interval,
+		Fetch: func(_ context.Context, oids, targets []string) []Reading {
+			mu.Lock()
+			starts = append(starts, time.Now())
+			mu.Unlock()
+			time.Sleep(round)
+			v := 1.0
+			return []Reading{{Target: targets[0], OID: oids[0], Value: &v, SnmpType: "Counter32"}}
+		},
+	})
+	defer s.StopAll()
+
+	select {
+	case <-reported:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the session never reported that it could not keep up")
+	}
+
+	s.AcceptSlow("answered")
+	s.AcceptSlow("no such session") // must not panic
+
+	mu.Lock()
+	from := len(starts)
+	mu.Unlock()
+	time.Sleep(time.Second)
+
+	mu.Lock()
+	defer mu.Unlock()
+	after := starts[from:]
+	if len(after) < 2 {
+		t.Fatalf("%d rounds in the second after accepting; the back-off is still in force", len(after))
+	}
+	// Back to running flat out, which is what accepting the slowdown means.
+	if gap := after[1].Sub(after[0]); gap > round+120*time.Millisecond {
+		t.Errorf("gap after accepting is %v; the cadence was not restored", gap.Round(time.Millisecond))
+	}
+}

--- a/pkg/monitor/scheduler.go
+++ b/pkg/monitor/scheduler.go
@@ -60,6 +60,10 @@ type SessionSpec struct {
 	Interval   time.Duration
 	Thresholds map[string]*Threshold
 	Fetch      FetchFunc
+	// AcceptSlow is the operator having been shown that this session cannot
+	// poll as fast as it asks, and having chosen to keep the cadence anyway.
+	// It suppresses the back-off, never the report: see overrun.go.
+	AcceptSlow bool
 }
 
 // minInterval floors the poll period. A zero or negative interval from a
@@ -87,6 +91,12 @@ type Scheduler struct {
 	Emit func(sessionID string, points []Point)
 	// OnStateChange fires when a session starts or stops, for the tray read-out.
 	OnStateChange func()
+	// OnOverrun reports that a session cannot poll as fast as it promised, and
+	// what the scheduler did about it. Edge-triggered: once when a session
+	// stops keeping up, once when it starts again. Called on the poll
+	// goroutine, so a handler that blocks delays that session's next round —
+	// which is why it fires once per episode rather than once per tick.
+	OnOverrun func(o Overrun)
 	// Now is injectable so tests are not at the mercy of the wall clock.
 	Now func() time.Time
 }
@@ -94,6 +104,10 @@ type Scheduler struct {
 type handle struct {
 	cancel context.CancelFunc
 	done   chan struct{}
+	// accept carries the operator's answer to an overrun report into the loop
+	// goroutine. Buffered, and sent to without blocking, because the caller is
+	// a bound method on the Wails thread and must never wait on a poll.
+	accept chan struct{}
 }
 
 // NewScheduler returns an idle scheduler.
@@ -124,7 +138,7 @@ func (s *Scheduler) Start(spec SessionSpec) {
 		return
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	h := &handle{cancel: cancel, done: make(chan struct{})}
+	h := &handle{cancel: cancel, done: make(chan struct{}), accept: make(chan struct{}, 1)}
 	s.running[spec.ID] = h
 	s.mu.Unlock()
 
@@ -172,6 +186,29 @@ func (s *Scheduler) loop(ctx context.Context, h *handle, spec SessionSpec) {
 	ticker := time.NewTicker(spec.Interval)
 	defer ticker.Stop()
 
+	// The guardrail. It reads the CYCLE TIME rather than anything declared,
+	// widens the period when a session cannot keep up, and reports the edge so
+	// the operator can accept the slowdown instead of having it chosen for
+	// them. All of the policy is in overrun.go, which holds no clock.
+	guard := newOverrunGuard(spec.Interval, spec.AcceptSlow)
+	effective := spec.Interval
+	recadence := func() {
+		if guard.effective != effective {
+			effective = guard.effective
+			ticker.Reset(effective)
+		}
+	}
+	report := func(o *Overrun) {
+		if o == nil {
+			return
+		}
+		o.SessionID, o.Name = spec.ID, spec.Name
+		o.OIDs, o.Targets = len(spec.OIDs), len(spec.Targets)
+		if s.OnOverrun != nil {
+			s.OnOverrun(*o)
+		}
+	}
+
 	// Spread the first poll, then keep the promise of a prompt first point.
 	//
 	// Measured before this existed: twenty sessions started back to back — which
@@ -197,32 +234,68 @@ func (s *Scheduler) loop(ctx context.Context, h *handle, spec SessionSpec) {
 		case <-timer.C:
 		}
 	}
-	s.tick(ctx, spec, last)
+	report(guard.observe(s.tick(ctx, spec, last)))
+	recadence()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
+		case <-h.accept:
+			// Answered while backed off, so the cadence is restored now rather
+			// than at the next round — which can be eight periods away.
+			guard.accept()
+			recadence()
 		case <-ticker.C:
 			// A poll slower than the interval simply delays the next tick.
 			// Go coalesces the missed ticks, so a struggling agent can never
-			// pile up overlapping rounds against itself.
-			s.tick(ctx, spec, last)
+			// pile up overlapping rounds against itself — and that coalescing
+			// is exactly why the guardrail is needed: the loop stops being
+			// idle and nothing about it looks wrong.
+			report(guard.observe(s.tick(ctx, spec, last)))
+			recadence()
 		}
 	}
 }
 
-func (s *Scheduler) tick(ctx context.Context, spec SessionSpec, last map[string]lastSample) {
+// tick runs one poll round and returns what it cost.
+//
+// The measurement covers the WHOLE round — the fetch, the persist, the
+// threshold evaluation and the emit — because all four are the load, and the
+// question the guardrail answers is whether a round fits inside the period the
+// session promised.
+func (s *Scheduler) tick(ctx context.Context, spec SessionSpec, last map[string]lastSample) cycleStat {
 	now := s.now()
 	stamp := now.UTC().Format(time.RFC3339Nano)
+	started := time.Now()
+	stat := cycleStat{}
 
 	var points []Point
 	var samples []Sample
 
 	if ctx.Err() != nil {
-		return
+		return stat
 	}
-	for _, r := range spec.Fetch(ctx, spec.OIDs, spec.Targets) {
+	readings := spec.Fetch(ctx, spec.OIDs, spec.Targets)
+	if ctx.Err() != nil {
+		// A CANCELLED round is not a measurement, and must not be stored.
+		//
+		// This became load-bearing the moment the fetch started honouring the
+		// context: what a cancelled poll returns is one error per OID, and
+		// persisting those breaks every series while the evaluator reads them
+		// as a device that stopped answering. Pressing Stop would have raised
+		// an unreachability alert on a healthy switch.
+		return stat
+	}
+	for _, r := range readings {
+		stat.readings++
+		if r.Error != "" {
+			// An ERROR, not a nil value: a string OID answers with no numeric
+			// value and no error at all, and counting that as a failure would
+			// leave a session polling sysDescr with a guardrail that can never
+			// engage.
+			stat.failed++
+		}
 		oid := r.OID
 		key := r.Target + "|" + oid
 		p := Point{
@@ -259,7 +332,7 @@ func (s *Scheduler) tick(ctx context.Context, spec SessionSpec, last map[string]
 	}
 
 	if len(points) == 0 {
-		return
+		return stat
 	}
 	if s.Persist != nil {
 		s.Persist(points)
@@ -270,6 +343,30 @@ func (s *Scheduler) tick(ctx context.Context, spec SessionSpec, last map[string]
 	}
 	if s.Emit != nil {
 		s.Emit(spec.ID, points)
+	}
+	// Wall clock deliberately, not s.Now: this measures how long the round
+	// actually took, and s.Now is injected by tests that move time in jumps.
+	stat.dur = time.Since(started)
+	return stat
+}
+
+// AcceptSlow is the operator answering an overrun report: keep the cadence I
+// chose, I accept that it slows things down. It applies to the running session
+// and takes effect at once.
+//
+// Not persisted here on purpose — the scheduler holds no storage. A session
+// resumed after a restart asks again, which is the right default for a decision
+// about this machine's load.
+func (s *Scheduler) AcceptSlow(sessionID string) {
+	s.mu.Lock()
+	h := s.running[sessionID]
+	s.mu.Unlock()
+	if h == nil {
+		return
+	}
+	select {
+	case h.accept <- struct{}{}:
+	default:
 	}
 }
 

--- a/pkg/snmp/getmany_test.go
+++ b/pkg/snmp/getmany_test.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
@@ -45,7 +46,7 @@ func TestAnUnreachableDeviceCostsOneTimeoutNotOnePerOid(t *testing.T) {
 	}
 
 	start := time.Now()
-	res := c.GetMany([]string{host}, oids, "public", "v2c", port, timeoutSec, 0, V3Params{})
+	res := c.GetMany(context.Background(), []string{host}, oids, "public", "v2c", port, timeoutSec, 0, V3Params{})
 	elapsed := time.Since(start)
 
 	// One timeout, with generous headroom. The old shape would be at least
@@ -87,7 +88,7 @@ func TestUnreachableTargetsAreStillPolledConcurrently(t *testing.T) {
 	}
 
 	start := time.Now()
-	res := c.GetMany(targets, []string{"1.3.6.1.2.1.1.3.0"}, "public", "v2c", port, 1, 0, V3Params{})
+	res := c.GetMany(context.Background(), targets, []string{"1.3.6.1.2.1.1.3.0"}, "public", "v2c", port, 1, 0, V3Params{})
 	elapsed := time.Since(start)
 
 	if elapsed > 3*time.Second {
@@ -106,7 +107,7 @@ func TestGetManyReturnsTargetsInTheOrderAsked(t *testing.T) {
 	_, port := deadTarget(t)
 	targets := []string{"127.0.0.1", "127.0.0.2", "127.0.0.3"}
 
-	res := c.GetMany(targets, []string{"1.3.6.1.2.1.1.3.0"}, "public", "v2c", port, 1, 0, V3Params{})
+	res := c.GetMany(context.Background(), targets, []string{"1.3.6.1.2.1.1.3.0"}, "public", "v2c", port, 1, 0, V3Params{})
 	if len(res) != len(targets) {
 		t.Fatalf("%d results for %d targets", len(res), len(targets))
 	}
@@ -124,7 +125,7 @@ func TestGetManyWithNoOidsDoesNothing(t *testing.T) {
 	host, port := deadTarget(t)
 
 	start := time.Now()
-	res := c.GetMany([]string{host}, nil, "public", "v2c", port, 5, 3, V3Params{})
+	res := c.GetMany(context.Background(), []string{host}, nil, "public", "v2c", port, 5, 3, V3Params{})
 	if len(res) != 0 {
 		t.Errorf("%d results for no OIDs", len(res))
 	}

--- a/pkg/snmp/operations.go
+++ b/pkg/snmp/operations.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -260,7 +261,16 @@ const maxVarbindsPerGet = 30
 // that produced no per-OID entries would leave every series looking as though
 // nothing had been polled at all — which is indistinguishable from a paused
 // session.
-func (c *Client) GetMany(targets []string, oids []string, community, version string, port, timeoutSec, retries int, v3 V3Params) []*MultiResult {
+//
+// The context is the poll's, and it is what makes a session STOPPABLE while it
+// is on the wire. Chunking is serial within one target, so without it a stop
+// waited for every remaining chunk: measured against a silent device, 90 OIDs
+// (three chunks) took 12.0 s to stop, and a preset at pkg/preset's sanity bound
+// of 500 OIDs would be seventeen chunks — over a minute of an application that
+// will not close. gosnmp consults the context between retries and for the dial,
+// so the wait is now bounded by ONE request timeout rather than by the whole
+// round.
+func (c *Client) GetMany(ctx context.Context, targets []string, oids []string, community, version string, port, timeoutSec, retries int, v3 V3Params) []*MultiResult {
 	out := make([]*MultiResult, 0, len(targets))
 	if len(oids) == 0 {
 		return out
@@ -272,7 +282,7 @@ func (c *Client) GetMany(targets []string, oids []string, community, version str
 		wg.Add(1)
 		go func(t string) {
 			defer wg.Done()
-			m := c.getManyOne(t, oids, community, version, port, timeoutSec, retries, v3)
+			m := c.getManyOne(ctx, t, oids, community, version, port, timeoutSec, retries, v3)
 			mu.Lock()
 			out = append(out, m)
 			mu.Unlock()
@@ -296,7 +306,7 @@ func (c *Client) GetMany(targets []string, oids []string, community, version str
 	return ordered
 }
 
-func (c *Client) getManyOne(target string, oids []string, community, version string, port, timeoutSec, retries int, v3 V3Params) *MultiResult {
+func (c *Client) getManyOne(ctx context.Context, target string, oids []string, community, version string, port, timeoutSec, retries int, v3 V3Params) *MultiResult {
 	start := time.Now()
 	m := &MultiResult{
 		Target:  target,
@@ -315,6 +325,11 @@ func (c *Client) getManyOne(target string, oids []string, community, version str
 	if err != nil {
 		return failAll(err)
 	}
+	// Before Connect: gosnmp dials with DialContext and defaults the field to
+	// context.Background() inside connect() if it is still nil.
+	if ctx != nil {
+		g.Context = ctx
+	}
 	if err := g.Connect(); err != nil {
 		return failAll(fmt.Errorf("connect failed: %v", err))
 	}
@@ -326,6 +341,16 @@ func (c *Client) getManyOne(target string, oids []string, community, version str
 			to = len(oids)
 		}
 		chunk := oids[from:to]
+
+		// Between chunks, because that is the granularity a serial loop can
+		// offer: a cancelled poll stops here instead of paying every remaining
+		// timeout.
+		if ctx != nil && ctx.Err() != nil {
+			for _, oid := range oids[from:] {
+				m.Errors[oid] = ctx.Err().Error()
+			}
+			break
+		}
 
 		packet, err := g.Get(chunk)
 		if err != nil {


### PR DESCRIPTION
The guardrail #37 deliberately does not contain. `pkg/preset` refuses a malformed *file*; this refuses a *cadence the machine cannot keep* — and it is **measured**, not declared.

## What goes wrong without it

Bind three community presets to a switch over a WAN link and nothing fails. The poll round simply takes longer than the period it promised, and Go's ticker **coalesces** the ticks it missed — so the loop is never idle: it finishes a round and the next one is already due. The device is asked continuously, the inserts never stop arriving on a database with one writer, and nothing anywhere says a word.

*"Every 30 s"* has quietly become *"as fast as it can"*, which is a different product.

## Four rules, each a defect in the version without it

**The measurement is the cycle, not the OID count.** Sixty OIDs against a chassis on the same switch cost less than five over a satellite link, so no number drawn on a preset predicts what it costs *here*. That is exactly why #37's limits are sanity bounds and say so — the policy is `pkg/monitor/overrun.go`, and it reads the whole round: fetch, persist, threshold evaluation, emit.

**A cycle spent waiting for a device that is down is not evidence of load.** Measured against a silent agent:

| OIDs | round | |
| --- | --- | --- |
| 10 | 4.0 s | one chunk, 2 s timeout × 1 retry |
| 30 | 4.0 s | still one chunk |
| 60 | 8.0 s | two chunks, serial |

Past any interval a preset may declare. Backing off there would slow the reachability detection at the exact moment monitoring matters, so a round where half the readings or more are **errors** counts neither way. An *error*, note, not a nil value: a string OID answers with no number and no error at all, and counting that as a failure would leave a session polling `sysDescr` with a guardrail that can never engage.

**Recovery is judged against the requested interval, never the effective one.** Once backed off, every cycle fits the widened period trivially — judging against it would recover on the next round, overrun again, and flap forever at one report per tick. Hysteresis is the other half: a cycle has to fit in **half** the requested interval, so a session sitting on the boundary settles instead of oscillating. One report per **episode**, for the same reason the pool-contention sampler in `app_router.go` is edge-triggered.

**The operator decides, and can.** The default is to widen to twice the cycle — the loop idle half the time — capped at eight times the interval, because a monitoring must never quietly become hourly and recovery is counted in rounds. `MonitorAcceptSlow` is *keep the cadence I chose*: it reaches the **running** session rather than restarting it (a restart throws away the previous samples every delta and rate is derived from) and takes effect **at once** rather than at the next round, which can be eight periods away.

The report goes to two places, because the two questions differ: the event journal answers *"what happened while I was away"* for someone running with no window open, and the renderer is what actually **asks** — a banner on the session card, not a toast. A toast is gone by the time anyone reads it, and this is a question with two answers, so it stays next to the session it is about and survives collapsing the card. It is cleared by the recovery edge rather than by a timer: a banner that faded on its own would leave the widened cadence in force with nothing on screen explaining why the charts thinned out.

`formatCadence` rather than `formatDuration`: the latter is for a measurement and answers "600.00s" where a period is read as "10 min".

## And stopping now works

Measured: **90 OIDs against a silent device took 12.0 s to stop.** `GetMany` chunks serially and ignored the poll's context; at #37's bound of 500 OIDs that is seventeen chunks — over a minute of an application that will not close.

The context now reaches the wire (gosnmp consults it for the dial and between retries) and is checked between chunks. A stop landing five seconds into that round now returns in **1.0 s**, bounded by one request timeout instead of the whole round.

That fix creates a defect of its own, so it is fixed here too: what a cancelled round returns is one error per OID, and persisting those breaks every series while the evaluator reads them as a device that stopped answering. **Pressing Stop would have raised an unreachability alert on a healthy switch.** A cancelled round is not a measurement and is not stored.

## What is deliberately not here

The acceptance is not persisted. A decision about how hard to work *this* machine is not one to inherit silently after a restart, and the session asks again — which is also the honest default until presets are actually bound to targets.

## Checks

`gofmt`, `go vet`, `staticcheck`, `go test -race -count=1 ./...` (14 packages), `npm test` (520 checks), `npm run check` and `npm run build` clean.

Eleven new Go tests: eight pure ones over the guard (no clock, no lock) and three on the real scheduler — the report fires once and the polling really does widen, the answer reaches a running session, and a cancelled round reaches no storage. On the renderer side the smoke test drives the whole path against the stubbed bridge: the report lands on the right session, another session's does not, accepting reaches Go and changes the banner at once, and recovering takes it away.

`MonitorAcceptSlow` is a new `App` method, so the bindings regenerate — nothing to do beyond the usual `wails dev`/`wails build`.
