### PR TITLE
Turn a preset into a monitoring, bound to one equipment

### DIFF
--- a/app_monitor.go
+++ b/app_monitor.go
@@ -66,7 +66,9 @@ func (a *App) MonitorCreateSession(oid string, targets []string, intervalMs int,
 		return "", fmt.Errorf("storage not initialized")
 	}
 	sessConn, creds := conn.split()
-	id, err := a.storage.CreateSession(name, oid, targets, intervalMs, snmpVersion, time.Now().UTC().Format(time.RFC3339), thresholds, sessConn)
+	// nil: a session built by hand carries no preset snapshot. PresetBind is
+	// the one caller that passes one.
+	id, err := a.storage.CreateSession(name, oid, targets, intervalMs, snmpVersion, time.Now().UTC().Format(time.RFC3339), thresholds, sessConn, nil)
 	if err != nil {
 		return "", err
 	}

--- a/app_preset.go
+++ b/app_preset.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"SnmpLens/pkg/mib"
 	"SnmpLens/pkg/preset"
 	"SnmpLens/pkg/snmp"
+	"SnmpLens/pkg/storage"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -272,6 +274,85 @@ func (a *App) ImportPresetDialog() ([]PresetImportResult, error) {
 	// Cancelled. An empty ARRAY rather than nil: the caller renders a result
 	// list, and null throws on .map.
 	return a.ImportPresetFiles(paths), nil
+}
+
+// PresetBind is the moment a preset stops being a file and starts being a
+// monitoring: it creates one session for one equipment and starts it.
+//
+// ONE SESSION PER TARGET, never one session across several. The cost was stated
+// per equipment, the credentials are per equipment, and the guardrail in
+// pkg/monitor is per session — so one slow device backing off must not slow the
+// healthy ones down with it.
+//
+// What to poll is materialised into the session's OWN columns: the OID list and
+// the interval are what the poll clock reads, and it never opens the snapshot.
+// A session whose layout cannot be decoded keeps polling and loses its
+// dashboard; the other way round it would keep its dashboard and poll nothing.
+//
+// A preset with problems cannot be bound. It can be imported, listed and read —
+// that is what the error list is for — but binding is the step that puts
+// traffic on somebody's network, and doing that from a file this application
+// has already said it does not understand is not a thing to do quietly.
+func (a *App) PresetBind(fileName, target, snmpVersion string, conn MonitorConnection) (storage.Session, error) {
+	if a.storage == nil || a.scheduler == nil {
+		return storage.Session{}, fmt.Errorf("storage not initialized")
+	}
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return storage.Session{}, fmt.Errorf("a preset is bound to an equipment; no target was given")
+	}
+
+	path, err := a.resolvePresetPath(fileName)
+	if err != nil {
+		return storage.Session{}, err
+	}
+	p, errs, err := preset.LoadFile(path)
+	if err != nil {
+		return storage.Session{}, err
+	}
+	if len(errs) > 0 {
+		return storage.Session{}, fmt.Errorf(
+			"%s has %d problem(s) and cannot be bound until they are fixed", filepath.Base(path), len(errs))
+	}
+
+	oids := preset.PollOIDs(p)
+	if len(oids) == 0 {
+		return storage.Session{}, fmt.Errorf("%s polls nothing", filepath.Base(path))
+	}
+
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		name = filepath.Base(path)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	sessConn, creds := conn.split()
+
+	id, err := a.storage.CreateSession(
+		name, strings.Join(oids, ","), []string{target},
+		p.IntervalSec*1000, snmpVersion, now,
+		// No thresholds: a preset describes what to WATCH, and what counts as
+		// too much is the operator's judgement about their own network.
+		nil, sessConn,
+		&storage.SessionPreset{
+			File:          filepath.Base(path),
+			Name:          p.Name,
+			FormatVersion: p.FormatVersion,
+			BoundAt:       now,
+			Widgets:       p.Widgets,
+		},
+	)
+	if err != nil {
+		return storage.Session{}, err
+	}
+	a.saveSessionCreds(id, creds)
+
+	if err := a.MonitorStart(id); err != nil {
+		// The session exists and is stored; it simply is not polling. Reported
+		// rather than rolled back, because deleting it would throw away the
+		// binding the operator just made and leave nothing to retry from.
+		log.Printf("PresetBind: %s created but not started: %v", id, err)
+	}
+	return a.findSession(id)
 }
 
 // DeletePreset removes one preset from the library.

