### PR TITLE
Ask the device what it is, so a preset's match has something to match on

### DIFF
--- a/app_preset.go
+++ b/app_preset.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -274,6 +275,93 @@ func (a *App) ImportPresetDialog() ([]PresetImportResult, error) {
 	// Cancelled. An empty ARRAY rather than nil: the caller renders a result
 	// list, and null throws on .map.
 	return a.ImportPresetFiles(paths), nil
+}
+
+// DeviceIdentity is what a device says it is, and which presets claim it.
+type DeviceIdentity struct {
+	Target string `json:"target"`
+	// SysObjectID is the vendor and model as an OID. Presets match on it and
+	// not on sysDescr, which is prose that differs between two firmware
+	// revisions of the same switch.
+	SysObjectID string `json:"sysObjectId,omitempty"`
+	SysDescr    string `json:"sysDescr,omitempty"`
+	SysName     string `json:"sysName,omitempty"`
+	Error       string `json:"error,omitempty"`
+	// Presets is the whole library, ORDERED for this device rather than
+	// filtered to it. Match is advice to the person binding, never an automatic
+	// action — hiding the rest would turn that advice into a decision, and a
+	// preset that says nothing about which device it is for is still one
+	// somebody downloaded for this one.
+	Presets []preset.Info `json:"presets"`
+	// Matched is how many of them claim this device, so the interface can say
+	// so without recomputing the rule in JavaScript.
+	Matched int `json:"matched"`
+}
+
+// IdentifyDevice asks a device what it is and orders the preset library for it.
+//
+// A separate method from TestConnection, which answers a different question —
+// "did these credentials work" — and answers it with one varbind. This one is
+// three varbinds in one request, and it exists because nothing in this
+// application read sysObjectID before: preset.Match had no data source at all,
+// so the matching rule was written and never wired.
+//
+// It never fails hard. A device that does not answer still gets the library
+// back, unordered, because the operator picking a preset by hand is the normal
+// path and an unreachable device must not take the picker away with it.
+func (a *App) IdentifyDevice(req snmp.TestRequest) DeviceIdentity {
+	out := DeviceIdentity{Target: req.Target, Presets: a.ListPresets()}
+
+	const (
+		oidSysDescr    = "1.3.6.1.2.1.1.1.0"
+		oidSysObjectID = "1.3.6.1.2.1.1.2.0"
+		oidSysName     = "1.3.6.1.2.1.1.5.0"
+	)
+	results := a.snmpClient.GetMany(context.Background(),
+		[]string{req.Target}, []string{oidSysDescr, oidSysObjectID, oidSysName},
+		req.Community, req.Version, req.Port, req.Timeout, 1, req.V3)
+
+	if len(results) == 0 {
+		out.Error = "no response"
+		return out
+	}
+	m := results[0]
+	if err, bad := m.Errors[oidSysObjectID]; bad {
+		out.Error = err
+	}
+	text := func(oid string) string {
+		if r := m.Results[oid]; r != nil {
+			return fmt.Sprintf("%v", r.Value)
+		}
+		return ""
+	}
+	out.SysObjectID = text(oidSysObjectID)
+	out.SysDescr = text(oidSysDescr)
+	out.SysName = text(oidSysName)
+
+	out.Presets, out.Matched = rankForDevice(out.Presets, out.SysObjectID)
+	return out
+}
+
+// rankForDevice orders the library for one device and counts what claims it.
+//
+// Split out because the counting rule is the part worth testing and the SNMP
+// round trip is the part that needs a device: with them in one function the
+// only way to check that "3 presets match" is 3 is to have a switch.
+func rankForDevice(list []preset.Info, sysObjectID string) ([]preset.Info, int) {
+	if strings.TrimSpace(sysObjectID) == "" {
+		// Nothing to rank by. The library comes back in its own order rather
+		// than empty: picking by hand is the normal path.
+		return list, 0
+	}
+	ranked := preset.Rank(list, sysObjectID)
+	matched := 0
+	for _, p := range ranked {
+		if preset.MatchDepth(p.SysObjectIDPrefix, sysObjectID) > 0 {
+			matched++
+		}
+	}
+	return ranked, matched
 }
 
 // PresetBind is the moment a preset stops being a file and starts being a

