### PR TITLE
Make the preset format survive contact with a real file

### DIFF
--- a/pkg/preset/load.go
+++ b/pkg/preset/load.go
@@ -1,0 +1,216 @@
+package preset
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Reading presets off disk.
+//
+// Everything here is about a file SOMEBODY ELSE WROTE, which is the whole
+// premise of the format: it arrives from a community repository, an email or a
+// vendor's site, and nothing about it may be assumed. So this file parses,
+// bounds and reports; it never repairs, and it never decides.
+
+// MaxFileBytes bounds a preset file before it is read.
+//
+// The bound is checked with os.Stat rather than after os.ReadFile, the way
+// importSingleFile does for MIBs: a size check that happens after the read has
+// already spent the memory it exists to refuse. A preset at every one of this
+// package's sanity bounds — 40 widgets, 500 OIDs, 120-character strings — is
+// well under 100 KB, so a megabyte is generous by an order of magnitude and
+// still refuses the file that is a video with the wrong extension.
+const MaxFileBytes = 1 << 20
+
+// Info is one preset as a LIST shows it: enough to choose between files,
+// without opening the widgets.
+//
+// Problems is a count rather than the errors themselves. A directory listing
+// that carried every validation error of every file would be most of the data
+// for a screen that shows none of it; the errors are what ReadPreset is for,
+// and this says which file to ask about.
+type Info struct {
+	File        string `json:"file"`
+	Name        string `json:"name"`
+	Author      string `json:"author,omitempty"`
+	Vendor      string `json:"vendor,omitempty"`
+	Description string `json:"description,omitempty"`
+	// SysObjectIDPrefix is carried so a caller can rank a list against a device
+	// without re-reading every file.
+	SysObjectIDPrefix []string `json:"sysObjectIdPrefix,omitempty"`
+	IntervalSec       int      `json:"intervalSec"`
+	Widgets           int      `json:"widgets"`
+	OIDs              int      `json:"oids"`
+	Problems          int      `json:"problems"`
+}
+
+// Parse reads a preset from bytes and validates it.
+//
+// A file that is not JSON at all is reported as one error with an empty Field,
+// not as a bare encoding/json message: the caller renders a field path beside
+// each problem, and "invalid character 'P' looking for beginning of value" in
+// that column reads as a problem with a field called nothing.
+//
+// DisallowUnknownFields is deliberately NOT used. FormatVersion is how this
+// format handles a file from a version that has moved on, and refusing an
+// unknown key would refuse exactly the files that mechanism exists to accept.
+func Parse(data []byte) (Preset, []Error) {
+	var p Preset
+	if err := json.Unmarshal(data, &p); err != nil {
+		return p, []Error{errf("", "notJson", map[string]string{"detail": clip(err.Error())})}
+	}
+	return p, Validate(p)
+}
+
+// LoadFile reads one preset from disk.
+//
+// Three answers, and they are not the same thing: err is "this file could not
+// be read", the error slice is "this file is not a valid preset", and both
+// empty is a preset. Collapsing the first two would report a permission
+// problem as a formatting problem.
+func LoadFile(path string) (Preset, []Error, error) {
+	st, err := os.Stat(path)
+	if err != nil {
+		return Preset{}, nil, err
+	}
+	if st.IsDir() {
+		return Preset{}, nil, fmt.Errorf("%s is a directory", filepath.Base(path))
+	}
+	if st.Size() > MaxFileBytes {
+		return Preset{}, []Error{errf("", "tooBig", map[string]string{
+			"found": fmt.Sprint(st.Size()), "max": fmt.Sprint(MaxFileBytes),
+		})}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Preset{}, nil, err
+	}
+	p, errs := Parse(data)
+	return p, errs, nil
+}
+
+// List reads a directory of presets.
+//
+// One unreadable or malformed file must never hide the others: a broken preset
+// is listed with its problem count, and a file that cannot be read at all is
+// skipped rather than aborting the sweep. That is the rule ListMibFiles
+// follows for the same reason — a folder of files from strangers has one bad
+// one in it, and a listing that fails entirely is a listing nobody can use to
+// find which.
+func List(dir string) ([]Info, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// A directory nobody has put a preset in yet is empty, not broken.
+			return []Info{}, nil
+		}
+		return nil, err
+	}
+
+	out := make([]Info, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		p, errs, err := LoadFile(full)
+		if err != nil {
+			continue
+		}
+		out = append(out, Info{
+			File:              e.Name(),
+			Name:              p.Name,
+			Author:            p.Author,
+			Vendor:            p.Match.Vendor,
+			Description:       p.Description,
+			SysObjectIDPrefix: p.Match.SysObjectIDPrefix,
+			IntervalSec:       p.IntervalSec,
+			Widgets:           len(p.Widgets),
+			OIDs:              Estimate(p).OIDs,
+			Problems:          len(errs),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].File < out[j].File
+	})
+	return out, nil
+}
+
+// prefixDepth is how many sub-identifiers of prefix an OID matches, or zero.
+//
+// Arc by arc, never as text. strings.HasPrefix is the obvious implementation
+// and it is wrong in the way that matters here: "1.3.6.1.4.1.9" is Cisco and
+// "1.3.6.1.4.1.911" is somebody else entirely, and a text prefix says they are
+// the same vendor. Leading dots are stripped on both sides, because
+// formatSnmpValue renders an ObjectIdentifier WITH one and a preset file is
+// written by hand either way.
+func prefixDepth(prefix, oid string) int {
+	pa := strings.Split(strings.TrimPrefix(strings.TrimSpace(prefix), "."), ".")
+	oa := strings.Split(strings.TrimPrefix(strings.TrimSpace(oid), "."), ".")
+	if len(pa) == 0 || pa[0] == "" || len(pa) > len(oa) {
+		return 0
+	}
+	for i, arc := range pa {
+		if arc != oa[i] {
+			return 0
+		}
+	}
+	return len(pa)
+}
+
+// MatchDepth says how specifically a preset claims this device, in
+// sub-identifiers. Zero is "it does not".
+//
+// Depth rather than a boolean because two presets can both match — a vendor's
+// generic one and a model's — and the specific one is the better advice.
+func MatchDepth(prefixes []string, sysObjectID string) int {
+	if strings.TrimSpace(sysObjectID) == "" {
+		return 0
+	}
+	best := 0
+	for _, prefix := range prefixes {
+		if d := prefixDepth(prefix, sysObjectID); d > best {
+			best = d
+		}
+	}
+	return best
+}
+
+// Matches reports whether this preset claims this device.
+func Matches(p Preset, sysObjectID string) bool {
+	return MatchDepth(p.Match.SysObjectIDPrefix, sysObjectID) > 0
+}
+
+// Rank orders a listing for one device: what claims it first, most specific
+// first, then everything else by name.
+//
+// It ORDERS, it never filters. A preset that says nothing about which device it
+// is for is still a preset the operator may have downloaded for this one, and
+// Match is documented as advice to the person binding — never an automatic
+// action. Hiding the rest would turn that advice into a decision.
+func Rank(infos []Info, sysObjectID string) []Info {
+	out := make([]Info, len(infos))
+	copy(out, infos)
+	depth := make(map[string]int, len(out))
+	for _, in := range out {
+		depth[in.File] = MatchDepth(in.SysObjectIDPrefix, sysObjectID)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		di, dj := depth[out[i].File], depth[out[j].File]
+		if di != dj {
+			return di > dj
+		}
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].File < out[j].File
+	})
+	return out
+}

