### PR TITLE
Cache the symbol catalogue, and give the editor an outline

### DIFF
--- a/app.go
+++ b/app.go
@@ -27,7 +27,6 @@ import (
 
 	"time"
 
-	"github.com/sleepinggenius2/gosmi"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
@@ -97,9 +96,8 @@ func (a *App) startup(ctx context.Context) {
 	a.ensureStandardMibs()
 
 	// 2. Initialize gosmi and our MIB service
-	gosmi.Init()
 	log.Printf("Setting MIB search path to: %s", a.persistentMibDir)
-	gosmi.AppendPath(a.persistentMibDir)
+	mib.InitPath(a.persistentMibDir)
 	a.mibService = mib.NewService(a.persistentMibDir)
 
 	// 3. Initialize SQLite storage for monitoring data
@@ -143,8 +141,9 @@ func (a *App) startup(ctx context.Context) {
 
 	// 4. Load core MIBs
 	coreMibs := []string{"SNMPv2-SMI", "SNMPv2-TC"}
+	failed := mib.LoadCore(coreMibs...)
 	for _, mibName := range coreMibs {
-		if _, err := gosmi.LoadModule(mibName); err != nil {
+		if err, bad := failed[mibName]; bad {
 			log.Printf("ERROR: Failed to load core MIB '%s': %v.", mibName, err)
 		} else {
 			log.Printf("Successfully loaded core MIB: %s", mibName)

--- a/frontend/src/MibEditorPanel.svelte
+++ b/frontend/src/MibEditorPanel.svelte
@@ -28,6 +28,8 @@
   let atomicEdit = false;
   let showSnippets = false;
   let showSymbols = false;
+  let outlineFilter = '';
+  let showOutline = true;
   let symbolFilter = '';
   let catalogue = { modules: [], symbols: [] };
   let textarea;
@@ -575,6 +577,31 @@
     syncScroll();
   }
 
+  // What the buffer defines. Derived in a reactive statement rather than in the
+  // markup: Svelte 5 tracks what the EXPRESSION reads, and a store read inside
+  // a callee is not a dependency it can see — reactive.test.mjs exists for
+  // exactly that.
+  $: outline = $mibEditorStore.outline || [];
+  $: shownOutline = filterOutline(outline, outlineFilter);
+
+  // Takes what it reads as arguments, for the same reason.
+  function filterOutline(items, needle) {
+    const q = needle.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((it) =>
+      it.name.toLowerCase().includes(q) || (it.syntax || '').toLowerCase().includes(q));
+  }
+
+  // A one-character badge, because the list is narrow and the kind is the thing
+  // that tells a table from the row inside it from the columns inside that —
+  // three definitions that read almost identically in the source.
+  const OUTLINE_BADGE = {
+    module: 'M', object: 'o', table: 'T', row: 'R', identity: 'i',
+    notification: 'N', group: 'G', compliance: 'C', capabilities: 'A',
+    trap: 'N', node: '·', type: 't', macro: 'm',
+  };
+  const badgeOf = (kind) => OUTLINE_BADGE[kind] || '·';
+
   // Hover: the word under the pointer, looked up in the loaded tree.
   let hoverTimer;
   function onMouseMove(e) {
@@ -787,6 +814,44 @@
         <li class="empty">{$_('mibEditor.noFiles')}</li>
       {/if}
     </ul>
+
+    <!-- The outline. A MIB has no indentation to navigate by and no folding to
+         collapse, so scrolling is the only tool and a 185 KB file is a lot of
+         scrolling. It costs nothing: every field comes off the parse the
+         analysis already makes on every pause in typing. -->
+    {#if source}
+      <div class="outline">
+        <button class="outline-head" on:click={() => (showOutline = !showOutline)}
+          aria-expanded={showOutline}>
+          <Icon name={showOutline ? 'chevron-down' : 'chevron-right'} size={12} />
+          {$_('mibEditor.outline')}
+          <span class="count">{outline.length}</span>
+        </button>
+
+        {#if showOutline}
+          <input type="search" class="outline-filter" bind:value={outlineFilter}
+            placeholder={$_('mibEditor.outlineFilter')} />
+
+          <ul class="outline-list">
+            {#each shownOutline as item (item.kind + item.name + item.line)}
+              <li>
+                <button class="outline-item" on:click={() => jumpTo(item)}
+                  title={item.description || item.name}>
+                  <span class="badge kind-{item.kind}">{badgeOf(item.kind)}</span>
+                  <span class="oname">{item.name}</span>
+                  {#if item.syntax}<span class="osyntax">{item.syntax}</span>{/if}
+                </button>
+              </li>
+            {/each}
+            {#if outline.length === 0}
+              <li class="empty">{$_('mibEditor.outlineEmpty')}</li>
+            {:else if shownOutline.length === 0}
+              <li class="empty">{$_('mibEditor.outlineNoMatch')}</li>
+            {/if}
+          </ul>
+        {/if}
+      </div>
+    {/if}
   </aside>
 
   <!-- ---------------- editor ---------------- -->
@@ -1052,6 +1117,102 @@
     gap: var(--space-sm);
     height: 100%;
     min-height: 0;
+  }
+
+  .outline {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.35rem;
+  }
+
+  .outline-head {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.2rem 0.3rem;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font: inherit;
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+  }
+
+  .outline-head .count {
+    margin-left: auto;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .outline-filter {
+    margin: 0.2rem 0.3rem 0.3rem;
+    font-size: 0.75rem;
+  }
+
+  .outline-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .outline-item {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    width: 100%;
+    padding: 0.12rem 0.3rem;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    font-size: 0.76rem;
+    text-align: left;
+    cursor: pointer;
+    min-width: 0;
+  }
+
+  .outline-item:hover {
+    background-color: var(--bg-tertiary);
+  }
+
+  .outline-item .badge {
+    flex: 0 0 auto;
+    width: 1.05em;
+    text-align: center;
+    border-radius: 2px;
+    background-color: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 0.66rem;
+    font-family: var(--font-mono, monospace);
+  }
+
+  /* A table, the row inside it and the columns inside that read almost
+     identically in the source, so the badge is where they differ. */
+  .outline-item .kind-table,
+  .outline-item .kind-row {
+    background-color: var(--accent-subtle, var(--bg-tertiary));
+    color: var(--accent-color, var(--text-primary));
+  }
+
+  .outline-item .oname {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .outline-item .osyntax {
+    margin-left: auto;
+    flex: 0 1 auto;
+    color: var(--text-secondary);
+    font-size: 0.68rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .rail {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1089,7 +1089,11 @@
     "undo": "Rückgängig",
     "redo": "Wiederholen",
     "matchCase": "Groß-/Kleinschreibung",
-    "matchesCapped": "Nur die ersten {max} Treffer werden aufgeführt; es gibt weitere."
+    "matchesCapped": "Nur die ersten {max} Treffer werden aufgeführt; es gibt weitere.",
+    "outline": "Gliederung",
+    "outlineFilter": "Definitionen filtern",
+    "outlineEmpty": "Noch nichts definiert.",
+    "outlineNoMatch": "Keine Definition passt."
   },
   "preset": {
     "title": "Dashboard-Vorlagen",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1089,7 +1089,11 @@
     "undo": "Undo",
     "redo": "Redo",
     "matchCase": "Match case",
-    "matchesCapped": "Only the first {max} matches are listed; there are more."
+    "matchesCapped": "Only the first {max} matches are listed; there are more.",
+    "outline": "Outline",
+    "outlineFilter": "Filter definitions",
+    "outlineEmpty": "Nothing defined yet.",
+    "outlineNoMatch": "No definition matches."
   },
   "preset": {
     "title": "Dashboard presets",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1089,7 +1089,11 @@
     "undo": "Deshacer",
     "redo": "Rehacer",
     "matchCase": "Distinguir mayúsculas",
-    "matchesCapped": "Solo se listan las primeras {max} coincidencias; hay más."
+    "matchesCapped": "Solo se listan las primeras {max} coincidencias; hay más.",
+    "outline": "Esquema",
+    "outlineFilter": "Filtrar definiciones",
+    "outlineEmpty": "Aún no hay nada definido.",
+    "outlineNoMatch": "Ninguna definición coincide."
   },
   "preset": {
     "title": "Presets de panel",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1089,7 +1089,11 @@
     "undo": "Annuler",
     "redo": "Rétablir",
     "matchCase": "Respecter la casse",
-    "matchesCapped": "Seules les {max} premières correspondances sont listées ; il y en a d'autres."
+    "matchesCapped": "Seules les {max} premières correspondances sont listées ; il y en a d'autres.",
+    "outline": "Plan",
+    "outlineFilter": "Filtrer les définitions",
+    "outlineEmpty": "Rien de défini pour l'instant.",
+    "outlineNoMatch": "Aucune définition ne correspond."
   },
   "preset": {
     "title": "Presets de tableau de bord",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1089,7 +1089,11 @@
     "undo": "撤销",
     "redo": "重做",
     "matchCase": "区分大小写",
-    "matchesCapped": "仅列出前 {max} 个匹配项，还有更多。"
+    "matchesCapped": "仅列出前 {max} 个匹配项，还有更多。",
+    "outline": "大纲",
+    "outlineFilter": "筛选定义",
+    "outlineEmpty": "尚未定义任何内容。",
+    "outlineNoMatch": "没有匹配的定义。"
   },
   "preset": {
     "title": "仪表板预设",

--- a/frontend/src/stores/mibEditorStore.js
+++ b/frontend/src/stores/mibEditorStore.js
@@ -24,6 +24,9 @@ const EMPTY = {
   buffer: '',         // what the user is editing
   diagnostics: [],
   missingImports: [],
+  // What the buffer defines, from the same parse as the diagnostics. Empty
+  // until the first analysis answers, which is 350 ms after the file opens.
+  outline: [],
   checking: false,
 };
 
@@ -152,6 +155,7 @@ function createMibEditorStore() {
           ...s,
           diagnostics: out.diagnostics || [],
           missingImports: out.missing || [],
+          outline: out.outline || [],
         };
       });
     } catch (e) {

--- a/frontend/src/stores/mibEditorStore.js
+++ b/frontend/src/stores/mibEditorStore.js
@@ -121,8 +121,14 @@ function createMibEditorStore() {
     checkTimer = setTimeout(refresh, 350);
   }
 
-  // Validation and the import check both run in Go and touch nothing: no file,
-  // no gosmi state. That is what makes them safe on every keystroke.
+  // Validation and the import check write nothing: no file is touched and no
+  // module is loaded. What they DO take is pkg/mib's exclusive gosmi mutex, to
+  // read the symbol catalogue — which used to be rebuilt from scratch on every
+  // one of these calls. Measured on a 135-module corpus: 122 ms a round, of
+  // which 1.35 ms was the analysis, and all 122 ms held that lock, so every OID
+  // translation in every other tab waited for somebody's typing to pause. The
+  // catalogue is cached now and the round is 1.35 ms; this is safe on every
+  // keystroke BECAUSE of that, not by nature.
   // ONE bridge call, one parse. This used to be two calls that each parsed the
   // file, on every pause in typing, over a MIB that can be 185 KB.
   // Analyses can overlap — the user keeps typing while one runs — and nothing

--- a/frontend/tests/mibeditor.store.test.mjs
+++ b/frontend/tests/mibeditor.store.test.mjs
@@ -319,4 +319,43 @@ check('a pending draft is not written under the newly opened file',
     JSON.stringify(keys));
 }
 
+// The outline rides on the analysis, and it must not outlive the file it
+// describes.
+//
+// A stale outline is worse than none: it lists definitions that are not in the
+// buffer, and clicking one puts the caret on a line that now holds something
+// else entirely.
+{
+  await mibEditorStore.open('O-MIB');
+  pending = [];
+  mibEditorStore.setBuffer('anything');
+  mibEditorStore.refresh();
+  await tick();
+  pending[0].resolve({
+    diagnostics: [],
+    missing: [],
+    outline: [{ name: 'oUptime', kind: 'object', line: 12, column: 1, syntax: 'Counter32' }],
+  });
+  await tick();
+
+  check('the outline reaches the store', get(mibEditorStore).outline?.length === 1,
+    JSON.stringify(get(mibEditorStore).outline));
+
+  // Opening another file must clear it, BEFORE its own analysis answers.
+  pending = [];
+  await mibEditorStore.open('P-MIB');
+  check('opening another file clears the previous outline',
+    (get(mibEditorStore).outline || []).length === 0, JSON.stringify(get(mibEditorStore).outline));
+
+  // An answer with no outline at all — an older backend, or a failure — leaves
+  // an array rather than undefined, because the pane maps over it.
+  mibEditorStore.setBuffer('x');
+  mibEditorStore.refresh();
+  await tick();
+  pending[pending.length - 1].resolve({ diagnostics: [], missing: [] });
+  await tick();
+  check('a response with no outline still leaves an array',
+    Array.isArray(get(mibEditorStore).outline), JSON.stringify(get(mibEditorStore).outline));
+}
+
 process.exit(failures ? 1 : 0);

--- a/pkg/mib/analyse.go
+++ b/pkg/mib/analyse.go
@@ -412,6 +412,11 @@ func (a *analysis) checkUnusedImports() {
 type Analysis struct {
 	Diagnostics []Diagnostic    `json:"diagnostics"`
 	Missing     []MissingImport `json:"missing"`
+	// Outline is what the buffer DEFINES, from the same parse. It rides along
+	// because the parse is the expensive part and it has already happened —
+	// asking for it separately would double the cost of every pause in typing
+	// to answer a question the parse already knows.
+	Outline []OutlineItem `json:"outline"`
 }
 
 // AnalyseAll runs every check from ONE parse.
@@ -429,6 +434,7 @@ func AnalyseAll(content string, cat Catalogue) Analysis {
 		Missing:     checkImportsParsed(content, module, err, index),
 	}
 	out.Diagnostics = append(out.Diagnostics, analyseParsed(content, module, err, cat)...)
+	out.Outline = outlineOf(module)
 	if out.Missing == nil {
 		out.Missing = []MissingImport{}
 	}

--- a/pkg/mib/outline.go
+++ b/pkg/mib/outline.go
@@ -1,0 +1,212 @@
+package mib
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sleepinggenius2/gosmi/parser"
+)
+
+// The outline: what this file DEFINES, in the order it defines it.
+//
+// The question in front of somebody editing a vendor MIB is "where is
+// ifXEntry", and the answer is four hundred lines further down. A MIB has no
+// indentation to navigate by and no folding to collapse — every definition
+// starts hard against the left margin — so scrolling is the only tool, and a
+// 185 KB file is a lot of scrolling.
+//
+// It costs NOTHING. AnalyseAll already parses the buffer once, 350 ms after
+// every pause in typing, and every field below comes off that same parse — no
+// second pass, no gosmi, and in particular no gosmi LOCK. An outline built from
+// the loaded tree instead would describe the file as it was when it was last
+// loaded, which for a file being edited is the one description that is wrong.
+
+// Outline kinds. Not the SMI's own vocabulary but the reader's: what the thing
+// IS in the tree, which is what somebody scanning a list wants to tell apart.
+const (
+	OutlineModule       = "module"
+	OutlineObject       = "object"
+	OutlineTable        = "table"
+	OutlineRow          = "row"
+	OutlineIdentity     = "identity"
+	OutlineNotification = "notification"
+	OutlineGroup        = "group"
+	OutlineCompliance   = "compliance"
+	OutlineCapabilities = "capabilities"
+	OutlineTrap         = "trap"
+	OutlineNode         = "node"
+	OutlineType         = "type"
+	OutlineMacro        = "macro"
+)
+
+// OutlineItem is one definition, with where it is and what it says about
+// itself.
+type OutlineItem struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	// Line and Column are 1-based, like every position in this package.
+	Line   int `json:"line"`
+	Column int `json:"column"`
+	// Parent is the name this definition is placed under — the first
+	// sub-identifier of `::= { parent n }` — and SubID the number after it.
+	// Together they are what makes an outline a TREE rather than a list.
+	Parent string `json:"parent,omitempty"`
+	SubID  string `json:"subId,omitempty"`
+	// Syntax, Access and Status are the three things a reader checks before
+	// scrolling to a definition, so the list carries them instead of making the
+	// scroll the way to find out.
+	Syntax string `json:"syntax,omitempty"`
+	Access string `json:"access,omitempty"`
+	Status string `json:"status,omitempty"`
+	// Description is the first line only. The whole DESCRIPTION of a single
+	// object routinely runs longer than this entire structure.
+	Description string `json:"description,omitempty"`
+}
+
+// outlineOf reads the definitions out of an already-parsed module.
+//
+// A parse that FAILED still has a module for everything it managed to read, so
+// the outline of a file with a syntax error on line 412 still lists what comes
+// before it. That is the moment an outline is most useful and the easiest one
+// to drop by accident.
+func outlineOf(module *parser.Module) []OutlineItem {
+	out := []OutlineItem{}
+	if module == nil {
+		return out
+	}
+
+	if id := module.Body.Identity; id != nil {
+		out = append(out, OutlineItem{
+			Name: string(id.Name), Kind: OutlineModule,
+			Line: id.Pos.Line, Column: id.Pos.Column,
+			Description: firstLine(id.Description),
+		})
+	}
+
+	for i := range module.Body.Types {
+		t := &module.Body.Types[i]
+		item := OutlineItem{
+			Name: string(t.Name), Kind: OutlineType,
+			Line: t.Pos.Line, Column: t.Pos.Column,
+		}
+		if tc := t.TextualConvention; tc != nil {
+			item.Syntax = syntaxTypeName(&tc.Syntax)
+			item.Status = string(tc.Status)
+			item.Description = firstLine(tc.Description)
+		} else if t.Sequence != nil {
+			item.Syntax = "SEQUENCE"
+		}
+		out = append(out, item)
+	}
+
+	for i := range module.Body.Nodes {
+		n := &module.Body.Nodes[i]
+		item := OutlineItem{
+			Name: string(n.Name), Kind: OutlineNode,
+			Line: n.Pos.Line, Column: n.Pos.Column,
+		}
+
+		switch {
+		case n.ObjectType != nil:
+			ot := n.ObjectType
+			item.Kind = OutlineObject
+			if ot.Syntax.Sequence != nil {
+				item.Kind = OutlineTable
+			} else if len(ot.Index) > 0 || ot.Augments != nil {
+				item.Kind = OutlineRow
+			}
+			item.Syntax = syntaxName(&ot.Syntax)
+			item.Access = string(ot.Access)
+			item.Status = string(ot.Status)
+			item.Description = firstLine(ot.Description)
+		case n.ObjectIdentity != nil:
+			item.Kind = OutlineIdentity
+			item.Status = string(n.ObjectIdentity.Status)
+			item.Description = firstLine(n.ObjectIdentity.Description)
+		case n.NotificationType != nil:
+			item.Kind = OutlineNotification
+			item.Status = string(n.NotificationType.Status)
+			item.Description = firstLine(n.NotificationType.Description)
+		case n.ObjectGroup != nil:
+			item.Kind = OutlineGroup
+			item.Status = string(n.ObjectGroup.Status)
+			item.Description = firstLine(n.ObjectGroup.Description)
+		case n.NotificationGroup != nil:
+			item.Kind = OutlineGroup
+			item.Status = string(n.NotificationGroup.Status)
+			item.Description = firstLine(n.NotificationGroup.Description)
+		case n.ModuleCompliance != nil:
+			item.Kind = OutlineCompliance
+			item.Status = string(n.ModuleCompliance.Status)
+			item.Description = firstLine(n.ModuleCompliance.Description)
+		case n.AgentCapabilities != nil:
+			item.Kind = OutlineCapabilities
+			item.Status = string(n.AgentCapabilities.Status)
+			item.Description = firstLine(n.AgentCapabilities.Description)
+		case n.TrapType != nil:
+			item.Kind = OutlineTrap
+			item.Description = firstLine(n.TrapType.Description)
+		}
+
+		if n.Oid != nil && len(n.Oid.SubIdentifiers) > 0 {
+			first := n.Oid.SubIdentifiers[0]
+			if first.Name != nil {
+				item.Parent = string(*first.Name)
+			}
+			last := n.Oid.SubIdentifiers[len(n.Oid.SubIdentifiers)-1]
+			if last.Number != nil {
+				item.SubID = fmt.Sprint(*last.Number)
+			}
+		}
+		if n.SubIdentifier != nil {
+			item.SubID = fmt.Sprint(*n.SubIdentifier)
+		}
+
+		out = append(out, item)
+	}
+
+	for i := range module.Body.Macros {
+		m := &module.Body.Macros[i]
+		out = append(out, OutlineItem{
+			Name: string(m.Name), Kind: OutlineMacro,
+			Line: m.Pos.Line, Column: m.Pos.Column,
+		})
+	}
+
+	return out
+}
+
+// syntaxName renders a SYNTAX clause as the one word a reader scans for.
+//
+// Not the full clause: "INTEGER { up(1), down(2), testing(3) }" is the whole
+// point of opening the definition, and putting it in the list turns a column
+// into a paragraph.
+func syntaxName(s *parser.Syntax) string {
+	if s == nil {
+		return ""
+	}
+	if s.Sequence != nil {
+		return "SEQUENCE OF " + string(*s.Sequence)
+	}
+	// Type is a POINTER and the grammar is an alternation, so a syntax that
+	// matched neither branch leaves both nil. Reading through it would be a
+	// panic in the editor's own analysis path, on a file being typed — which is
+	// to say on half-written input, which is all this ever sees.
+	return syntaxTypeName(s.Type)
+}
+
+// syntaxTypeName is the same for a TEXTUAL-CONVENTION, whose SYNTAX is a bare
+// SyntaxType rather than the alternation.
+func syntaxTypeName(t *parser.SyntaxType) string {
+	if t == nil {
+		return ""
+	}
+	name := strings.TrimSpace(t.Name.String())
+	if name == "" {
+		return ""
+	}
+	if len(t.Enum) > 0 {
+		return name + " {…}"
+	}
+	return name
+}

--- a/pkg/mib/outline_test.go
+++ b/pkg/mib/outline_test.go
@@ -1,0 +1,245 @@
+package mib
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func outlineOfSource(src string) []OutlineItem {
+	return AnalyseAll(src, Catalogue{}).Outline
+}
+
+func find(items []OutlineItem, name string) *OutlineItem {
+	for i := range items {
+		if items[i].Name == name {
+			return &items[i]
+		}
+	}
+	return nil
+}
+
+const outlineSample = `ACME-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+    OBJECT-TYPE, MODULE-IDENTITY, Integer32, Counter32, enterprises
+        FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DisplayString
+        FROM SNMPv2-TC;
+
+acmeMIB MODULE-IDENTITY
+    LAST-UPDATED "202601010000Z"
+    ORGANIZATION "Acme"
+    CONTACT-INFO "noc@acme.example"
+    DESCRIPTION  "The Acme MIB.
+                  A second line nobody needs in a list."
+    ::= { enterprises 99999 }
+
+AcmeState ::= TEXTUAL-CONVENTION
+    STATUS      current
+    DESCRIPTION "A port state."
+    SYNTAX      INTEGER { up(1), down(2) }
+
+acmeObjects OBJECT IDENTIFIER ::= { acmeMIB 1 }
+
+acmeUptime OBJECT-TYPE
+    SYNTAX      Counter32
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Seconds since boot."
+    ::= { acmeObjects 1 }
+
+acmePortTable OBJECT-TYPE
+    SYNTAX      SEQUENCE OF AcmePortEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "The ports."
+    ::= { acmeObjects 2 }
+
+acmePortEntry OBJECT-TYPE
+    SYNTAX      AcmePortEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "One port."
+    INDEX       { acmePortIndex }
+    ::= { acmePortTable 1 }
+
+AcmePortEntry ::= SEQUENCE {
+    acmePortIndex Integer32,
+    acmePortState AcmeState
+}
+
+acmePortIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..48)
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION "The port number."
+    ::= { acmePortEntry 1 }
+
+acmePortState OBJECT-TYPE
+    SYNTAX      AcmeState
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION "Whether the port is up."
+    ::= { acmePortEntry 2 }
+
+END
+`
+
+// The outline names what the file defines, and says which KIND each one is —
+// a table, a row and a column read the same in the source and are three
+// different things in the tree.
+func TestTheOutlineTellsTheKindsApart(t *testing.T) {
+	items := outlineOfSource(outlineSample)
+	if len(items) == 0 {
+		t.Fatal("the outline is empty")
+	}
+
+	want := map[string]string{
+		"acmeMIB":       OutlineModule,
+		"AcmeState":     OutlineType,
+		"acmeObjects":   OutlineNode,
+		"acmeUptime":    OutlineObject,
+		"acmePortTable": OutlineTable,
+		"acmePortEntry": OutlineRow,
+		"acmePortIndex": OutlineObject,
+		"AcmePortEntry": OutlineType,
+	}
+	for name, kind := range want {
+		got := find(items, name)
+		if got == nil {
+			t.Errorf("%s is missing from the outline", name)
+			continue
+		}
+		if got.Kind != kind {
+			t.Errorf("%s: kind = %q, want %q", name, got.Kind, kind)
+		}
+	}
+}
+
+// It is a navigation aid, so the position is the point.
+func TestEveryItemPointsAtItsDefinition(t *testing.T) {
+	items := outlineOfSource(outlineSample)
+	lines := strings.Split(outlineSample, "\n")
+
+	for _, it := range items {
+		if it.Line < 1 || it.Line > len(lines) {
+			t.Errorf("%s: line %d is outside the file", it.Name, it.Line)
+			continue
+		}
+		// The name must be on the line the outline points at — this is what
+		// makes clicking an entry land on the definition rather than near it.
+		if !strings.Contains(lines[it.Line-1], it.Name) {
+			t.Errorf("%s: line %d reads %q", it.Name, it.Line, strings.TrimSpace(lines[it.Line-1]))
+		}
+	}
+}
+
+// The three things a reader checks before scrolling.
+func TestAnObjectCarriesWhatTheListNeedsToShow(t *testing.T) {
+	items := outlineOfSource(outlineSample)
+
+	up := find(items, "acmeUptime")
+	if up == nil {
+		t.Fatal("acmeUptime is missing")
+	}
+	if up.Syntax != "Counter32" || up.Access != "read-only" || up.Status != "current" {
+		t.Errorf("acmeUptime: %+v", up)
+	}
+	if up.Parent != "acmeObjects" || up.SubID != "1" {
+		t.Errorf("acmeUptime is placed at %q %q; the outline cannot be a tree without that",
+			up.Parent, up.SubID)
+	}
+	// The first line only: a DESCRIPTION routinely runs longer than the whole
+	// list it would be shown in.
+	mod := find(items, "acmeMIB")
+	if mod == nil || strings.Contains(mod.Description, "second line") {
+		t.Errorf("the module description is not shortened: %q", mod.Description)
+	}
+
+	// An enumeration is named, never spelled out: "INTEGER { up(1), down(2) }"
+	// is the reason to open the definition, not a column in a list.
+	state := find(items, "AcmeState")
+	if state == nil || !strings.HasPrefix(state.Syntax, "INTEGER") || strings.Contains(state.Syntax, "up(1)") {
+		t.Errorf("AcmeState syntax = %q", state.Syntax)
+	}
+	tbl := find(items, "acmePortTable")
+	if tbl == nil || tbl.Syntax != "SEQUENCE OF AcmePortEntry" {
+		t.Errorf("acmePortTable syntax = %q", tbl.Syntax)
+	}
+}
+
+// The moment an outline is most useful is the moment it is easiest to lose: a
+// file with a syntax error part way down still has everything above it.
+func TestABrokenFileStillHasAnOutlineOfWhatParsed(t *testing.T) {
+	broken := strings.Replace(outlineSample,
+		`acmePortIndex OBJECT-TYPE
+    SYNTAX      Integer32 (1..48)`,
+		`acmePortIndex OBJECT-TYPE
+    SYNTAX      Integer32 ((((`, 1)
+
+	analysis := AnalyseAll(broken, Catalogue{})
+	if len(analysis.Diagnostics) == 0 {
+		t.Fatal("setup: the broken file produced no diagnostic")
+	}
+	if len(analysis.Outline) == 0 {
+		t.Fatal("a file with a syntax error has no outline at all")
+	}
+	if find(analysis.Outline, "acmeUptime") == nil {
+		t.Error("a definition before the error is missing from the outline")
+	}
+}
+
+// It must survive what a half-typed file really looks like, because that is all
+// it ever sees: this runs 350 ms after a pause in typing.
+func TestTheOutlineSurvivesHalfTypedInput(t *testing.T) {
+	for _, src := range []string{
+		"", "\n\n", "ACME-MIB",
+		"ACME-MIB DEFINITIONS ::= BEGIN",
+		"ACME-MIB DEFINITIONS ::= BEGIN\nEND\n",
+		"ACME-MIB DEFINITIONS ::= BEGIN\nfoo OBJECT-TYPE\n  SYNTAX\nEND\n",
+		"ACME-MIB DEFINITIONS ::= BEGIN\nfoo OBJECT-TYPE\n  SYNTAX SEQUENCE OF\nEND\n",
+		"ACME-MIB DEFINITIONS ::= BEGIN\nfoo ::= TEXTUAL-CONVENTION\nEND\n",
+		"ACME-MIB DEFINITIONS ::= BEGIN\nfoo OBJECT IDENTIFIER ::= {\nEND\n",
+	} {
+		got := AnalyseAll(src, Catalogue{})
+		if got.Outline == nil {
+			t.Errorf("%q produced a nil outline, which crosses the bridge as null", src)
+		}
+	}
+}
+
+// And on the real corpus, where the shapes are the ones people actually write.
+func TestTheOutlineHandlesTheBundledCorpus(t *testing.T) {
+	entries, err := os.ReadDir("../../mibs")
+	if err != nil {
+		t.Skip("no corpus")
+	}
+	total := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join("../../mibs", e.Name()))
+		if err != nil {
+			continue
+		}
+		content, _ := NormaliseSource(raw)
+		items := AnalyseAll(content, Catalogue{}).Outline
+		if len(items) == 0 {
+			t.Errorf("%s: no outline", e.Name())
+			continue
+		}
+		total += len(items)
+		for _, it := range items {
+			if it.Name == "" {
+				t.Errorf("%s: an item with no name at line %d", e.Name(), it.Line)
+			}
+			if it.Line < 1 {
+				t.Errorf("%s: %s has no position", e.Name(), it.Name)
+			}
+		}
+	}
+	t.Logf("%d definitions across the bundled corpus", total)
+}

--- a/pkg/mib/reload.go
+++ b/pkg/mib/reload.go
@@ -78,6 +78,12 @@ func (s *Service) Rebuild(fileNames []string) Reloaded {
 	gosmiMu.Lock()
 	defer gosmiMu.Unlock()
 
+	// The whole world is about to be replaced, so nothing cached about it
+	// survives. Dropped BEFORE the teardown rather than after the reload,
+	// because the lock is held across both and a panic in between must not
+	// leave a catalogue describing modules that no longer exist.
+	invalidateCatalogue()
+
 	gosmi.Exit()
 	gosmi.Init()
 	gosmi.SetPath(s.path)

--- a/pkg/mib/service.go
+++ b/pkg/mib/service.go
@@ -62,6 +62,10 @@ func (s *Service) LoadAll() ([]*Node, error) {
 		return nil, fmt.Errorf("could not read MIB directory %s: %v", s.path, err)
 	}
 
+	// The loaded set is about to change, whatever the outcome: a partial load
+	// changes it too.
+	invalidateCatalogue()
+
 	loadedModuleNames := []string{}
 	for _, fileName := range files {
 		moduleName, err := gosmi.LoadModule(fileName)
@@ -80,6 +84,40 @@ func (s *Service) LoadAll() ([]*Node, error) {
 	return s.buildTree(loadedModuleNames)
 }
 
+// InitPath initialises gosmi and points it at the persistent MIB directory.
+//
+// Here rather than in main, because gosmi's state is global and this package
+// owns the mutex that guards it. A caller reaching for gosmi directly writes to
+// that state without the lock — and, now that the symbol catalogue is cached,
+// without dropping what describes it.
+func InitPath(path string) {
+	gosmiMu.Lock()
+	defer gosmiMu.Unlock()
+	gosmi.Init()
+	gosmi.AppendPath(path)
+	invalidateCatalogue()
+}
+
+// LoadCore loads modules BY NAME and reports which ones failed.
+//
+// The startup path used to call gosmi.LoadModule itself, outside this package
+// and outside the lock. Nothing else runs at that point, so it raced with
+// nothing — but it also meant the one load that always happens was the one load
+// that did not go through here, which is the shape a stale cache is made of.
+func LoadCore(names ...string) map[string]error {
+	gosmiMu.Lock()
+	defer gosmiMu.Unlock()
+	invalidateCatalogue()
+
+	failed := map[string]error{}
+	for _, name := range names {
+		if _, err := gosmi.LoadModule(name); err != nil {
+			failed[name] = err
+		}
+	}
+	return failed
+}
+
 // LoadSpecific loads only the specified MIB files from the service's path.
 func (s *Service) LoadSpecific(fileNames []string) ([]*Node, error) {
 	gosmiMu.Lock()
@@ -91,6 +129,8 @@ func (s *Service) LoadSpecific(fileNames []string) ([]*Node, error) {
 		log.Println("No MIB files specified. The tree will be empty.")
 		return []*Node{}, nil
 	}
+
+	invalidateCatalogue()
 
 	loadedModuleNames := []string{}
 	for _, fileName := range fileNames {
@@ -246,6 +286,8 @@ func (s *Service) loadWithDiagnosticsLocked(fileNames []string) MibLoadResponse 
 	// This only surfaced when the filter here was fixed: it required a .mib
 	// or .txt suffix, and the bundled MIBs are extension-less, so the
 	// fallback quietly loaded nothing and looked correct.
+
+	invalidateCatalogue()
 
 	// Shared across every diagnosis this loop triggers: the directory listing
 	// is the same for all of them.

--- a/pkg/mib/symbols.go
+++ b/pkg/mib/symbols.go
@@ -31,14 +31,59 @@ type Catalogue struct {
 	Symbols []Symbol `json:"symbols"`
 }
 
+// catalogue caches what symbolsLocked builds, until something changes the
+// loaded set.
+//
+// This is not an optimisation looking for a problem. MEASURED, by copying the
+// bundled MIBs under new module names to build a corpus the size a vendor
+// folder really is:
+//
+//	 15 modules,   767 symbols   1.36 ms
+//	 35 modules,  4677 symbols   8.77 ms
+//	 75 modules, 12497 symbols  32.73 ms
+//	135 modules, 24227 symbols 113.32 ms
+//
+// Superlinear, and every millisecond of it is spent holding the EXCLUSIVE gosmi
+// mutex — so every OID translation in every other tab waits. The editor calls
+// AnalyseAll(content, Symbols()) 350 ms after every pause in typing: at 135
+// modules that round cost 122.30 ms, of which 1.35 ms was the analysis and the
+// rest was rebuilding a catalogue that had not changed since the last keystroke.
+// With the catalogue cached, the same round is 1.35 ms.
+//
+// Guarded by gosmiMu, which every mutation of the loaded set already holds, so
+// the cache cannot be read while it is being invalidated.
+var catalogue *Catalogue
+
+// invalidateCatalogue drops the cache. The caller MUST hold gosmiMu.
+//
+// Called from every place that changes what gosmi has loaded. A load that does
+// not call it leaves the editor offering names from before the load and, worse,
+// reporting an import as missing that has just been satisfied — which reads as
+// a broken file rather than as a stale cache.
+func invalidateCatalogue() {
+	catalogue = nil
+}
+
 // Symbols lists every name in the loaded tree.
 //
-// Read-locked: the editor asks for this while other tabs resolve OIDs, and a
-// reload can be rebuilding the world at the same time.
+// Locked with the EXCLUSIVE gosmi mutex — this comment used to say "read
+// locked", which pkg/mib has none of: gosmi memoises inside its getters, so
+// there is no read-only operation to hold a shared lock for.
 func Symbols() Catalogue {
 	gosmiMu.Lock()
 	defer gosmiMu.Unlock()
-	return symbolsLocked()
+	if catalogue == nil {
+		built := symbolsLocked()
+		catalogue = &built
+	}
+	// The slices are shared, deliberately: copying twenty-four thousand symbols
+	// on every call would give back most of what the cache saves. What is
+	// returned is capped with a full-slice expression, so a caller that appends
+	// allocates its own array instead of writing into the cache.
+	c := *catalogue
+	c.Modules = c.Modules[:len(c.Modules):len(c.Modules)]
+	c.Symbols = c.Symbols[:len(c.Symbols):len(c.Symbols)]
+	return c
 }
 
 // symbolsLocked is Symbols for callers that already hold gosmiMu. Separate

--- a/pkg/mib/symbols_cache_test.go
+++ b/pkg/mib/symbols_cache_test.go
@@ -1,0 +1,188 @@
+package mib
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sleepinggenius2/gosmi"
+)
+
+// A world with the bundled MIBs in it, and nothing left behind for the next
+// test: gosmi's state is global.
+func withBundled(t *testing.T) {
+	t.Helper()
+	gosmi.Exit()
+	gosmi.Init()
+	gosmi.SetPath("../../mibs")
+	if _, err := NewService("../../mibs").LoadAll(); err != nil {
+		t.Skipf("could not load the corpus: %v", err)
+	}
+	t.Cleanup(func() {
+		gosmi.Exit()
+		gosmi.Init()
+	})
+}
+
+// The cache exists because the catalogue is expensive and is asked for on every
+// pause in typing. Measured on a corpus the size a vendor folder really is —
+// 135 modules, 24 227 symbols — one call cost 113 ms, all of it holding the
+// EXCLUSIVE gosmi mutex, so every OID translation in every other tab waited.
+func TestTheCatalogueIsBuiltOnceUntilSomethingChanges(t *testing.T) {
+	withBundled(t)
+
+	first := Symbols()
+	if len(first.Symbols) == 0 {
+		t.Fatal("the corpus produced no symbols")
+	}
+
+	// The second call must not rebuild. Timing is the only observable
+	// difference, so this asserts an order of magnitude rather than a number:
+	// building is thousands of map writes and slice appends, reading a cached
+	// pointer is neither.
+	start := time.Now()
+	for i := 0; i < 50; i++ {
+		Symbols()
+	}
+	cached := time.Since(start) / 50
+
+	gosmiMu.Lock()
+	invalidateCatalogue()
+	gosmiMu.Unlock()
+
+	start = time.Now()
+	Symbols()
+	built := time.Since(start)
+
+	if cached*4 > built {
+		t.Errorf("a cached call costs %v and building costs %v; the cache is not being used",
+			cached.Round(time.Microsecond), built.Round(time.Microsecond))
+	}
+	t.Logf("cached %v vs built %v", cached.Round(time.Microsecond), built.Round(time.Microsecond))
+}
+
+// The cache must never outlive what it describes.
+//
+// A stale catalogue does not look like a cache problem: the editor reports an
+// import as MISSING that has just been satisfied, and offers completions for
+// names that no longer exist. That reads as a broken file.
+func TestLoadingAMibDropsTheCache(t *testing.T) {
+	dir := t.TempDir()
+
+	// Start with the core modules only.
+	for _, name := range []string{"SNMPv2-SMI", "SNMPv2-TC"} {
+		raw, err := os.ReadFile(filepath.Join("../../mibs", name))
+		if err != nil {
+			t.Skip("no corpus")
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gosmi.Exit()
+	gosmi.Init()
+	gosmi.SetPath(dir)
+	t.Cleanup(func() {
+		gosmi.Exit()
+		gosmi.Init()
+	})
+
+	svc := NewService(dir)
+	if _, err := svc.LoadAll(); err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	before := Symbols()
+	if hasModule(before, "IF-MIB") {
+		t.Fatal("setup: IF-MIB is already loaded")
+	}
+
+	// Now add one and load it.
+	raw, err := os.ReadFile(filepath.Join("../../mibs", "IF-MIB"))
+	if err != nil {
+		t.Skip("no IF-MIB in the corpus")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "IF-MIB"), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.LoadSpecific([]string{"IF-MIB"}); err != nil {
+		t.Fatalf("LoadSpecific: %v", err)
+	}
+
+	after := Symbols()
+	if !hasModule(after, "IF-MIB") {
+		t.Fatal("the catalogue still describes the world from before the load")
+	}
+	if len(after.Symbols) <= len(before.Symbols) {
+		t.Errorf("%d symbols before, %d after: the cache was not dropped",
+			len(before.Symbols), len(after.Symbols))
+	}
+
+	// And the check that actually breaks for a user: an import that is now
+	// satisfiable must stop being reported as missing.
+	src := "ACME-MIB DEFINITIONS ::= BEGIN\nIMPORTS ifIndex FROM IF-MIB;\nEND\n"
+	for _, m := range CheckImports(src, after) {
+		if m.Module == "IF-MIB" {
+			t.Error("IF-MIB is loaded and is still reported as a missing import")
+		}
+	}
+}
+
+// Rebuild replaces the world entirely, so nothing cached about it survives.
+func TestRebuildDropsTheCache(t *testing.T) {
+	withBundled(t)
+
+	before := Symbols()
+	if len(before.Symbols) == 0 {
+		t.Fatal("setup: no symbols")
+	}
+
+	// Rebuild with nothing but the core modules: the catalogue must shrink.
+	svc := NewService("../../mibs")
+	svc.Rebuild([]string{"SNMPv2-SMI", "SNMPv2-TC"})
+
+	after := Symbols()
+	if len(after.Symbols) >= len(before.Symbols) {
+		t.Errorf("%d symbols before the rebuild, %d after; the cache survived it",
+			len(before.Symbols), len(after.Symbols))
+	}
+	if hasModule(after, "IF-MIB") {
+		t.Error("a module the rebuild did not load is still in the catalogue")
+	}
+}
+
+// The cache is shared, so a caller that appends to what it got back must not be
+// able to write into it.
+func TestACallerCannotGrowIntoTheCache(t *testing.T) {
+	withBundled(t)
+
+	got := Symbols()
+	n := len(got.Symbols)
+	got.Symbols = append(got.Symbols, Symbol{Name: "INJECTED", Module: "nowhere", Kind: "node"})
+	got.Modules = append(got.Modules, "INJECTED-MIB")
+
+	again := Symbols()
+	if len(again.Symbols) != n {
+		t.Errorf("the catalogue grew to %d after a caller appended to its copy", len(again.Symbols))
+	}
+	for _, s := range again.Symbols {
+		if s.Name == "INJECTED" {
+			t.Fatal("a caller's append reached the cache")
+		}
+	}
+	for _, m := range again.Modules {
+		if m == "INJECTED-MIB" {
+			t.Fatal("a caller's append reached the cached module list")
+		}
+	}
+}
+
+func hasModule(c Catalogue, name string) bool {
+	for _, m := range c.Modules {
+		if strings.EqualFold(m, name) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Two changes to the MIB editor's analysis path. Both come off the same reading: it runs **350 ms after every pause in typing**, and what it costs matters.

## 1. The symbol catalogue was rebuilt on every one of those rounds

Measured, by copying the bundled MIBs under new module names to build a corpus the size a vendor folder really is:

| modules | symbols | `Symbols()` |
| ---: | ---: | ---: |
| 15 | 767 | 1.36 ms |
| 35 | 4 677 | 8.77 ms |
| 75 | 12 497 | 32.73 ms |
| 135 | 24 227 | **113.32 ms** |

Superlinear — and every millisecond of it is spent holding the **exclusive** gosmi mutex, the one `CLAUDE.md` describes as held for a batch precisely because gosmi memoises inside its getters and has no read-only operation.

`App.MibEditorAnalyse` is `mib.AnalyseAll(content, mib.Symbols())`. So on a 135-module corpus that round cost **122.30 ms**, of which 1.35 ms was the analysis and the other 121 ms was rebuilding a catalogue that had not changed since the last keystroke — while every OID translation in every other tab waited. Cached, the same round is **1.35 ms**.

The store's own comment said those calls *"touch nothing: no file, no gosmi state. That is what makes them safe on every keystroke."* The first half was true and the conclusion was not. `Symbols()`'s doc comment said *"Read-locked"*; there is no read lock in this package and there cannot be one.

**The cache is only as good as its invalidation**, and a stale one does not look like a cache problem: the editor reports an import as *missing that has just been satisfied*, and offers completions for names that no longer exist. That reads as a broken file. So `invalidateCatalogue` is called from `LoadAll`, `LoadSpecific`, `loadWithDiagnostics` and `Rebuild` — in `Rebuild` **before** the teardown, so a panic between `Exit` and the reload cannot leave a catalogue describing modules that no longer exist.

Which is why the startup path moved too. `app.go` called `gosmi.Init`, `gosmi.AppendPath` and `gosmi.LoadModule` itself, outside this package and outside the lock. Nothing else runs at that point so it raced with nothing, but it made the one load that always happens the one that did **not** go through here. `mib.InitPath` and `mib.LoadCore` own those now, and `main` no longer imports gosmi at all.

The returned catalogue shares the cached slices deliberately — copying 24 000 symbols per call gives back most of what the cache saves — but they are capped with a full-slice expression, so a caller that appends allocates rather than writing into the cache. Pinned by a test: the accident is one line and the symptom would be a symbol nobody declared appearing in everybody's completions.

## 2. And with that headroom, an outline

The question in front of somebody editing a vendor MIB is *"where is ifXEntry"*, and the answer is four hundred lines further down. A MIB has no indentation to navigate by and no folding to collapse — every definition starts hard against the left margin.

**It costs nothing.** Every field comes off the parse `AnalyseAll` already makes: no second pass, no gosmi, no lock. An outline built from the *loaded tree* instead would describe the file as it was when it was last loaded — which, for the file being edited, is the one description that is wrong.

A table, the row inside it and the columns inside that read almost identically in the source and are three different things in the tree, so the kind is what the list leads with. Syntax, access and status ride along because they are what a reader checks before deciding to scroll; a DESCRIPTION is cut to its first line, and an enumeration is named rather than spelled out — `INTEGER {…}`, because the full clause is the reason to *open* the definition, not a column in a list.

**A file with a syntax error still has an outline** of everything above the error — the moment it is most useful and the easiest one to drop by accident. Pinned, along with nine shapes of half-typed input, which is all this ever sees.

The pane clears when another file opens, before that file's own analysis answers. A stale outline is worse than none: clicking an entry puts the caret on a line that now holds something else.

## Checks

`go vet`, `staticcheck`, `go test -race ./pkg/mib/` (the concurrency suite included), `go test ./...`, `npm test` (605 checks), `npm run check`, `npm run build`. Ten new tests: four on the cache, six on the outline — including the whole bundled corpus, where it finds 812 definitions with a position each.