--- a/app_preset_test.go
+++ b/app_preset_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -273,5 +275,72 @@ func TestAnEmptyLibraryListsAsAnArray(t *testing.T) {
 	raw, _ := json.Marshal(list)
 	if string(raw) != "[]" {
 		t.Errorf("an empty library crossed as %s", raw)
+	}
+}
+
+// Nothing in this application read sysObjectID before, so preset.Match had no
+// data source at all: the rule was written and never wired. This is the wiring,
+// and the part worth testing is the counting rather than the round trip.
+func TestRankingTheLibraryForOneDevice(t *testing.T) {
+	list := []preset.Info{
+		{File: "zzz-generic.json", Name: "Generic interfaces"},
+		{File: "cisco.json", Name: "Cisco", SysObjectIDPrefix: []string{"1.3.6.1.4.1.9"}},
+		{File: "cat9k.json", Name: "Catalyst 9300", SysObjectIDPrefix: []string{"1.3.6.1.4.1.9.1.2494"}},
+		{File: "juniper.json", Name: "Juniper", SysObjectIDPrefix: []string{"1.3.6.1.4.1.2636"}},
+	}
+
+	ranked, matched := rankForDevice(list, ".1.3.6.1.4.1.9.1.2494")
+	if matched != 2 {
+		t.Errorf("matched = %d, want 2 (the model and the vendor)", matched)
+	}
+	if len(ranked) != len(list) {
+		t.Fatalf("ranking dropped %d entries; Match is advice, not a filter", len(list)-len(ranked))
+	}
+	if ranked[0].File != "cat9k.json" {
+		t.Errorf("first is %q; the most specific match should lead", ranked[0].File)
+	}
+	// formatSnmpValue renders an ObjectIdentifier WITH a leading dot, and a
+	// preset file is written by hand either way. If this stopped working the
+	// symptom would be "0 presets match" on every device.
+	if _, withoutDot := rankForDevice(list, "1.3.6.1.4.1.9.1.2494"); withoutDot != 2 {
+		t.Error("the leading dot changed the answer")
+	}
+
+	// A device that did not answer still gets the library, in its own order.
+	same, none := rankForDevice(list, "")
+	if none != 0 || len(same) != len(list) || same[0].File != "zzz-generic.json" {
+		t.Errorf("an unidentified device got %d entries, %d matched", len(same), none)
+	}
+}
+
+// A device that does not answer must not take the picker away with it.
+func TestIdentifyingAnUnreachableDeviceStillReturnsTheLibrary(t *testing.T) {
+	a, _ := newPresetApp(t)
+	a.snmpClient = snmp.NewClient(context.Background())
+	a.importSinglePreset(writeSrc(t, t.TempDir(), "cisco.json", goodPreset))
+
+	// A bound-then-closed UDP port: the address is real and nothing answers.
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := pc.LocalAddr().(*net.UDPAddr).Port
+	pc.Close()
+
+	got := a.IdentifyDevice(snmp.TestRequest{
+		Target: "127.0.0.1", Community: "public", Version: "v2c", Port: port, Timeout: 1,
+	})
+
+	if len(got.Presets) != 1 {
+		t.Errorf("the library came back with %d entries", len(got.Presets))
+	}
+	if got.Presets == nil {
+		t.Error("nil crosses the bridge as null and throws on .map")
+	}
+	if got.SysObjectID != "" {
+		t.Errorf("an unreachable device reported %q", got.SysObjectID)
+	}
+	if got.Error == "" {
+		t.Error("it failed silently")
 	}
 }

--- a/frontend/src/TargetManager.svelte
+++ b/frontend/src/TargetManager.svelte
@@ -6,7 +6,7 @@
   import { settingsStore } from './stores/settingsStore';
   import { notificationStore } from './stores/notifications';
   import { onMount } from 'svelte';
-  import { TestConnection, ListPresets } from '../wailsjs/go/main/App';
+  import { TestConnection, ListPresets, IdentifyDevice } from '../wailsjs/go/main/App';
   import { pollingStore } from './stores/pollingStore';
   import { requestTab } from './stores/tabRequest';
   import { buildTestRequest } from './utils/snmpParams';