--- a/pkg/preset/load_test.go
+++ b/pkg/preset/load_test.go
@@ -1,0 +1,229 @@
+package preset
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func marshal(t *testing.T, p Preset) string {
+	t.Helper()
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// A preset survives the round trip it will actually make: written as JSON by
+// whoever authored it, read back here.
+//
+// Match carries `json:",omitzero"`, so a preset that names no device is
+// marshalled WITHOUT the key at all. That is the shape most community files
+// will have, and it must still validate.
+func TestAPresetRoundTripsThroughJson(t *testing.T) {
+	dir := t.TempDir()
+
+	full := valid()
+	back, errs := Parse([]byte(marshal(t, full)))
+	if len(errs) != 0 {
+		t.Fatalf("a valid preset did not survive JSON: %s", fieldsOf(errs))
+	}
+	if len(back.Widgets) != len(full.Widgets) || back.IntervalSec != full.IntervalSec {
+		t.Errorf("the preset changed shape: %+v", back)
+	}
+	if len(PollOIDs(back)) != len(PollOIDs(full)) {
+		t.Error("the OIDs did not survive")
+	}
+
+	bare := valid()
+	bare.Match = Match{}
+	raw := marshal(t, bare)
+	if strings.Contains(raw, "\"match\"") {
+		t.Errorf("a zero Match was marshalled anyway: %s", raw)
+	}
+	if _, errs := Parse([]byte(raw)); len(errs) != 0 {
+		t.Errorf("a preset naming no device was refused: %s", fieldsOf(errs))
+	}
+
+	// And from disk, which is the only way one ever really arrives.
+	p := writeFile(t, dir, "acme.json", raw)
+	if _, errs, err := LoadFile(p); err != nil || len(errs) != 0 {
+		t.Errorf("LoadFile: err=%v errs=%s", err, fieldsOf(errs))
+	}
+}
+
+// The three answers are three different things, and collapsing any two of them
+// reports the wrong problem to whoever has to fix it.
+func TestReadFailureAndFormatFailureAreNotTheSameAnswer(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, _, err := LoadFile(filepath.Join(dir, "nope.json")); err == nil {
+		t.Error("a missing file was not reported as a read failure")
+	}
+	if _, _, err := LoadFile(dir); err == nil {
+		t.Error("a directory was accepted as a preset")
+	}
+
+	// Not JSON at all: one error, no field path, and not a raw parser message
+	// sitting in a column that renders field names.
+	notJSON := writeFile(t, dir, "page.json", "<!DOCTYPE html><html><body>404</body></html>")
+	_, errs, err := LoadFile(notJSON)
+	if err != nil {
+		t.Fatalf("a readable file reported a read failure: %v", err)
+	}
+	if len(errs) != 1 || errs[0].Field != "" || errs[0].Message != "preset.err.notJson" {
+		t.Fatalf("an HTML page was reported as %+v", errs)
+	}
+
+	// JSON, but not a preset: every problem at once, with field paths.
+	empty := writeFile(t, dir, "empty.json", "{}")
+	if _, errs, _ := LoadFile(empty); !has(errs, "name") || !has(errs, "widgets") || !has(errs, "formatVersion") {
+		t.Errorf("an empty object was reported as %s", fieldsOf(errs))
+	}
+}
+
+// The size bound is checked before the read, so the file that is a video does
+// not get loaded into memory in order to be refused.
+func TestAnOversizedFileIsRefusedWithoutBeingRead(t *testing.T) {
+	dir := t.TempDir()
+	big := writeFile(t, dir, "big.json", strings.Repeat("x", MaxFileBytes+1))
+	_, errs, err := LoadFile(big)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(errs) != 1 || errs[0].Message != "preset.err.tooBig" {
+		t.Fatalf("an oversized file was reported as %+v", errs)
+	}
+}
+
+// A folder of files from strangers has a bad one in it. A listing that fails
+// entirely is a listing nobody can use to find which.
+func TestOneBadFileDoesNotHideTheGoodOnes(t *testing.T) {
+	dir := t.TempDir()
+	good := valid()
+	good.Name = "Alpha"
+	writeFile(t, dir, "alpha.json", marshal(t, good))
+	good.Name = "Zulu"
+	writeFile(t, dir, "zulu.json", marshal(t, good))
+	writeFile(t, dir, "broken.json", "{\"formatVersion\": 1}")
+	writeFile(t, dir, "notjson.txt", "hello")
+	writeFile(t, dir, ".hidden", marshal(t, good))
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	list, err := List(dir)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 4 {
+		t.Fatalf("%d entries, want 4 (two good, two broken; the dotfile and the directory skipped): %+v", len(list), list)
+	}
+	// Sorted by name, and a broken file still appears — with its count.
+	byFile := map[string]Info{}
+	for _, in := range list {
+		byFile[in.File] = in
+	}
+	if byFile["alpha.json"].Name != "Alpha" || byFile["alpha.json"].Problems != 0 {
+		t.Errorf("a good preset listed as %+v", byFile["alpha.json"])
+	}
+	if byFile["broken.json"].Problems == 0 {
+		t.Error("a broken preset listed as having no problems")
+	}
+	if byFile["notjson.txt"].Problems == 0 {
+		t.Error("a file that is not JSON listed as having no problems")
+	}
+	if byFile["alpha.json"].OIDs != 4 || byFile["alpha.json"].Widgets != 3 {
+		t.Errorf("the listing does not carry what it takes to choose: %+v", byFile["alpha.json"])
+	}
+}
+
+// A directory nobody has put a preset in yet is empty, not broken — and it is
+// the state the feature ships in.
+func TestAnAbsentDirectoryListsEmpty(t *testing.T) {
+	list, err := List(filepath.Join(t.TempDir(), "presets"))
+	if err != nil {
+		t.Fatalf("an absent directory reported an error: %v", err)
+	}
+	if list == nil {
+		t.Error("List returned nil, which crosses the bridge as null and throws on .map")
+	}
+	if len(list) != 0 {
+		t.Errorf("%d entries from nothing", len(list))
+	}
+}
+
+// The match is arc by arc, never as text.
+//
+// 1.3.6.1.4.1.9 is Cisco. 1.3.6.1.4.1.911 is somebody else. strings.HasPrefix
+// is the obvious implementation and says they are the same vendor.
+func TestAPrefixMatchesOnSubIdentifierBoundaries(t *testing.T) {
+	const cisco = "1.3.6.1.4.1.9"
+	yes := []string{"1.3.6.1.4.1.9", "1.3.6.1.4.1.9.1.2494", ".1.3.6.1.4.1.9.1.1"}
+	no := []string{"1.3.6.1.4.1.911", "1.3.6.1.4.1.911.1", "1.3.6.1.4.1.90", "1.3.6.1.4.1", ""}
+
+	for _, oid := range yes {
+		if MatchDepth([]string{cisco}, oid) == 0 {
+			t.Errorf("%q should match %q", oid, cisco)
+		}
+	}
+	for _, oid := range no {
+		if d := MatchDepth([]string{cisco}, oid); d != 0 {
+			t.Errorf("%q matched %q at depth %d", oid, cisco, d)
+		}
+	}
+
+	// The leading dot is not part of the OID on either side: formatSnmpValue
+	// renders an ObjectIdentifier with one, and a file is written by hand.
+	if MatchDepth([]string{".1.3.6.1.4.1.9"}, "1.3.6.1.4.1.9.1") == 0 {
+		t.Error("a prefix written with a leading dot did not match")
+	}
+
+	// A preset that names no device claims none.
+	if Matches(valid(), "") || Matches(Preset{}, "1.3.6.1.4.1.9") {
+		t.Error("a preset with no prefixes claimed a device")
+	}
+}
+
+// Ranking ORDERS, it never filters: Match is advice to the person binding, and
+// hiding the rest would turn advice into a decision.
+func TestRankingPutsTheMostSpecificFirstAndKeepsEverything(t *testing.T) {
+	infos := []Info{
+		{File: "zzz-generic.json", Name: "Generic interfaces"},
+		{File: "cisco.json", Name: "Cisco", SysObjectIDPrefix: []string{"1.3.6.1.4.1.9"}},
+		{File: "cat9k.json", Name: "Catalyst 9300", SysObjectIDPrefix: []string{"1.3.6.1.4.1.9.1.2494"}},
+		{File: "juniper.json", Name: "Juniper", SysObjectIDPrefix: []string{"1.3.6.1.4.1.2636"}},
+	}
+	got := Rank(infos, "1.3.6.1.4.1.9.1.2494")
+
+	if len(got) != len(infos) {
+		t.Fatalf("ranking dropped %d entries", len(infos)-len(got))
+	}
+	if got[0].File != "cat9k.json" {
+		t.Errorf("first is %q; the most specific match should lead", got[0].File)
+	}
+	if got[1].File != "cisco.json" {
+		t.Errorf("second is %q; the vendor match should follow the model match", got[1].File)
+	}
+	// The rest keep a stable, name-ordered place rather than an arbitrary one.
+	if got[2].Name != "Generic interfaces" || got[3].Name != "Juniper" {
+		t.Errorf("the non-matching tail is not name-ordered: %q then %q", got[2].Name, got[3].Name)
+	}
+
+	// And the input is not reordered under the caller.
+	if infos[0].File != "zzz-generic.json" {
+		t.Error("Rank sorted its argument in place")
+	}
+}

--- a/pkg/preset/preset.go
+++ b/pkg/preset/preset.go
@@ -33,7 +33,9 @@ package preset
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // FormatVersion is the shape this package writes and understands.
@@ -51,8 +53,11 @@ const (
 	MaxOIDsPerPreset = 500
 	// MaxWidgets bounds the panel, and the render loop that draws it.
 	MaxWidgets = 40
-	// MinIntervalSec floors the declared cadence. Below this a preset is
-	// asking the poll clock for something the scheduler will floor anyway.
+	// MinIntervalSec floors the declared cadence, and it is a POLICY rather
+	// than a restatement of something downstream. The scheduler's own floor is
+	// minInterval = 250 ms (pkg/monitor/scheduler.go), which exists to stop a
+	// corrupt row spinning a goroutine; this one is the only real cap on how
+	// much traffic a file somebody else wrote can make this application emit.
 	MinIntervalSec = 5
 	// MaxIntervalSec is a day: past that, a dashboard is a report.
 	MaxIntervalSec = 86400
@@ -74,9 +79,21 @@ const (
 	// KindStatus shows one reading as a state, mapped through the widget's own
 	// labels — ifOperStatus 1 as "up" rather than as 1.
 	KindStatus = "status"
-	// KindTable shows a conceptual table, split by INDEX.
-	KindTable = "table"
+	// KindGrid shows one cell per OID, all sharing the widget's label map:
+	// the port panel of a switch, where forty-eight readings are one thing to
+	// look at rather than forty-eight things.
+	KindGrid = "grid"
 )
+
+// There is deliberately no "table" kind.
+//
+// A conceptual table is a WALK, and the poll path a preset feeds is GET-only:
+// PollOIDs goes to snmp.GetMany, which sends what it is given as varbinds, and
+// a table's OID GET'd answers noSuchObject. The pivot also needs the column
+// definitions and the INDEX rules out of the MIB (pkg/mib/table.go), which a
+// flat list of numeric OIDs cannot supply. KindGrid is what that want actually
+// reduces to here: the instances named explicitly, which is also what makes
+// the cost of the preset knowable before it runs.
 
 // WidgetDoc describes one kind for the settings UI.
 //
@@ -97,8 +114,14 @@ var widgetKinds = []WidgetDoc{
 	{Kind: KindRate, MaxOIDs: 1},
 	{Kind: KindStatus, MaxOIDs: 1},
 	{Kind: KindChart, MaxOIDs: 8},
-	{Kind: KindTable, MaxOIDs: 0},
+	{Kind: KindGrid, MaxOIDs: 96},
 }
+
+// kindTakesLabels: a label map turns a number into a state, so it belongs to
+// the two kinds that show a state and nowhere else. On any other kind it is a
+// sign the author expected something this vocabulary does not do, and silence
+// would leave them wondering why nothing happened.
+func kindTakesLabels(kind string) bool { return kind == KindStatus || kind == KindGrid }
 
 // WidgetKinds serves the vocabulary to the UI.
 //
@@ -194,6 +217,43 @@ func errf(field, msg string, args map[string]string) Error {
 // from the file that caused it.
 var numericOID = regexp.MustCompile(`^\.?\d+(\.\d+)+$`)
 
+// maxOIDDepth and maxSubIdentifier are what an OID can BE on the wire.
+//
+// The regexp above says the shape; these say the range. gosnmp marshals a
+// sub-identifier as a uint32 and an object identifier is at most 128 of them
+// (RFC 2578 7.1.3), so a value past either is not a large OID — it is not an
+// OID, and refusing it here is the difference between a message naming the
+// file and a failure somewhere inside the encoder.
+const (
+	maxOIDDepth      = 128
+	maxSubIdentifier = 4294967295
+)
+
+// checkOID validates one OID string completely.
+func checkOID(field, oid string) []Error {
+	if !numericOID.MatchString(oid) {
+		return []Error{errf(field, "notAnOid", map[string]string{"value": clip(oid)})}
+	}
+	arcs := strings.Split(strings.TrimPrefix(oid, "."), ".")
+	if len(arcs) > maxOIDDepth {
+		return []Error{errf(field, "oidTooDeep", map[string]string{
+			"found": fmt.Sprint(len(arcs)), "max": fmt.Sprint(maxOIDDepth),
+		})}
+	}
+	for _, a := range arcs {
+		// Parsed rather than compared as a string: "0000000000004" is four.
+		n, err := strconv.ParseUint(a, 10, 64)
+		if err != nil || n > maxSubIdentifier {
+			return []Error{errf(field, "oidOutOfRange", map[string]string{"value": clip(oid)})}
+		}
+	}
+	// The root has three children and always did: ccitt, iso, joint-iso-ccitt.
+	if arcs[0] != "0" && arcs[0] != "1" && arcs[0] != "2" {
+		return []Error{errf(field, "notAnOid", map[string]string{"value": clip(oid)})}
+	}
+	return nil
+}
+
 // Validate checks a preset completely and returns every problem, not the first.
 //
 // Everything, because a preset is edited in a text editor by someone who is not
@@ -202,7 +262,9 @@ var numericOID = regexp.MustCompile(`^\.?\d+(\.\d+)+$`)
 func Validate(p Preset) []Error {
 	var errs []Error
 
-	if p.FormatVersion == 0 {
+	if p.FormatVersion < 1 {
+		// Below one, not equal to zero: a negative version fell through both
+		// branches and was accepted as though it had been read.
 		errs = append(errs, errf("formatVersion", "missing", nil))
 	} else if p.FormatVersion > FormatVersion {
 		errs = append(errs, errf("formatVersion", "tooNew", map[string]string{
@@ -230,10 +292,7 @@ func Validate(p Preset) []Error {
 	}
 
 	for i, prefix := range p.Match.SysObjectIDPrefix {
-		if !numericOID.MatchString(prefix) {
-			errs = append(errs, errf(fmt.Sprintf("match.sysObjectIdPrefix[%d]", i), "notAnOid",
-				map[string]string{"value": clip(prefix)}))
-		}
+		errs = append(errs, checkOID(fmt.Sprintf("match.sysObjectIdPrefix[%d]", i), prefix)...)
 	}
 
 	if len(p.Widgets) == 0 {
@@ -264,17 +323,22 @@ func Validate(p Preset) []Error {
 			}))
 		}
 		for j, oid := range w.OIDs {
-			if !numericOID.MatchString(oid) {
-				errs = append(errs, errf(fmt.Sprintf("%s.oids[%d]", at, j), "notAnOid",
-					map[string]string{"value": clip(oid)}))
-			}
+			errs = append(errs, checkOID(fmt.Sprintf("%s.oids[%d]", at, j), oid)...)
 		}
 		total += len(w.OIDs)
 
-		if w.Kind != KindStatus && len(w.Labels) > 0 {
-			errs = append(errs, errf(at+".labels", "labelsOnlyForStatus", map[string]string{"kind": w.Kind}))
+		if len(w.Labels) > 0 && !kindTakesLabels(w.Kind) {
+			errs = append(errs, errf(at+".labels", "labelsOnlyForStatus", map[string]string{"kind": clip(w.Kind)}))
 		}
 		for k, v := range w.Labels {
+			// The KEY as well as the value. It is author-supplied text that is
+			// interpolated into Error.Field and rendered as the name of the
+			// state it maps, so a newline or a hundred characters in it travel
+			// exactly as far as one in the value would.
+			if _, err := strconv.ParseInt(k, 10, 64); err != nil {
+				errs = append(errs, errf(at+".labels", "labelKey", map[string]string{"key": clip(k)}))
+				continue
+			}
 			errs = append(errs, checkText(at+".labels."+k, v)...)
 		}
 	}
@@ -297,15 +361,30 @@ func Validate(p Preset) []Error {
 // cost less than five over a satellite link, so a number derived from the count
 // alone would be a guess dressed as a fact.
 type Cost struct {
-	OIDs            int `json:"oids"`
-	Widgets         int `json:"widgets"`
-	IntervalSec     int `json:"intervalSec"`
-	RequestsPerHour int `json:"requestsPerHour"`
-	// VarbindsPerHour is the honest measure of what the device is asked for:
-	// one request carries every OID, so the request count alone understates it
-	// and the varbind count is what the agent actually does work for.
-	VarbindsPerHour int `json:"varbindsPerHour"`
+	OIDs        int `json:"oids"`
+	Widgets     int `json:"widgets"`
+	IntervalSec int `json:"intervalSec"`
+	// PollsPerDay and VarbindsPerDay are stated over a DAY, not an hour.
+	//
+	// Not a presentation choice: MaxIntervalSec is a day, so an hourly base is
+	// integer-divided to ZERO for every cadence slower than 3600 s — a preset
+	// polling twice a day reported "0 requests, 0 varbinds" on the one screen
+	// whose job is to say what it will cost. A day is the coarsest cadence the
+	// format admits, so the count is at least one for every valid preset.
+	PollsPerDay int `json:"pollsPerDay"`
+	// VarbindsPerDay is the honest measure of what the device is asked for:
+	// one request carries every OID, so counting rounds alone understates what
+	// the agent does work for.
+	//
+	// There is no REQUEST count here on purpose. How many requests a round
+	// takes depends on the transport's chunk size, which is pkg/snmp's to know
+	// and not this package's — a copy of it here is a copy that drifts.
+	VarbindsPerDay int `json:"varbindsPerDay"`
 }
+
+// secondsPerDay is the base Estimate divides. Equal to MaxIntervalSec, and
+// that is the point: the slowest cadence the format admits still counts one.
+const secondsPerDay = 86400
 
 // Estimate reports what one target bound to this preset will ask for.
 func Estimate(p Preset) Cost {
@@ -327,9 +406,8 @@ func Estimate(p Preset) Cost {
 	if c.IntervalSec <= 0 {
 		return c
 	}
-	perHour := 3600 / c.IntervalSec
-	c.RequestsPerHour = perHour
-	c.VarbindsPerHour = perHour * c.OIDs
+	c.PollsPerDay = secondsPerDay / c.IntervalSec
+	c.VarbindsPerDay = c.PollsPerDay * c.OIDs
 	return c
 }
 
@@ -356,9 +434,13 @@ func checkText(field, s string) []Error {
 		return nil
 	}
 	var errs []Error
-	if len(s) > MaxTextLen {
+	// Runes, not bytes. MaxTextLen is about LAYOUT, which is a property of what
+	// is displayed — and this application ships a zh locale, where a
+	// forty-character title is a hundred and twenty bytes and would be refused
+	// for being too long to fit in a panel it fits in comfortably.
+	if n := utf8.RuneCountInString(s); n > MaxTextLen {
 		errs = append(errs, errf(field, "tooLong", map[string]string{
-			"found": fmt.Sprint(len(s)), "max": fmt.Sprint(MaxTextLen),
+			"found": fmt.Sprint(n), "max": fmt.Sprint(MaxTextLen),
 		}))
 	}
 	// A control character in a title reaches a panel, a log line and — through
@@ -373,9 +455,22 @@ func checkText(field, s string) []Error {
 	return errs
 }
 
+// clip shortens a value for an error message, on a RUNE boundary.
+//
+// Slicing bytes splits a multi-byte rune, and the result travels: Error.Args
+// crosses the bridge as JSON, where encoding/json rewrites the broken tail to
+// U+FFFD — so the message naming the offending value would misquote it.
 func clip(s string) string {
-	if len(s) > 40 {
-		return s[:40] + "…"
+	const max = 40
+	if utf8.RuneCountInString(s) <= max {
+		return s
+	}
+	n := 0
+	for i := range s {
+		if n == max {
+			return s[:i] + "…"
+		}
+		n++
 	}
 	return s
 }

--- a/pkg/preset/preset_test.go
+++ b/pkg/preset/preset_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func valid() Preset {
@@ -201,6 +202,13 @@ func TestLabelsBelongOnlyToStatus(t *testing.T) {
 	if errs := Validate(p); !has(errs, "widgets[0].labels") {
 		t.Error("labels on a value widget were accepted silently")
 	}
+	// A grid is a wall of states, so it takes them too.
+	p2 := valid()
+	p2.Widgets[0] = Widget{Kind: KindGrid, Title: "Ports", OIDs: []string{"1.3.6.1.2.1.2.2.1.8.1"},
+		Labels: map[string]string{"1": "up"}}
+	if errs := Validate(p2); has(errs, "widgets[0].labels") {
+		t.Error("labels on a grid widget were refused")
+	}
 }
 
 // The cost is arithmetic that can be shown BEFORE anything is polled, and it
@@ -215,13 +223,142 @@ func TestTheCostIsStatedInVarbinds(t *testing.T) {
 	if c.Widgets != 3 {
 		t.Errorf("Widgets = %d, want 3", c.Widgets)
 	}
-	if c.RequestsPerHour != 120 {
-		t.Errorf("RequestsPerHour = %d, want 120", c.RequestsPerHour)
+	if c.PollsPerDay != 2880 {
+		t.Errorf("PollsPerDay = %d, want 2880", c.PollsPerDay)
 	}
-	// One request carries every OID, so the request count alone understates
-	// what the agent does work for.
-	if c.VarbindsPerHour != 480 {
-		t.Errorf("VarbindsPerHour = %d, want 480", c.VarbindsPerHour)
+	// One round carries every OID, so counting rounds alone understates what
+	// the agent does work for.
+	if c.VarbindsPerDay != 11520 {
+		t.Errorf("VarbindsPerDay = %d, want 11520", c.VarbindsPerDay)
+	}
+}
+
+// The screen whose whole job is to say what a preset will cost must not answer
+// "nothing" for a preset that polls slowly.
+//
+// An hourly base is integer-divided to ZERO for every cadence past 3600 s, and
+// MaxIntervalSec is 86400 — so a third of the legal range reported no cost at
+// all, on the one number an operator is shown before agreeing to it.
+func TestACadenceLongerThanAnHourStillHasACost(t *testing.T) {
+	for _, iv := range []int{3601, 7200, 43200, MaxIntervalSec} {
+		p := valid()
+		p.IntervalSec = iv
+		if errs := Validate(p); len(errs) != 0 {
+			t.Fatalf("interval %d is legal and was refused: %s", iv, fieldsOf(errs))
+		}
+		c := Estimate(p)
+		if c.PollsPerDay < 1 || c.VarbindsPerDay < 1 {
+			t.Errorf("interval %d reports %d polls and %d varbinds a day; a preset that polls has a cost",
+				iv, c.PollsPerDay, c.VarbindsPerDay)
+		}
+	}
+	// And two different cadences do not collapse onto the same answer.
+	a, b := valid(), valid()
+	a.IntervalSec, b.IntervalSec = 2400, 3600
+	if Estimate(a).PollsPerDay == Estimate(b).PollsPerDay {
+		t.Error("forty minutes and an hour report the same number of polls")
+	}
+}
+
+// MaxTextLen is about layout, and layout is measured in characters. This
+// application ships a zh locale: counting bytes refuses a title that fits.
+func TestAuthorTextIsBoundedInCharactersNotBytes(t *testing.T) {
+	p := valid()
+	p.Widgets[0].Title = strings.Repeat("端", 44) // 44 runes, 132 bytes
+	if errs := Validate(p); has(errs, "widgets[0].title") {
+		t.Error("a 44-character title was refused for being too long")
+	}
+	p.Widgets[0].Title = strings.Repeat("端", MaxTextLen+1)
+	if errs := Validate(p); !has(errs, "widgets[0].title") {
+		t.Error("an over-long title was accepted because its runes were counted as bytes")
+	}
+}
+
+// clip quotes the offending value back to the author. Slicing bytes splits a
+// rune, and encoding/json rewrites the broken tail — so the message naming the
+// value would misquote it.
+func TestClipNeverProducesInvalidUtf8(t *testing.T) {
+	for _, s := range []string{strings.Repeat("é", 80), strings.Repeat("端", 80), strings.Repeat("a", 80)} {
+		if got := clip(s); !utf8.ValidString(got) {
+			t.Errorf("clip produced invalid UTF-8 from %d runes", utf8.RuneCountInString(s))
+		}
+	}
+}
+
+// An OID is not just a shape: gosnmp marshals a sub-identifier as a uint32 and
+// RFC 2578 caps the depth. Past either, it is not a large OID — it is not one.
+func TestAnOidOutsideTheWireFormatIsRefused(t *testing.T) {
+	bad := map[string]string{
+		"an arc past uint32":   "1.3.6.1.4.1.4294967296",
+		"a huge arc":           "1.3.6.1.99999999999999999999",
+		"a non-root first arc": "3.6.1.2.1.1.3.0",
+		"too deep":             "1." + strings.TrimSuffix(strings.Repeat("1.", maxOIDDepth), "."),
+	}
+	for name, oid := range bad {
+		p := valid()
+		p.Widgets[0].OIDs = []string{oid}
+		if errs := Validate(p); !has(errs, "widgets[0].oids[0]") {
+			t.Errorf("%s: %q was accepted", name, oid)
+		}
+	}
+	// The top of the range is still an OID.
+	p := valid()
+	p.Widgets[0].OIDs = []string{"1.3.6.1.4.1.4294967295"}
+	if errs := Validate(p); has(errs, "widgets[0].oids[0]") {
+		t.Error("the largest legal sub-identifier was refused")
+	}
+}
+
+// A version below one fell through both branches and was read as though it had
+// been declared.
+func TestANegativeFormatVersionIsRefused(t *testing.T) {
+	p := valid()
+	p.FormatVersion = -1
+	if errs := Validate(p); !has(errs, "formatVersion") {
+		t.Error("a negative format version was accepted")
+	}
+}
+
+// The label KEY is author-supplied text too: it is interpolated into
+// Error.Field and rendered as the name of a state.
+func TestALabelKeyIsCheckedAsWellAsItsValue(t *testing.T) {
+	for _, k := range []string{"up", "1\n2", "", strings.Repeat("9", 40)} {
+		p := valid()
+		p.Widgets[2] = Widget{Kind: KindStatus, Title: "Link", OIDs: []string{"1.3.6.1.2.1.2.2.1.8.1"},
+			Labels: map[string]string{k: "up"}}
+		if errs := Validate(p); !has(errs, "widgets[2].labels") {
+			t.Errorf("%q was accepted as a label key: %s", k, fieldsOf(errs))
+		}
+	}
+	p := valid()
+	p.Widgets[2].Labels = map[string]string{"-1": "down", "2": "up"}
+	if errs := Validate(p); has(errs, "widgets[2].labels") {
+		t.Errorf("a negative state number was refused: %s", fieldsOf(errs))
+	}
+}
+
+// The port panel: one widget, one cell per interface, one label map.
+//
+// It replaces the table kind, which the GET-only poll path cannot feed. What
+// makes it work is that the instances are named explicitly — which is also what
+// keeps the cost knowable before the preset runs.
+func TestAPortPanelIsOneWidget(t *testing.T) {
+	oids := make([]string, 0, 48)
+	for i := 1; i <= 48; i++ {
+		oids = append(oids, "1.3.6.1.2.1.2.2.1.8."+strconv.Itoa(i))
+	}
+	p := valid()
+	p.Widgets = []Widget{{Kind: KindGrid, Title: "Ports", OIDs: oids,
+		Labels: map[string]string{"1": "up", "2": "down"}}}
+	if errs := Validate(p); len(errs) != 0 {
+		t.Fatalf("a 48-port grid was refused: %s", fieldsOf(errs))
+	}
+	if c := Estimate(p); c.OIDs != 48 || c.Widgets != 1 {
+		t.Errorf("cost = %d OIDs across %d widgets, want 48 across 1", c.OIDs, c.Widgets)
+	}
+	// And a table kind no longer exists: it would need a walk.
+	if _, known := widgetDoc("table"); known {
+		t.Error("the table kind is still in the vocabulary; the poll path is GET-only")
 	}
 }
 


### PR DESCRIPTION
Two commits. The first fixes what #37 got wrong, found by reading it back before anything depends on it; the second is the part that actually meets a file.

## The cost screen would have said zero

`Estimate` divided an hour by the cadence, in integers, and `MaxIntervalSec` is a **day**:

| cadence | reported | truth |
| --- | --- | --- |
| 30 s | 120 rounds/h | correct |
| 2400 s | 1 | 1.5 |
| 3601 s | **0** | 0.999 |
| 86400 s | **0** | — |

A third of the legal range answering *"nothing"* on the one number an operator is shown before agreeing to it. The base is now a **day**, so the slowest cadence the format admits still counts one.

`RequestsPerHour` is **gone** rather than renamed. It was documented as requests and was actually rounds: how many requests a round takes depends on the transport's chunk size (`maxVarbindsPerGet = 30`), so at the 500-OID bound it understated by seventeen. That number belongs where both packages are already in scope, not copied into `pkg/preset` where it would drift.

## Three more, all wrong answers rather than crashes

**A title is measured in characters.** `MaxTextLen` exists for layout, and layout is characters — `checkText` counted bytes, so a 44-character Chinese widget title was refused for being too long to fit in a panel it fits in comfortably, in an app shipping a `zh` locale. `pkg/mib/editor.go` already carries this exact fix. `clip` had the same shape and worse consequences: it sliced bytes at 40, splitting a rune, and `Error.Args` crosses the bridge as JSON — the message quoting the offending value back to the author *misquoted it*.

**A negative format version was accepted.** The check tested `== 0` then `> 1`; `-1` fell through both as though it had been declared.

**A label key was not checked at all**, only its value — although the key is author-supplied text interpolated into `Error.Field` and rendered as the name of the state it maps. It now has to be an integer, which is what a state is.

And an OID was bounded in *shape* but not on the *wire*: gosnmp marshals a sub-identifier as a `uint32` and RFC 2578 7.1.3 caps an object identifier at 128 of them. Past either it is not a large OID, it is not an OID — and refusing it here is the difference between a message naming the file and a failure inside the encoder.

## The vocabulary loses `table` and gains `grid`

Removing `table` is a correction, not a trim. A conceptual table is a **walk**, and the poll path a preset feeds is GET-only: `PollOIDs` → `snmp.GetMany` → `g.Get`, and a table's OID GET'd answers `noSuchObject`. The pivot also needs the column definitions and the INDEX rules out of the MIB (`pkg/mib/table.go`), which a flat list of numeric OIDs cannot supply. It would have been a kind the editor offers and the wire cannot serve.

`grid` is what that want actually reduces to here — and it is the port panel this feature was asked for: **one widget, one cell per OID, one label map**, forty-eight interfaces as one thing to look at rather than forty-eight things. The instances are named explicitly, which is also what keeps the preset's cost knowable before it runs. Nothing outside the package referenced either kind yet, so the vocabulary could still change without a format version.

## Reading a file

Three answers, not two: `LoadFile` returns a **read** error, a **validation** error list, and the preset. An unreadable file is a permission problem and an invalid one is a formatting problem; collapsing them reports the wrong one to whoever has to fix it. A file that is not JSON at all becomes one error with an empty field path rather than `encoding/json`'s message — the caller renders a field name beside each problem, and `invalid character '<'` in that column reads as a problem with a field called nothing.

The size bound is checked with `os.Stat` **before** the read, the way `importSingleFile` does for MIBs. `DisallowUnknownFields` is deliberately not used: `FormatVersion` is how this format handles a file from a version that has moved on, and refusing an unknown key would refuse exactly the files that mechanism exists to accept.

**One bad file must not hide the good ones.** A folder of files from strangers has a bad one in it, and a listing that fails entirely is one nobody can use to find which — so `List` reports a broken preset *with* its problem count and skips only what it cannot read. An absent directory lists empty (the state the feature ships in) and returns `[]`, never `nil`, which would cross the bridge as `null` and throw on the first `.map`.

**Matching is arc by arc, never as text.** `1.3.6.1.4.1.9` is Cisco; `1.3.6.1.4.1.911` is somebody else entirely, and `strings.HasPrefix` — the obvious implementation — says they are the same vendor. `MatchDepth` returns sub-identifiers rather than a boolean because two presets can both match, a vendor's generic one and a model's, and the specific one is the better advice. `Rank` **orders** a listing and never filters it: `Match` is documented as advice to the person binding, never an automatic action, and hiding the rest would turn advice into a decision.

## What is not here

Nothing reaches the bridge, the config directory or the UI yet — this is the pure half, testable without a directory the application owns. No `sysObjectID` is read from any device either; `MatchDepth` exists and is wired later.

## Checks

`go vet`, `staticcheck`, `go build`, `go test -count=1 ./pkg/preset/` — 13 existing tests plus 13 new ones. The ones worth naming: a cadence past an hour still has a cost and 40 minutes does not equal an hour; a 44-rune CJK title validates and `clip` never emits invalid UTF-8; `1.3.6.1.4.1.911` does not match Cisco; a zero `Match` is dropped by `omitzero` and still round-trips; one broken file among four still lists four.