--- a/app_presetbind_test.go
+++ b/app_presetbind_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/monitor"
+	"SnmpLens/pkg/secrets"
+	"SnmpLens/pkg/storage"
+)
+
+// An app with everything binding needs: storage, a secret store, a preset
+// directory and a scheduler.
+func newBindApp(t *testing.T) (*App, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	st, err := storage.Init(filepath.Join(dir, "monitoring.db"))
+	if err != nil {
+		t.Fatalf("storage.Init: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	sec, err := secrets.Open(dir)
+	if err != nil {
+		t.Fatalf("secrets.Open: %v", err)
+	}
+
+	mibDir := filepath.Join(dir, "SnmpLens", "mibs")
+	if err := os.MkdirAll(mibDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	a := &App{storage: st, secrets: sec, persistentMibDir: mibDir}
+	a.scheduler = monitor.NewScheduler()
+	// The clock must not actually reach a network in a unit test, and Persist
+	// is required by the scheduler.
+	a.scheduler.Persist = func([]monitor.Point) {}
+	t.Cleanup(func() { a.scheduler.StopAll() })
+
+	presetDir, err := a.presetDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a, presetDir
+}
+
+func putPreset(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Binding turns a file into a monitoring, and what to POLL has to land in the
+// session's own columns.
+//
+// The mistake this catches is storing what to poll only in the snapshot: the
+// dashboard would look perfect while specFor — which reads sess.OID and
+// sess.IntervalMs and nothing else — polls nothing at all.
+func TestPresetBindMaterialisesTheOidsAndTheInterval(t *testing.T) {
+	a, dir := newBindApp(t)
+
+	// Three widgets, two of which share an OID: the poll list is the
+	// deduplicated set, in a stable order.
+	putPreset(t, dir, "cisco.json", `{
+	  "formatVersion": 1, "name": "Cisco Catalyst", "intervalSec": 45,
+	  "widgets": [
+	    {"kind": "value", "title": "Uptime", "oids": ["1.3.6.1.2.1.1.3.0"]},
+	    {"kind": "chart", "title": "Uptime again", "oids": [".1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.2.2.1.10.1"]},
+	    {"kind": "status", "title": "Link", "oids": ["1.3.6.1.2.1.2.2.1.8.1"], "labels": {"1": "up"}}
+	  ]
+	}`)
+
+	sess, err := a.PresetBind("cisco.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161, TimeoutSec: 2, Retries: 1})
+	if err != nil {
+		t.Fatalf("PresetBind: %v", err)
+	}
+
+	if want := "1.3.6.1.2.1.1.3.0,1.3.6.1.2.1.2.2.1.10.1,1.3.6.1.2.1.2.2.1.8.1"; sess.OID != want {
+		t.Errorf("oid column = %q, want %q", sess.OID, want)
+	}
+	if sess.IntervalMs != 45000 {
+		t.Errorf("interval_ms = %d, want 45000 (intervalSec x 1000)", sess.IntervalMs)
+	}
+	if len(sess.Targets) != 1 || sess.Targets[0] != "10.0.0.1" {
+		t.Errorf("targets = %v; a preset is bound to ONE equipment", sess.Targets)
+	}
+	if sess.Name != "Cisco Catalyst" {
+		t.Errorf("name = %q", sess.Name)
+	}
+
+	// The snapshot came with it, and it is the layout rather than the poll list.
+	if sess.Preset == nil {
+		t.Fatal("the session carries no snapshot")
+	}
+	if sess.Preset.File != "cisco.json" || len(sess.Preset.Widgets) != 3 {
+		t.Errorf("snapshot: %+v", sess.Preset)
+	}
+
+	// And the specification the poll clock would build reads the columns.
+	spec := a.specFor(sess)
+	if len(spec.OIDs) != 3 || spec.Interval.Seconds() != 45 {
+		t.Errorf("the poll clock would use %d OID(s) every %v", len(spec.OIDs), spec.Interval)
+	}
+	if !a.scheduler.IsRunning(sess.ID) {
+		t.Error("binding did not start the session")
+	}
+}
+
+// Binding is the step that puts traffic on somebody's network. Doing it from a
+// file this application has already said it does not understand is not a thing
+// to do quietly.
+func TestAPresetWithProblemsCannotBeBound(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "broken.json", `{"formatVersion": 1, "name": "", "intervalSec": 0,
+	  "widgets": [{"kind": "iframe", "title": "x", "oids": ["sysUpTime.0"]}]}`)
+
+	_, err := a.PresetBind("broken.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161})
+	if err == nil {
+		t.Fatal("a preset with problems was bound")
+	}
+	if !strings.Contains(err.Error(), "problem") {
+		t.Errorf("the refusal does not say why: %v", err)
+	}
+	// And nothing was created on the way to refusing.
+	if sessions, _ := a.storage.ListSessions(); len(sessions) != 0 {
+		t.Errorf("%d session(s) left behind by a refused bind", len(sessions))
+	}
+}
+
+// A preset is bound to an EQUIPMENT. Without one there is nothing to poll and
+// nothing to name the session after.
+func TestBindingRefusesWithoutATarget(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ok.json", goodPreset)
+
+	if _, err := a.PresetBind("ok.json", "   ", "v2c", MonitorConnection{Port: 161}); err == nil {
+		t.Error("a preset was bound to no equipment")
+	}
+	if _, err := a.PresetBind("../monitoring.db", "10.0.0.1", "v2c", MonitorConnection{Port: 161}); err == nil {
+		t.Error("a path outside the library was bound")
+	}
+	if sessions, _ := a.storage.ListSessions(); len(sessions) != 0 {
+		t.Errorf("%d session(s) created by refused binds", len(sessions))
+	}
+}
+
+// The credentials go to pkg/secrets, never into monitoring.db — the same rule
+// MonitorCreateSession follows, and the reason SessionConn exists.
+func TestBindingStoresTheCredentialsOutsideTheDatabase(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ok.json", goodPreset)
+
+	sess, err := a.PresetBind("ok.json", "10.0.0.1", "v2c", MonitorConnection{
+		Port: 161, TimeoutSec: 2, Community: "s3cret-community",
+	})
+	if err != nil {
+		t.Fatalf("PresetBind: %v", err)
+	}
+
+	raw, err := a.secrets.Get(secrets.SessionRef(sess.ID))
+	if err != nil || !strings.Contains(raw, "s3cret-community") {
+		t.Errorf("the community did not reach the secret store: %q %v", raw, err)
+	}
+	if sess.Conn == nil || sess.Conn.Port != 161 {
+		t.Errorf("the connection profile did not survive: %+v", sess.Conn)
+	}
+
+	// Nothing secret in the row itself.
+	sessions, _ := a.storage.ListSessions()
+	for _, s := range sessions {
+		if s.Conn != nil && strings.Contains(strings.ToLower(s.Name+s.OID), "s3cret") {
+			t.Error("the community reached the session row")
+		}
+	}
+}
+
+// Two equipments, two sessions: the cost was stated per equipment, the
+// credentials are per equipment, and the guardrail in pkg/monitor is per
+// session — so one slow device must not back off the healthy one with it.
+func TestBindingTheSamePresetTwiceGivesTwoSessions(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ok.json", goodPreset)
+
+	first, err := a.PresetBind("ok.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := a.PresetBind("ok.json", "10.0.0.2", "v2c", MonitorConnection{Port: 161})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID == second.ID {
+		t.Fatal("the second bind reused the first session")
+	}
+	if !a.scheduler.IsRunning(first.ID) || !a.scheduler.IsRunning(second.ID) {
+		t.Error("both sessions should be polling independently")
+	}
+	if sessions, _ := a.storage.ListSessions(); len(sessions) != 2 {
+		t.Errorf("%d session(s) for two equipments", len(sessions))
+	}
+}
+
+// The snapshot is a snapshot. Editing the file afterwards changes nothing
+// already bound, and deleting it stops nothing — rebinding is how an edit is
+// adopted, and the opposite behaviour reads as a bug either way round.
+func TestEditingOrDeletingThePresetDoesNotChangeABoundSession(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ok.json", goodPreset)
+
+	sess, err := a.PresetBind("ok.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := sess.OID
+	widgets := len(sess.Preset.Widgets)
+
+	// Rewrite it with a different OID and a different cadence, then delete it.
+	putPreset(t, dir, "ok.json", `{"formatVersion": 1, "name": "Changed", "intervalSec": 600,
+	  "widgets": [{"kind": "value", "title": "Something else", "oids": ["1.3.6.1.2.1.1.5.0"]}]}`)
+	if err := a.DeletePreset("ok.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, _ := a.storage.ListSessions()
+	if len(sessions) != 1 {
+		t.Fatalf("%d session(s) after deleting the file", len(sessions))
+	}
+	if sessions[0].OID != before {
+		t.Errorf("the session started polling something else: %q then %q", before, sessions[0].OID)
+	}
+	if sessions[0].Preset == nil || len(sessions[0].Preset.Widgets) != widgets {
+		t.Error("the layout followed the file instead of staying put")
+	}
+	if !a.scheduler.IsRunning(sessions[0].ID) {
+		t.Error("deleting the preset stopped the monitoring")
+	}
+}

--- a/app_sessionsecret_test.go
+++ b/app_sessionsecret_test.go
@@ -19,7 +19,7 @@ func TestDeletingASessionRemovesItsCredentials(t *testing.T) {
 	a := newTestApp(t)
 
 	id, err := a.storage.CreateSession("core switches", "1.3.6.1.2.1.2.2.1.10.1",
-		[]string{"10.0.0.1"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+		[]string{"10.0.0.1"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestRetentionRemovesTheCredentialsOfTheSessionsItDeletes(t *testing.T) {
 	a := newTestApp(t)
 
 	id, err := a.storage.CreateSession("finished", "1.3.6.1.2.1.1.3.0",
-		[]string{"10.0.0.2"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+		[]string{"10.0.0.2"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestRetentionLeavesLiveSessionsAndTheirCredentialsAlone(t *testing.T) {
 	a := newTestApp(t)
 
 	live, err := a.storage.CreateSession("running", "1.3.6.1.2.1.1.3.0",
-		[]string{"10.0.0.3"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+		[]string{"10.0.0.3"}, 1000, "v2c", time.Now().UTC().Format(time.RFC3339), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/frontend/src/stores/pollingStore.js
+++ b/frontend/src/stores/pollingStore.js
@@ -159,18 +159,23 @@ function createPollingStore() {
       throw e;
     }
 
+    // Built through the SAME function as a session restored from Go. It used
+    // to be a second object literal here, and it had already drifted: it never
+    // set needsConnection, so the field consumers test was simply absent on
+    // every session created in this window and present on every restored one.
     update((sessions) => [...sessions, {
-      id,
-      name: (name || '').trim(),
-      oid: oidList[0],
-      oids: oidList,
-      targets,
-      interval: intervalMs,
-      snmpVersion,
-      results: [],
+      ...sessionFromBackend({
+        id,
+        name: (name || '').trim(),
+        oid: oidKey,
+        targets,
+        intervalMs,
+        snmpVersion,
+        startedAt: new Date().toISOString(),
+        thresholds: thresholdsPayload || {},
+        conn,
+      }),
       running: true,
-      startedAt: new Date().toISOString(),
-      thresholds: thresholdsPayload || {},
     }]);
 
     try {
@@ -227,6 +232,45 @@ function createPollingStore() {
     await Promise.allSettled(ids.map((id) => MonitorStop(id)));
   }
 
+  /**
+   * One session, in the shape the rest of the interface expects.
+   *
+   * ONE function, for the same reason normalisePoint is one: there are two ways
+   * a session arrives from Go — restored at startup, and handed back by
+   * PresetBind — and two builders of the same object is the defect, not the
+   * symptom. Every consumer reads `oids`, `interval` and `needsConnection`, and
+   * a second copy that forgets one of them produces a session that renders
+   * almost correctly.
+   */
+  function sessionFromBackend(s, results = []) {
+    const oids = (s.oid || '').split(',').map((o) => o.trim()).filter(Boolean);
+    return {
+      id: s.id,
+      name: s.name || '',
+      oid: oids[0] || '',
+      oids,
+      targets: s.targets || [],
+      interval: s.intervalMs,
+      snmpVersion: s.snmpVersion,
+      results,
+      running: false,
+      startedAt: s.startedAt,
+      thresholds: s.thresholds || {},
+      // A session stored before the connection was persisted cannot be polled
+      // from Go; the UI offers to re-arm it with the current settings rather
+      // than failing silently.
+      needsConnection: !s.conn,
+      // The dashboard layout this session was bound with, or null. A SNAPSHOT:
+      // Go took it when the preset was bound, so editing the file afterwards
+      // changes nothing here.
+      preset: s.preset || null,
+      // Declared from the start rather than attached when the first report
+      // arrives, so a consumer testing it sees null on a fresh session instead
+      // of undefined — and so both ways in produce the same object.
+      overrun: null,
+    };
+  }
+
   // Load persisted sessions, then ask Go which ones are actually polling. That
   // second question matters: with the window closed the scheduler kept running,
   // so the database's `active` flag is a record of intent while MonitorRunning
@@ -240,7 +284,6 @@ function createPollingStore() {
       }
       const loaded = [];
       for (const s of sessions) {
-        const oids = (s.oid || '').split(',').map((o) => o.trim()).filter(Boolean);
         let results = [];
         try {
           const points = await MonitorLoadSessionData(s.id, MAX_DATA_POINTS * (s.targets?.length || 1));
@@ -248,23 +291,7 @@ function createPollingStore() {
         } catch (e) {
           console.warn('Failed to load session data:', e);
         }
-        loaded.push({
-          id: s.id,
-          name: s.name || '',
-          oid: oids[0] || '',
-          oids,
-          targets: s.targets || [],
-          interval: s.intervalMs,
-          snmpVersion: s.snmpVersion,
-          results,
-          running: false,
-          startedAt: s.startedAt,
-          thresholds: s.thresholds || {},
-          // A session stored before the connection was persisted cannot be
-          // polled from Go; the UI offers to re-arm it with the current
-          // settings rather than failing silently.
-          needsConnection: !s.conn,
-        });
+        loaded.push(sessionFromBackend(s, results));
       }
       set(loaded);
     } catch (e) {
@@ -358,9 +385,29 @@ function createPollingStore() {
     }
   }
 
+  /**
+   * Take a session Go has just created — PresetBind — into the store.
+   *
+   * It is already stored and already polling by the time this runs, so this
+   * adds no session and starts nothing: it makes the window show what the poll
+   * clock is doing. Idempotent, because a caller that retries after a slow
+   * bridge call must not produce two rows for one monitoring.
+   */
+  function adoptSession(s) {
+    if (!s || !s.id) return null;
+    const shaped = { ...sessionFromBackend(s), running: true };
+    update((sessions) => (
+      sessions.some((x) => x.id === s.id)
+        ? sessions.map((x) => (x.id === s.id ? { ...shaped, results: x.results } : x))
+        : [...sessions, shaped]
+    ));
+    return shaped;
+  }
+
   return {
     subscribe,
     acceptSlow,
+    adoptSession,
     startPolling,
     resumeSession,
     stopPolling,

--- a/frontend/tests/polling.smoke.mjs
+++ b/frontend/tests/polling.smoke.mjs
@@ -224,4 +224,50 @@ check('the session reads as stopped', !!s && s.running === false);
   check('recovering takes the banner away', o === null, JSON.stringify(o));
 }
 
+// One builder for the session shape.
+//
+// There are two ways a session arrives: created here, and handed back by Go
+// (PresetBind, or restored at startup). Two object literals building the same
+// thing is the defect normalisePoint was written to end, and it had already
+// happened — the local one never set needsConnection, so the field every
+// consumer tests was absent on sessions made in this window and present on
+// restored ones.
+{
+  const local = get(pollingStore).find((x) => x.id === id);
+  const adopted = pollingStore.adoptSession({
+    id: 'bound-1',
+    name: 'Cisco Catalyst',
+    oid: '1.3.6.1.2.1.1.3.0,1.3.6.1.2.1.2.2.1.10.1',
+    targets: ['10.0.0.9'],
+    intervalMs: 45000,
+    snmpVersion: 'v2c',
+    startedAt: '2026-01-01T00:00:00Z',
+    conn: { port: 161 },
+    preset: { file: 'cisco.json', formatVersion: 1, widgets: [{ kind: 'value', title: 'Uptime', oids: ['1.3.6.1.2.1.1.3.0'] }] },
+  });
+
+  const keys = (o) => Object.keys(o).sort().join(',');
+  check('a bound session has the same shape as a locally created one',
+    keys(local) === keys(adopted), `${keys(local)} vs ${keys(adopted)}`);
+
+  check('the OID list was split out of the stored column',
+    adopted.oids.length === 2 && adopted.oid === '1.3.6.1.2.1.1.3.0', JSON.stringify(adopted.oids));
+  check('the cadence came across', adopted.interval === 45000, String(adopted.interval));
+  check('a session with a connection does not ask to be re-armed', adopted.needsConnection === false);
+  check('the dashboard layout came with it', adopted.preset?.widgets?.length === 1);
+  check('and it is polling, because Go already started it', adopted.running === true);
+
+  const inStore = get(pollingStore).find((x) => x.id === 'bound-1');
+  check('the bound session reached the store', !!inStore && inStore.name === 'Cisco Catalyst');
+
+  // Adopting twice must not produce two rows for one monitoring: a caller that
+  // retries after a slow bridge call is the ordinary case, not the exotic one.
+  pollingStore.adoptSession({ id: 'bound-1', oid: '1.1', targets: ['10.0.0.9'], intervalMs: 45000, conn: {} });
+  check('adopting the same session twice is idempotent',
+    get(pollingStore).filter((x) => x.id === 'bound-1').length === 1);
+
+  check('a session with no connection asks to be re-armed',
+    pollingStore.adoptSession({ id: 'legacy-1', oid: '1.1', targets: ['x'], intervalMs: 1000 }).needsConnection === true);
+}
+
 process.exit(failures ? 1 : 0);

--- a/pkg/storage/preset_test.go
+++ b/pkg/storage/preset_test.go
@@ -1,0 +1,205 @@
+package storage
+
+import (
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/preset"
+)
+
+// The snapshot survives the round trip, and it is a SNAPSHOT: what the session
+// draws is what the file said WHEN IT WAS BOUND, not what the file says now.
+func TestASessionCarriesItsPresetSnapshot(t *testing.T) {
+	st := newTestStorage(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	bound := &SessionPreset{
+		File: "cisco.json", Name: "Cisco Catalyst", FormatVersion: 1, BoundAt: now,
+		Widgets: []preset.Widget{
+			{Kind: preset.KindValue, Title: "Uptime", OIDs: []string{"1.3.6.1.2.1.1.3.0"}},
+			{Kind: preset.KindGrid, Title: "Ports", OIDs: []string{"1.3.6.1.2.1.2.2.1.8.1"},
+				Labels: map[string]string{"1": "up", "2": "down"}},
+		},
+	}
+	id, err := st.CreateSession("Cisco Catalyst", "1.3.6.1.2.1.1.3.0,1.3.6.1.2.1.2.2.1.8.1",
+		[]string{"10.0.0.1"}, 30000, "v2c", now, nil, &SessionConn{Port: 161}, bound)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	sessions, err := st.ListSessions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sessions) != 1 || sessions[0].Preset == nil {
+		t.Fatalf("the snapshot did not round-trip: %+v", sessions)
+	}
+	got := sessions[0].Preset
+	if got.File != "cisco.json" || got.FormatVersion != 1 || len(got.Widgets) != 2 {
+		t.Fatalf("snapshot changed shape: %+v", got)
+	}
+	if got.Widgets[1].Kind != preset.KindGrid || got.Widgets[1].Labels["2"] != "down" {
+		t.Errorf("the widget layout did not survive: %+v", got.Widgets[1])
+	}
+
+	// What to POLL lives in the session's own columns, not in the snapshot. The
+	// poll clock never opens this blob, so a session whose layout cannot be
+	// decoded keeps polling and loses only its dashboard.
+	if sessions[0].OID != "1.3.6.1.2.1.1.3.0,1.3.6.1.2.1.2.2.1.8.1" || sessions[0].IntervalMs != 30000 {
+		t.Errorf("what to poll was not materialised: oid=%q interval=%d", sessions[0].OID, sessions[0].IntervalMs)
+	}
+
+	// And a preset carries no credential, so nothing secret may reach the blob.
+	var raw sql.NullString
+	if err := st.db.QueryRow(`SELECT preset FROM sessions WHERE id = ?`, id).Scan(&raw); err != nil {
+		t.Fatalf("read the stored snapshot: %v", err)
+	}
+	for _, forbidden := range []string{"community", "authpass", "privpass", "password", "secret"} {
+		if strings.Contains(strings.ToLower(raw.String), forbidden) {
+			t.Errorf("the snapshot carries %q into the database: %s", forbidden, raw.String)
+		}
+	}
+}
+
+// A session nobody bound from a preset reports nil, rather than an empty
+// snapshot that reads as "a preset with no widgets".
+func TestASessionWithoutAPresetReportsNil(t *testing.T) {
+	st := newTestStorage(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := st.CreateSession("", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	sessions, _ := st.ListSessions()
+	if len(sessions) != 1 || sessions[0].Preset != nil {
+		t.Errorf("a hand-built session must report Preset == nil, got %+v", sessions[0].Preset)
+	}
+}
+
+// The upgrade direction, which is the one with the worst blast radius.
+//
+// ensureColumn adds a column to a database that predates it, and it LOGS AND
+// CONTINUES when the ALTER fails — which is right for an optional column and
+// fatal for a SELECT that names it anyway: "no such column: preset" takes every
+// session with it, including the ones still polling. So this builds the old
+// schema by hand, opens it, and requires the sessions to still be there.
+func TestASessionCreatedBeforeThePresetColumnStillLists(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "monitoring.db")
+
+	// The sessions table as it was before this change: no preset column.
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE sessions (
+		id TEXT PRIMARY KEY, name TEXT, oid TEXT NOT NULL, targets TEXT NOT NULL,
+		interval_ms INTEGER NOT NULL, snmp_version TEXT NOT NULL, started_at TEXT NOT NULL,
+		stopped_at TEXT, thresholds TEXT, active INTEGER NOT NULL DEFAULT 0, conn TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := db.Exec(
+		`INSERT INTO sessions (id, name, oid, targets, interval_ms, snmp_version, started_at, active)
+		 VALUES ('old-1', 'before the column', '1.3.6.1.2.1.1.3.0', '["10.0.0.1"]', 5000, 'v2c', ?, 1)`,
+		now); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err := Init(path)
+	if err != nil {
+		t.Fatalf("Init on an older database: %v", err)
+	}
+	defer st.Close()
+
+	if !st.sessionsHavePreset {
+		t.Error("the migration did not add the column, and nothing said so")
+	}
+	sessions, err := st.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions after the migration: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "old-1" {
+		t.Fatalf("the pre-existing session disappeared: %+v", sessions)
+	}
+	if sessions[0].Preset != nil {
+		t.Errorf("a session that predates presets reported one: %+v", sessions[0].Preset)
+	}
+	if !sessions[0].Active {
+		t.Error("it also lost its active flag")
+	}
+
+	// And a new session can still be created on the upgraded database.
+	if _, err := st.CreateSession("after", "1.1", []string{"10.0.0.2"}, 5000, "v2c", now, nil, nil,
+		&SessionPreset{File: "x.json", FormatVersion: 1}); err != nil {
+		t.Fatalf("CreateSession after the migration: %v", err)
+	}
+	if sessions, _ := st.ListSessions(); len(sessions) != 2 {
+		t.Errorf("%d sessions after adding one", len(sessions))
+	}
+}
+
+// The other half of the same rule: when the column is NOT there, everything
+// still works and only the layout is lost.
+//
+// Simulated rather than hoped for — sessionsHavePreset is what every branch
+// reads, so forcing it false exercises exactly the state a failed ALTER leaves.
+func TestWithoutThePresetColumnSessionsStillWork(t *testing.T) {
+	st := newTestStorage(t)
+	st.sessionsHavePreset = false
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	id, err := st.CreateSession("degraded", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil,
+		&SessionPreset{File: "cisco.json", FormatVersion: 1,
+			Widgets: []preset.Widget{{Kind: preset.KindValue, Title: "x", OIDs: []string{"1.1"}}}})
+	if err != nil {
+		t.Fatalf("a session could not be created without the column: %v", err)
+	}
+	sessions, err := st.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions without the column: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != id {
+		t.Fatalf("the session is not listed: %+v", sessions)
+	}
+	if sessions[0].Preset != nil {
+		t.Error("a snapshot appeared although the column is absent")
+	}
+	if sessions[0].OID != "1.1" || sessions[0].IntervalMs != 5000 {
+		t.Error("what to poll was lost with the layout")
+	}
+}
+
+// A snapshot that cannot be decoded costs the dashboard its layout and must not
+// cost the session its poll.
+func TestAnUnreadableSnapshotDoesNotHideTheSession(t *testing.T) {
+	st := newTestStorage(t)
+	now := time.Now().UTC().Format(time.RFC3339)
+	id, err := st.CreateSession("corrupt", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil,
+		&SessionPreset{File: "x.json", FormatVersion: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.Exec(`UPDATE sessions SET preset = ? WHERE id = ?`, "{not json", id); err != nil {
+		t.Fatal(err)
+	}
+
+	sessions, err := st.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions with a corrupt snapshot: %v", err)
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("the session vanished: %+v", sessions)
+	}
+	if sessions[0].Preset != nil {
+		t.Error("a corrupt snapshot was decoded into something")
+	}
+	if sessions[0].OID != "1.1" {
+		t.Error("the session lost what it polls")
+	}
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"SnmpLens/pkg/preset"
+
 	_ "modernc.org/sqlite"
 )
 
@@ -27,6 +29,14 @@ type Storage struct {
 	historySaves int // counter to trim query_history only periodically
 	eventWrites  int // counter to trim the event journal only periodically
 	outboxWrites int // same, for the delivery outbox
+	// sessionsHavePreset records whether the preset column is really there.
+	//
+	// ensureColumn logs and continues when an ALTER fails, which is right for
+	// an optional column — but a SELECT that names it unconditionally then
+	// fails with "no such column" and EVERY session disappears from the
+	// interface, including the ones still polling. Reading the answer once at
+	// startup costs nothing and bounds that to a missing label.
+	sessionsHavePreset bool
 }
 
 type Session struct {
@@ -47,6 +57,35 @@ type Session struct {
 	// now lives in Go: a background poll has no renderer to ask for the
 	// connection settings, and after a restart there is no renderer at all.
 	Conn *SessionConn `json:"conn,omitempty"`
+	// Preset is the dashboard description this session was created from, if it
+	// was created from one at all. Nil for a session someone built by hand.
+	Preset *SessionPreset `json:"preset,omitempty"`
+}
+
+// SessionPreset is what a bound preset left behind, and it is a SNAPSHOT.
+//
+// Not a reference to the file. Editing a preset afterwards changes nothing
+// already bound, and deleting it stops nothing — rebinding is how an edit is
+// adopted. The alternative reads well right up to the moment somebody fixes a
+// typo in a preset and three sessions silently start polling different OIDs,
+// with the charts keeping the old labels.
+//
+// It is also the reason the session row still carries oid and interval_ms in
+// its own columns: what to poll is materialised there, so the poll clock never
+// reads this blob and a session whose snapshot cannot be decoded still polls.
+// This is notify_outbox's rule — self-contained, never joining back to what
+// produced it — applied to the one other place a stranger's file reaches
+// durable state.
+type SessionPreset struct {
+	// File is where it came from, for the label. It may no longer exist.
+	File string `json:"file"`
+	Name string `json:"name,omitempty"`
+	// FormatVersion is the version that was READ, so a session bound by an
+	// older release is recognisable rather than reinterpreted.
+	FormatVersion int `json:"formatVersion"`
+	BoundAt       string `json:"boundAt,omitempty"`
+	// Widgets is the layout, exactly as the file declared it.
+	Widgets []preset.Widget `json:"widgets"`
 }
 
 // SessionConn holds the NON-SECRET SNMP connection parameters of a session.
@@ -331,11 +370,13 @@ func Init(dbPath string) (*Storage, error) {
 	ensureColumn(db, "data_points", "oid", "TEXT")
 	ensureColumn(db, "sessions", "name", "TEXT")
 	ensureColumn(db, "sessions", "conn", "TEXT")
+	havePreset := ensureColumn(db, "sessions", "preset", "TEXT")
 
 	s := &Storage{
-		db:          db,
-		batchTicker: time.NewTicker(5 * time.Second),
-		done:        make(chan struct{}),
+		db:                 db,
+		batchTicker:        time.NewTicker(5 * time.Second),
+		done:               make(chan struct{}),
+		sessionsHavePreset: havePreset,
 	}
 
 	// Background batch flush goroutine. Close waits for it.
@@ -385,7 +426,7 @@ func (s *Storage) Close() error {
 }
 
 // CreateSession inserts a new monitoring session and returns its UUID.
-func (s *Storage) CreateSession(name, oid string, targets []string, intervalMs int, snmpVersion, startedAt string, thresholds map[string]*Thresholds, conn *SessionConn) (string, error) {
+func (s *Storage) CreateSession(name, oid string, targets []string, intervalMs int, snmpVersion, startedAt string, thresholds map[string]*Thresholds, conn *SessionConn, bound *SessionPreset) (string, error) {
 	id := generateUUID()
 	targetsJSON, _ := json.Marshal(targets)
 	var thresholdsJSON []byte
@@ -396,11 +437,23 @@ func (s *Storage) CreateSession(name, oid string, targets []string, intervalMs i
 	if conn != nil {
 		connJSON, _ = json.Marshal(conn)
 	}
-	_, err := s.db.Exec(
-		`INSERT INTO sessions (id, name, oid, targets, interval_ms, snmp_version, started_at, thresholds, active, conn)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
-		id, nullableString([]byte(name)), oid, string(targetsJSON), intervalMs, snmpVersion, startedAt, nullableString(thresholdsJSON), nullableString(connJSON),
-	)
+	cols := `(id, name, oid, targets, interval_ms, snmp_version, started_at, thresholds, active, conn)`
+	vals := `VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`
+	args := []any{id, nullableString([]byte(name)), oid, string(targetsJSON), intervalMs, snmpVersion, startedAt,
+		nullableString(thresholdsJSON), nullableString(connJSON)}
+	// The snapshot is written only when the column is really there. A session
+	// that loses its layout still polls; a session that could not be INSERTed
+	// at all does not exist.
+	if s.sessionsHavePreset {
+		var presetJSON []byte
+		if bound != nil {
+			presetJSON, _ = json.Marshal(bound)
+		}
+		cols = `(id, name, oid, targets, interval_ms, snmp_version, started_at, thresholds, active, conn, preset)`
+		vals = `VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`
+		args = append(args, nullableString(presetJSON))
+	}
+	_, err := s.db.Exec(`INSERT INTO sessions `+cols+` `+vals, args...)
 	if err != nil {
 		return "", fmt.Errorf("create session: %w", err)
 	}
@@ -442,7 +495,16 @@ func (s *Storage) DeleteSession(id string) error {
 
 // ListSessions returns all persisted sessions.
 func (s *Storage) ListSessions() ([]Session, error) {
-	rows, err := s.db.Query(`SELECT id, COALESCE(name, ''), oid, targets, interval_ms, snmp_version, started_at, stopped_at, thresholds, active, conn FROM sessions ORDER BY started_at DESC`)
+	// The preset column is named only when it is really there. ensureColumn
+	// logs and continues when an ALTER fails; a SELECT that named it anyway
+	// would fail with "no such column" and take EVERY session with it,
+	// including the ones still polling.
+	presetCol := "NULL"
+	if s.sessionsHavePreset {
+		presetCol = "preset"
+	}
+	rows, err := s.db.Query(`SELECT id, COALESCE(name, ''), oid, targets, interval_ms, snmp_version, started_at, stopped_at, thresholds, active, conn, ` +
+		presetCol + ` FROM sessions ORDER BY started_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -455,9 +517,10 @@ func (s *Storage) ListSessions() ([]Session, error) {
 		var stoppedAt sql.NullString
 		var thresholdsJSON sql.NullString
 		var connJSON sql.NullString
+		var presetJSON sql.NullString
 		var active int
 
-		if err := rows.Scan(&sess.ID, &sess.Name, &sess.OID, &targetsJSON, &sess.IntervalMs, &sess.SnmpVersion, &sess.StartedAt, &stoppedAt, &thresholdsJSON, &active, &connJSON); err != nil {
+		if err := rows.Scan(&sess.ID, &sess.Name, &sess.OID, &targetsJSON, &sess.IntervalMs, &sess.SnmpVersion, &sess.StartedAt, &stoppedAt, &thresholdsJSON, &active, &connJSON, &presetJSON); err != nil {
 			return nil, err
 		}
 
@@ -482,6 +545,14 @@ func (s *Storage) ListSessions() ([]Session, error) {
 			var c SessionConn
 			if json.Unmarshal([]byte(connJSON.String), &c) == nil {
 				sess.Conn = &c
+			}
+		}
+		// Decoded defensively, like Conn: a snapshot that cannot be read costs
+		// the dashboard its layout and must not cost the session its poll.
+		if presetJSON.Valid && presetJSON.String != "" {
+			var bound SessionPreset
+			if json.Unmarshal([]byte(presetJSON.String), &bound) == nil {
+				sess.Preset = &bound
 			}
 		}
 		sess.Active = active == 1
@@ -940,11 +1011,14 @@ func (s *Storage) ImportHistoryEntries(entries []map[string]interface{}) error {
 
 // ensureColumn adds a column to an existing table when it is missing. Errors
 // are logged, not fatal: a failure here only means the extra data is unavailable.
-func ensureColumn(db *sql.DB, table, column, ddl string) {
+// ensureColumn adds a column to an existing table, and reports whether the
+// column is there AFTERWARDS — which is not the same as whether it did
+// anything: it is already present on a fresh database, and an ALTER can fail.
+func ensureColumn(db *sql.DB, table, column, ddl string) bool {
 	rows, err := db.Query(fmt.Sprintf("PRAGMA table_info(%s)", table))
 	if err != nil {
 		log.Printf("storage: inspect %s: %v", table, err)
-		return
+		return false
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -953,15 +1027,17 @@ func ensureColumn(db *sql.DB, table, column, ddl string) {
 		var notnull, pk int
 		var dflt sql.NullString
 		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
-			return
+			return false
 		}
 		if name == column {
-			return // already present
+			return true // already present
 		}
 	}
 	if _, err := db.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", table, column, ddl)); err != nil {
 		log.Printf("storage: add %s.%s: %v", table, column, err)
+		return false
 	}
+	return true
 }
 
 // QueryBuckets aggregates a session's data points into fixed-width time buckets

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -68,7 +68,7 @@ func TestDeleteSessionCascadesDataPoints(t *testing.T) {
 	st := newTestStorage(t)
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	id, err := st.CreateSession("", "1.3.6.1.2.1.1.3.0", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil)
+	id, err := st.CreateSession("", "1.3.6.1.2.1.1.3.0", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestLegacyThresholdsMigrateToFirstOID(t *testing.T) {
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	id, err := st.CreateSession("legacy", "1.3.6.1.2.1.1.3.0,1.3.6.1.2.1.2.2.1.10.1",
-		[]string{"10.0.0.1"}, 5000, "v2c", now, nil, nil)
+		[]string{"10.0.0.1"}, 5000, "v2c", now, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestQueryBucketsAggregatesPerOIDAndWindow(t *testing.T) {
 	base := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
 
 	id, err := st.CreateSession("", "a,b", []string{"10.0.0.1"}, 5000, "v2c",
-		base.Format(time.RFC3339), nil, nil)
+		base.Format(time.RFC3339), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestSessionConnRoundTripsWithoutCredentials(t *testing.T) {
 		Port: 1161, TimeoutSec: 3, Retries: 2,
 		V3User: "snmplens", V3AuthProto: "SHA", V3PrivProto: "AES", V3SecLevel: "authPriv",
 	}
-	id, err := st.CreateSession("wan", "1.3.6.1.2.1.1.3.0", []string{"10.0.0.1"}, 5000, "v3", now, nil, conn)
+	id, err := st.CreateSession("wan", "1.3.6.1.2.1.1.3.0", []string{"10.0.0.1"}, 5000, "v3", now, nil, conn, nil)
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -265,7 +265,7 @@ func TestSessionConnRoundTripsWithoutCredentials(t *testing.T) {
 func TestSessionWithoutConnIsDistinguishable(t *testing.T) {
 	st := newTestStorage(t)
 	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := st.CreateSession("", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil); err != nil {
+	if _, err := st.CreateSession("", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	sessions, _ := st.ListSessions()
@@ -277,7 +277,7 @@ func TestSessionWithoutConnIsDistinguishable(t *testing.T) {
 func TestUpdateSessionConn(t *testing.T) {
 	st := newTestStorage(t)
 	now := time.Now().UTC().Format(time.RFC3339)
-	id, _ := st.CreateSession("", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil)
+	id, _ := st.CreateSession("", "1.1", []string{"10.0.0.1"}, 5000, "v2c", now, nil, nil, nil)
 
 	if err := st.UpdateSessionConn(id, &SessionConn{Port: 1161, TimeoutSec: 9}); err != nil {
 		t.Fatalf("UpdateSessionConn: %v", err)

--- a/pkg/storage/trimevents_test.go
+++ b/pkg/storage/trimevents_test.go
@@ -243,7 +243,7 @@ func TestCloseJoinsTheFlushGoroutine(t *testing.T) {
 func aSession(t *testing.T, st *Storage) string {
 	t.Helper()
 	id, err := st.CreateSession("test", "1.3.6.1.2.1.1.3.0", []string{"10.0.0.1"},
-		1000, "2c", time.Now().UTC().Format(time.RFC3339), nil, nil)
+		1000, "2c", time.Now().UTC().Format(time.RFC3339), nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Stacked on #40 — the base retargets to `main` once that merges.

The step the format and the library were built for: `PresetBind` takes a file and a target and produces a session that is **polling**.

## One session per target

Never one session across several equipments. The cost was stated per equipment, the credentials are per equipment, and the guardrail in `pkg/monitor` (#38) is per session — so one slow device backing off must not drag the healthy ones down with it. Binding the same preset to a second switch is a second session, independent in every one of those ways.

## What to poll is materialised; the layout is a snapshot

The OID list (deduplicated, stable — `preset.PollOIDs`) and the cadence go into the session's **own columns**, which is what `specFor` already reads. The poll clock never opens the snapshot.

So a session whose layout cannot be decoded keeps polling and loses only its dashboard. The other way round it would keep its dashboard and poll nothing — which looks correct and is not.

The snapshot is a **snapshot** rather than a reference to the file, and that is a decision rather than an implementation detail:

- editing a preset afterwards changes nothing already bound
- deleting it stops nothing
- rebinding is how an edit is adopted

The alternative reads well right up to the moment somebody fixes a typo in a preset and three sessions silently start polling different OIDs, with the charts keeping the old labels. Both directions are pinned by a test.

## A preset with problems cannot be bound

It can be imported, listed and read — that is what the error list is for. But binding is the step that puts traffic on somebody's network, and doing that from a file this application has already said it does not understand is not a thing to do quietly. A refused bind leaves **no session behind**.

Credentials go to `pkg/secrets` under `SessionRef(id)` like every other session: `SessionConn` holds only what is safe to read in a copied `monitoring.db`, and a preset carries no credential of its own.

## The migration is the risky part

`ensureColumn` logs and continues when an `ALTER` fails. That is right for an optional column and **fatal** for a `SELECT` that names it anyway: `no such column: preset` would take *every* session with it, including the ones still polling.

So `ensureColumn` now reports whether the column is really there, `Init` remembers the answer, and **both** the `INSERT` and the `SELECT` are built from it. Without the column a session is still created, still listed and still polling — it simply has no layout.

Four tests cover it, including one that builds the **old schema by hand**, opens it, and requires the sessions in it to survive the upgrade with their `active` flag intact.

## One builder for the session shape

`startPolling` stopped building its own session object. There were two literals for one shape — the defect `normalisePoint`'s comment describes — and they had **already drifted**: the local one never set `needsConnection`, so the field every consumer tests was absent on sessions made in this window and present on restored ones.

There is now one `sessionFromBackend`, and `adoptSession` takes a session Go has just created without starting anything or duplicating a row. The smoke test compares the key sets of both paths, which is what would have caught the drift.

## Also in here

A CodeQL finding on #40's own test, fixed in its own commit: the pattern that found `errf`'s arguments allowed nested parentheses in the first one (`errf(fmt.Sprintf("%s.oids[%d]", at, j), …)`), and the obvious way to write that is exponential. Nothing hostile reaches it — it reads this repository's Go source at test time — but a scanner that tracks bracket depth and string state is linear, handles the escaped quote the pattern never considered, and says what it does. Re-verified the same three ways.

## What is not here

No UI. `PresetBind` is reachable over the bridge and nothing calls it yet — the target-manager flow and the dashboard come next. The acceptance of a slowdown is still not persisted, on purpose.

## Checks

`go vet`, `staticcheck`, `go test -count=1 ./...`, `npm test` (578 checks), `npm run check`, `npm run build`. Sixteen new tests: five in `pkg/storage` (round trip, nil, the upgrade, the column-missing path, a corrupt snapshot), six in package `main` (materialisation, the refusals, credentials, two equipments, edit-and-delete), and five in the smoke test.