@@ -100,6 +100,40 @@
   let presets = [];
   let newPreset = '';
   let binding = false;
+  let identifying = false;
+  // What the device said about itself, or null. Reset whenever the address
+  // changes, because it describes an address and not a form.
+  let identity = null;
+
+  // Nothing in this application read sysObjectID until now, so a preset's
+  // `match` had no data source at all — the rule was written and never wired.
+  // This is the wiring, and it ORDERS the list rather than filtering it: match
+  // is advice to the person binding, and a preset that says nothing about which
+  // device it is for is still one they downloaded for this one.
+  async function identify() {
+    const address = newAddress.trim();
+    if (!address) return;
+    identifying = true;
+    identity = null;
+    try {
+      const settings = getEffectiveSettings($settingsStore, address);
+      const result = await IdentifyDevice(buildTestRequest(settings, address));
+      identity = result;
+      if (Array.isArray(result.presets) && result.presets.length) {
+        presets = result.presets;
+      }
+      // Offer the best match, without choosing it: the operator still has to
+      // see which preset is selected before pressing Add.
+      if (result.matched > 0 && !newPreset) {
+        const best = (result.presets || []).find((p) => p.problems === 0);
+        if (best) newPreset = best.file;
+      }
+    } catch (e) {
+      identity = { error: String(e) };
+    } finally {
+      identifying = false;
+    }
+  }
 
   onMount(async () => {
     try {
@@ -408,7 +442,14 @@
 
   {#if showAddForm}
     <div class="add-form">
-      <input type="text" bind:value={newAddress} placeholder={$_('targets.addressPlaceholder')} on:keydown={(e) => e.key === 'Enter' && addTarget()} />
+      <input type="text" bind:value={newAddress}
+        placeholder={$_('targets.addressPlaceholder')}
+        on:input={() => (identity = null)}
+        on:keydown={(e) => e.key === 'Enter' && addTarget()} />
+      <button class="btn-sm" on:click={identify} disabled={!newAddress.trim() || identifying}
+        title={$_('targets.presetDetectHint')}>
+        {identifying ? $_('common.working') : $_('targets.presetDetect')}
+      </button>
       <input type="text" bind:value={newLabel} placeholder={$_('targets.labelPlaceholder')} on:keydown={(e) => e.key === 'Enter' && addTarget()} />
       <!-- The preset is chosen HERE, when the equipment is added, because that
            is the only moment somebody knows what the equipment is. -->
@@ -422,6 +463,23 @@
         {binding ? $_('common.working') : $_('common.add')}
       </button>
     </div>
+
+    {#if identity}
+      <p class="identity" class:failed={!!identity.error}>
+        {#if identity.error}
+          {identity.error}
+        {:else}
+          <!-- sysObjectID names a vendor and a model as plainly as sysDescr
+               does, so Anonymous Mode masks it with everything else. -->
+          {$anonMode ? $_('targets.presetDeviceMasked') : (identity.sysDescr || identity.sysObjectId || '')}
+          <span class="matched">
+            {identity.matched > 0
+              ? $_('targets.presetMatched', { values: { count: identity.matched } })
+              : $_('targets.presetNoMatch')}
+          </span>
+        {/if}
+      </p>
+    {/if}
   {/if}
 
   <div class="target-list">

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -610,7 +610,12 @@
     "presetPick": "Keine Vorlage",
     "presetNone": "Keine Vorlage verfügbar",
     "presetHint": "Eine Dashboard-Vorlage an dieses Gerät binden. Die Abfrage beginnt sofort; was sie kostet, steht unter Einstellungen > Vorlagen.",
-    "presetBound": "{address} fragt jetzt seine Vorlage ab."
+    "presetBound": "{address} fragt jetzt seine Vorlage ab.",
+    "presetDetect": "Erkennen",
+    "presetDetectHint": "Das Gerät fragen, was es ist, und passende Vorlagen nach oben stellen.",
+    "presetMatched": "{count} Vorlage(n) passen zu diesem Gerät.",
+    "presetNoMatch": "Keine Vorlage nennt dieses Gerät.",
+    "presetDeviceMasked": "Gerät erkannt"
   },
   "update": {
     "available": "SnmpLens {version} ist verfügbar",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -610,7 +610,12 @@
     "presetPick": "No preset",
     "presetNone": "No preset available",
     "presetHint": "Bind a dashboard preset to this equipment. It starts polling straight away; what it costs is in Settings > Presets.",
-    "presetBound": "{address} is now polling its preset."
+    "presetBound": "{address} is now polling its preset.",
+    "presetDetect": "Detect",
+    "presetDetectHint": "Ask this equipment what it is, and put the presets that match it first.",
+    "presetMatched": "{count} preset(s) match this equipment.",
+    "presetNoMatch": "No preset names this equipment.",
+    "presetDeviceMasked": "Equipment identified"
   },
   "update": {
     "available": "SnmpLens {version} is available",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -610,7 +610,12 @@
     "presetPick": "Sin preset",
     "presetNone": "Ningún preset disponible",
     "presetHint": "Vincular un preset de panel a este equipo. La consulta empieza de inmediato; su coste está en Ajustes > Presets.",
-    "presetBound": "{address} ya consulta su preset."
+    "presetBound": "{address} ya consulta su preset.",
+    "presetDetect": "Detectar",
+    "presetDetectHint": "Preguntar al equipo qué es y poner primero los presets que le corresponden.",
+    "presetMatched": "{count} preset(s) corresponden a este equipo.",
+    "presetNoMatch": "Ningún preset menciona este equipo.",
+    "presetDeviceMasked": "Equipo identificado"
   },
   "update": {
     "available": "SnmpLens {version} está disponible",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -610,7 +610,12 @@
     "presetPick": "Aucun preset",
     "presetNone": "Aucun preset disponible",
     "presetHint": "Lier un preset de tableau de bord à cet équipement. L'interrogation démarre aussitôt ; le coût est indiqué dans Paramètres > Presets.",
-    "presetBound": "{address} interroge désormais son preset."
+    "presetBound": "{address} interroge désormais son preset.",
+    "presetDetect": "Détecter",
+    "presetDetectHint": "Demander à cet équipement ce qu'il est, et placer en tête les presets qui lui correspondent.",
+    "presetMatched": "{count} preset(s) correspondent à cet équipement.",
+    "presetNoMatch": "Aucun preset ne désigne cet équipement.",
+    "presetDeviceMasked": "Équipement identifié"
   },
   "update": {
     "available": "SnmpLens {version} est disponible",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -610,7 +610,12 @@
     "presetPick": "不使用预设",
     "presetNone": "暂无可用预设",
     "presetHint": "将仪表板预设绑定到此设备。绑定后立即开始轮询；其开销见「设置 > 预设」。",
-    "presetBound": "{address} 现已按其预设进行轮询。"
+    "presetBound": "{address} 现已按其预设进行轮询。",
+    "presetDetect": "识别",
+    "presetDetectHint": "询问该设备的型号，并把匹配的预设排在前面。",
+    "presetMatched": "有 {count} 个预设匹配此设备。",
+    "presetNoMatch": "没有预设指明此设备。",
+    "presetDeviceMasked": "设备已识别"
   },
   "update": {
     "available": "SnmpLens {version} 可用",

--- a/frontend/tests/series.test.mjs
+++ b/frontend/tests/series.test.mjs
@@ -112,7 +112,12 @@ const point = (target, oid) => ({ target, oid, timestamp: '2026-01-01T00:00:00Z'
 
   // Comments are stripped first: this file explains the defects it replaced, so
   // a check that scanned the prose would fail on its own description of them.
-  const code = (src) => src.split('\n').map((line) => line.replace(/\/\/.*$/, '')).join('\n');
+  // `[^\r\n]` rather than `.` and `$`: the working tree is CRLF on Windows and
+  // LF in git, so splitting on \n leaves a \r that `.` will not cross and `$`
+  // sits after — the strip silently did nothing on one platform and everything
+  // on the other, which is a check that passes in CI and fails on the machine
+  // that wrote it.
+  const code = (src) => src.replace(/\/\/[^\r\n]*/g, '');
 
   for (const [name, src] of [['MonitorChart', chart], ['MetricTiles', tiles], ['ChannelsModal', modal]]) {
     check(`${name} takes its colours from the plan`, /seriesPlan\(/.test(code(src)));

--- a/pkg/snmp/discovery.go
+++ b/pkg/snmp/discovery.go
@@ -13,8 +13,12 @@ import (
 
 // DiscoveryResult represents the outcome of scanning a single IP.
 type DiscoveryResult struct {
-	IP           string `json:"ip"`
-	SysName      string `json:"sysName"`
+	IP      string `json:"ip"`
+	SysName string `json:"sysName"`
+	// SysObjectID is the vendor and model, as an OID. It is what a dashboard
+	// preset matches on: sysDescr is prose that differs between two firmware
+	// revisions of the same switch, and this does not.
+	SysObjectID  string `json:"sysObjectId,omitempty"`
 	SysDescr     string `json:"sysDescr"`
 	SysUpTime    string `json:"sysUpTime"`
 	ResponseTime int64  `json:"responseTime"`
@@ -65,6 +69,7 @@ func (c *Client) Discover(cidr, community, version string, port, timeoutSec int,
 				".1.3.6.1.2.1.1.1.0", // sysDescr
 				".1.3.6.1.2.1.1.5.0", // sysName
 				".1.3.6.1.2.1.1.3.0", // sysUpTime
+				".1.3.6.1.2.1.1.2.0", // sysObjectID
 			}
 			packet, err := g.Get(oids)
 			result.ResponseTime = time.Since(start).Milliseconds()
@@ -86,6 +91,8 @@ func (c *Client) Discover(cidr, community, version string, port, timeoutSec int,
 					result.SysName = fmt.Sprintf("%v", val)
 				case ".1.3.6.1.2.1.1.3.0":
 					result.SysUpTime = fmt.Sprintf("%v", val)
+				case ".1.3.6.1.2.1.1.2.0":
+					result.SysObjectID = fmt.Sprintf("%v", val)
 				}
 			}
 			resultsChan <- result


### PR DESCRIPTION
`preset.Match` was written in the format (#37) and **never wired**, because nothing in this application read `sysObjectID`. `Discover` asked for sysDescr, sysName and sysUpTime; `TestConnection` asks for sysDescr alone. So the rule that decides which presets are *for* a device had no data source at all.

`sysObjectID` and not `sysDescr`, and that is the whole reason the field exists: a description is prose that differs between two firmware revisions of the same switch, and an object identifier names the vendor and the model and does not move.

## `IdentifyDevice`

A separate method from `TestConnection`, which answers a different question — *"did these credentials work"* — with one varbind. This one is three varbinds in a single request, and it **orders** the library rather than filtering it.

`Match` is documented as advice to the person binding, never an automatic action. A preset that says nothing about which device it is for is still one somebody downloaded for this one, and hiding it would turn advice into a decision.

It never fails hard: a device that does not answer still gets the whole library back, because picking by hand is the normal path and an unreachable device must not take the picker away with it. The best match is **offered** rather than chosen — the operator still has to see which preset is selected before pressing Add.

Discovery carries `sysObjectID` too, since it already opens a connection and asks three questions; a fourth varbind in the same PDU costs nothing.

## The ranking is split out of the round trip

With them in one function, the only way to check that *"3 presets match"* is really 3 is to have a switch. So `rankForDevice` is pure and the counting is tested — including the leading dot that `formatSnmpValue` puts on an `ObjectIdentifier` and a hand-written preset file does not. If that stopped working the symptom would be *"no preset names this equipment"*, on every device.

`sysObjectID` names a vendor and a model as plainly as `sysDescr` does, so Anonymous Mode masks it with everything else.

## Also fixed

`series.test.mjs` (from #43) stripped comments with `//.*$`, which **cannot match when the working tree is CRLF**: `.` will not cross the `\r` and `$` sits after it. The strip did nothing on Windows and everything on Linux — so the check passed in CI and failed on the machine that wrote it. `[^\r\n]*` over the whole string instead.

## Checks

`go vet`, `staticcheck`, `go test -count=1 ./...`, `npm test` (623 checks), `npm run check`, `npm run build`. `IdentifyDevice` is a new `App` method, so the bindings regenerate. Two new Go tests: the ranking and its dot handling, and an unreachable device still returning the library.