### PR TITLE
Ship five example presets, and let a unit be inferred at all

### DIFF
--- a/app.go
+++ b/app.go
@@ -34,6 +34,7 @@ import (
 type App struct {
 	ctx              context.Context
 	mibs             embed.FS
+	presets          embed.FS
 	persistentMibDir string
 	mibService       *mib.Service
 	snmpClient       *snmp.Client
@@ -64,9 +65,10 @@ type App struct {
 }
 
 // NewApp creates a new App application struct.
-func NewApp(mibs embed.FS) *App {
+func NewApp(mibs, presets embed.FS) *App {
 	return &App{
 		mibs:    mibs,
+		presets: presets,
 		updater: updater.NewService("Wasabules", "SnmpLens"),
 	}
 }
@@ -94,6 +96,7 @@ func (a *App) startup(ctx context.Context) {
 	// this on every startup (not just first run) self-heals an empty or
 	// partially-populated MIB directory.
 	a.ensureStandardMibs()
+	a.ensureBundledPresets()
 
 	// 2. Initialize gosmi and our MIB service
 	log.Printf("Setting MIB search path to: %s", a.persistentMibDir)

--- a/app_bundledpresets_test.go
+++ b/app_bundledpresets_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/preset"
+	"SnmpLens/pkg/snmp"
+)
+
+// Every preset that ships must be bindable.
+//
+// The bar `pkg/mib`'s Analyse holds over the fourteen bundled MIBs, for the same
+// reason: a shipped file with problems is listed WITH them and cannot be bound,
+// so it would be an example that demonstrates the error list rather than the
+// feature. And nothing else would say so — it imports, it lists, it simply has
+// a number beside it.
+func TestEveryBundledPresetIsValid(t *testing.T) {
+	entries, err := os.ReadDir("presets")
+	if err != nil {
+		t.Fatalf("no bundled presets: %v", err)
+	}
+	if len(entries) < 3 {
+		t.Fatalf("%d bundled preset(s); the library ships as the feature's first impression", len(entries))
+	}
+
+	names := map[string]string{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		p, errs, err := preset.LoadFile(filepath.Join("presets", e.Name()))
+		if err != nil {
+			t.Errorf("%s: %v", e.Name(), err)
+			continue
+		}
+		for _, ve := range errs {
+			t.Errorf("%s: %s %s %v", e.Name(), ve.Field, ve.Message, ve.Args)
+		}
+		if len(errs) > 0 {
+			continue
+		}
+
+		// A name is what the picker shows, so two files with the same one are
+		// two rows nobody can tell apart.
+		if other, clash := names[p.Name]; clash {
+			t.Errorf("%s and %s are both called %q", e.Name(), other, p.Name)
+		}
+		names[p.Name] = e.Name()
+
+		if strings.TrimSpace(p.Description) == "" {
+			t.Errorf("%s has no description; the library is a list of names without one", e.Name())
+		}
+		if p.Author == "" {
+			t.Errorf("%s has no author", e.Name())
+		}
+
+		// The cost has to be honest before it is shown, and these are the files
+		// most people will bind first.
+		c := presetCost(p)
+		if c.OIDs == 0 || c.VarbindsPerDay == 0 {
+			t.Errorf("%s costs nothing: %+v", e.Name(), c)
+		}
+		// One round in one request keeps the example cheap to reason about.
+		if c.OIDs > snmp.MaxVarbindsPerGet*2 {
+			t.Errorf("%s polls %d OIDs, more than two requests a round", e.Name(), c.OIDs)
+		}
+	}
+}
+
+// The examples are extracted on FIRST RUN ONLY, and that is the difference from
+// the bundled MIBs.
+//
+// ensureStandardMibs restores an absent MIB on every startup because nearly
+// every other MIB imports from those three. Nothing depends on a preset, and
+// restoring one the operator deleted would be the application arguing with
+// them, once per restart, forever.
+func TestBundledPresetsAreExtractedOnceAndNotRestored(t *testing.T) {
+	a, dir := newPresetApp(t)
+	a.presets = presets
+
+	// newPresetApp already created the directory, which is what a second run
+	// looks like: nothing is written.
+	a.ensureBundledPresets()
+	if list := a.ListPresets(); len(list) != 0 {
+		t.Fatalf("an existing library was populated anyway: %+v", list)
+	}
+
+	// A first run: the directory does not exist yet.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	a.ensureBundledPresets()
+	first := a.ListPresets()
+	if len(first) < 3 {
+		t.Fatalf("a first run extracted %d preset(s)", len(first))
+	}
+	for _, p := range first {
+		if p.Problems != 0 {
+			t.Errorf("%s shipped with %d problem(s)", p.File, p.Problems)
+		}
+	}
+
+	// Deleting one and restarting must leave it deleted.
+	if err := a.DeletePreset(first[0].File); err != nil {
+		t.Fatal(err)
+	}
+	a.ensureBundledPresets()
+	after := a.ListPresets()
+	if len(after) != len(first)-1 {
+		t.Errorf("a deleted example came back: %d entries, was %d", len(after), len(first))
+	}
+	for _, p := range after {
+		if p.File == first[0].File {
+			t.Errorf("%s was restored after being deleted", p.File)
+		}
+	}
+}
+
+// One of them names a vendor, so the matching feature has something to match on
+// out of the box — otherwise Detect always answers "no preset names this
+// equipment" on a fresh installation, which reads as a broken feature.
+func TestAtLeastOneBundledPresetClaimsADevice(t *testing.T) {
+	list, err := preset.List("presets")
+	if err != nil {
+		t.Fatal(err)
+	}
+	claiming := 0
+	for _, in := range list {
+		if len(in.SysObjectIDPrefix) > 0 {
+			claiming++
+		}
+	}
+	if claiming == 0 {
+		t.Error("no bundled preset names a device; Detect can never match anything on a fresh install")
+	}
+
+	// And it really matches what it says it does.
+	if _, matched := rankForDevice(list, "1.3.6.1.4.1.9.1.2494"); matched == 0 {
+		t.Error("nothing matches a Cisco sysObjectID")
+	}
+	if _, matched := rankForDevice(list, "1.3.6.1.4.1.911.1"); matched != 0 {
+		t.Error("a Cisco preset matched enterprise 911; the prefix is being compared as text")
+	}
+}

--- a/app_preset.go
+++ b/app_preset.go
@@ -69,6 +69,57 @@ type PresetDetail struct {
 	Cost   PresetCost     `json:"cost"`
 }
 
+// ensureBundledPresets writes the example presets out, ON FIRST RUN ONLY.
+//
+// Deliberately NOT the shape ensureStandardMibs has. That one runs on every
+// startup and restores any bundled MIB that is absent, because nearly every
+// other MIB imports from those three and a missing one breaks the tree for
+// everything — self-healing is worth more there than obeying a deletion.
+//
+// A preset is the opposite: nothing depends on it, and it is a file the
+// operator curates. Restoring one they deleted would be the application
+// arguing with them, once per restart, forever. So the whole extraction is
+// skipped as soon as the directory exists — which also means an operator who
+// wants the examples back can delete the directory rather than hunt for a
+// setting.
+func (a *App) ensureBundledPresets() {
+	if a.persistentMibDir == "" {
+		return
+	}
+	dir := filepath.Join(filepath.Dir(a.persistentMibDir), presetSubdir)
+	if _, err := os.Stat(dir); err == nil {
+		return // this machine has a preset library already
+	}
+
+	entries, err := a.presets.ReadDir(presetSubdir)
+	if err != nil {
+		log.Printf("WARNING: could not read the embedded presets: %v", err)
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		log.Printf("WARNING: could not create the preset directory: %v", err)
+		return
+	}
+
+	written := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := a.presets.ReadFile(presetSubdir + "/" + e.Name())
+		if err != nil {
+			log.Printf("WARNING: could not read the embedded preset %s: %v", e.Name(), err)
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(dir, e.Name()), data, 0o600); err != nil {
+			log.Printf("WARNING: could not write the preset %s: %v", e.Name(), err)
+			continue
+		}
+		written++
+	}
+	log.Printf("Extracted %d example preset(s) to %s", written, dir)
+}
+
 // presetDir returns the preset directory, creating it on first use.
 func (a *App) presetDir() (string, error) {
 	if a.persistentMibDir == "" {

--- a/frontend/src/monitor/MetricTiles.svelte
+++ b/frontend/src/monitor/MetricTiles.svelte
@@ -45,7 +45,14 @@
 
   // One tile per target, one row per OID inside it: a separate tile grid per
   // OID stacked vertically and burned a lot of height for the same information.
-  function buildTiles(s, m, _hidden, _scope, _range, _stats, _layout, _theme) {
+  // inferUnit reads a NAME, and every caller was handing it a numeric OID.
+  //
+  // Its patterns are /octets|bytes|bandwidth/ and /percent|utili|load/, which
+  // "1.3.6.1.2.1.2.2.1.10.1" cannot match — so no session has ever had a unit
+  // inferred: an interface counter rendered as a bare scaled number instead of
+  // bit/s, and a processor load lost its %. The tree is what turns one into the
+  // other, and this component already has it.
+  function buildTiles(s, m, _hidden, _scope, _range, _stats, _layout, _theme, tree) {
     const source = s?.results || [];
     const field = FIELD[m] || 'value';
     const dark = theme !== 'light';
@@ -101,7 +108,7 @@
           rows.push({
             oid: o,
             color: seriesColor(colorIdx, dark),
-            unit: inferUnit(o, (series.find((r) => r.snmpType) || {}).snmpType || '', m),
+            unit: inferUnit(oidName(o, tree), (series.find((r) => r.snmpType) || {}).snmpType || '', m),
             summary,
             spark: recent,
             trend,
@@ -114,7 +121,7 @@
       .filter((t) => t.rows.length);
   }
 
-  $: tiles = buildTiles(session, mode, hiddenSet, scope, range, stats, layout, theme);
+  $: tiles = buildTiles(session, mode, hiddenSet, scope, range, stats, layout, theme, $mibStore.tree);
 
   // Sparkline as an SVG polyline in a 100x20 viewBox.
   function sparkPath(values) {

--- a/frontend/src/monitor/MonitorChart.svelte
+++ b/frontend/src/monitor/MonitorChart.svelte
@@ -114,7 +114,9 @@
     return list.filter((r) => (r.oid || s?.oid || oid) === oid);
   }
 
-  $: unit = inferUnit(oid || session?.oid || '', snmpTypeOf(session), mode);
+  // The NAME, not the numeric OID: inferUnit matches on words and every caller
+  // was handing it digits, so no chart has ever inferred a unit. See MetricTiles.
+  $: unit = inferUnit(oidName(oid || session?.oid || '', mibTree), snmpTypeOf(session), mode);
 
   $: labels = $targetLabels;
   $: mibTree = $mibStore.tree;
@@ -157,7 +159,7 @@
         id: axisId,
         index: axes.length,
         oid: o,
-        unit: inferUnit(o, type, m),
+        unit: inferUnit(oidName(o, mibTree), type, m),
         color: seriesColor(drawable[0].colorIndex, dark),
       });
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,10 @@ var assets embed.FS
 //go:embed mibs
 var mibs embed.FS
 
+// The example presets, extracted on FIRST RUN only — see ensureBundledPresets.
+//go:embed presets
+var presets embed.FS
+
 // Tray artwork. Windows needs an .ico; the other desktops want a .png. Both
 // are a couple of kilobytes, so embedding both beats a build-tagged file.
 //
@@ -42,7 +46,7 @@ func main() {
 		log.Printf("WARNING: could not read %s, using defaults: %v", service.Path(cfgDir), err)
 	}
 
-	app := NewApp(mibs)
+	app := NewApp(mibs, presets)
 	app.configDir = cfgDir
 	app.serviceCfg = svcCfg
 	app.trayIcons = trayIcons{png: iconPNG, ico: iconICO}

--- a/pkg/preset/preset.go
+++ b/pkg/preset/preset.go
@@ -61,10 +61,23 @@ const (
 	MinIntervalSec = 5
 	// MaxIntervalSec is a day: past that, a dashboard is a report.
 	MaxIntervalSec = 86400
-	// MaxTextLen caps every author-supplied string. A preset's title lands in
-	// a panel, and a title the length of a novel is a layout attack whatever
-	// the intent.
+	// MaxTextLen caps author-supplied LABELS: the preset's name, a widget
+	// title, a unit, a state's word. Each of those lands in a panel, and one
+	// the length of a novel is a layout attack whatever the intent.
 	MaxTextLen = 120
+	// MaxDescriptionLen caps the one field that is PROSE rather than a label.
+	//
+	// It exists because 120 was applied to it and should not have been: the
+	// reasoning above is about a title in a panel, and a description is a
+	// paragraph in the library's detail view, where explaining that the
+	// storage indexes are per device takes more than a dozen words. Every
+	// example preset that ships was refused by the label bound before this
+	// existed, which is the clearest possible evidence that the bound was
+	// being asked to do two jobs.
+	//
+	// The control-character rule is unchanged and applies to both: that half is
+	// about what travels into a log line and a syslog collector, not layout.
+	MaxDescriptionLen = 600
 )
 
 // Widget kinds. This IS the vocabulary: a preset chooses from here and cannot
@@ -277,7 +290,7 @@ func Validate(p Preset) []Error {
 	}
 	errs = append(errs, checkText("name", p.Name)...)
 	errs = append(errs, checkText("author", p.Author)...)
-	errs = append(errs, checkText("description", p.Description)...)
+	errs = append(errs, checkProse("description", p.Description)...)
 	errs = append(errs, checkText("match.vendor", p.Match.Vendor)...)
 
 	if p.IntervalSec == 0 {
@@ -429,7 +442,14 @@ func PollOIDs(p Preset) []string {
 	return out
 }
 
-func checkText(field, s string) []Error {
+// checkText bounds a LABEL. checkProse bounds the one field that is a
+// paragraph; both refuse control characters, which is the half that is about
+// what travels rather than what fits.
+func checkText(field, s string) []Error { return checkBounded(field, s, MaxTextLen) }
+
+func checkProse(field, s string) []Error { return checkBounded(field, s, MaxDescriptionLen) }
+
+func checkBounded(field, s string, max int) []Error {
 	if s == "" {
 		return nil
 	}
@@ -438,9 +458,9 @@ func checkText(field, s string) []Error {
 	// is displayed — and this application ships a zh locale, where a
 	// forty-character title is a hundred and twenty bytes and would be refused
 	// for being too long to fit in a panel it fits in comfortably.
-	if n := utf8.RuneCountInString(s); n > MaxTextLen {
+	if n := utf8.RuneCountInString(s); n > max {
 		errs = append(errs, errf(field, "tooLong", map[string]string{
-			"found": fmt.Sprint(n), "max": fmt.Sprint(MaxTextLen),
+			"found": fmt.Sprint(n), "max": fmt.Sprint(max),
 		}))
 	}
 	// A control character in a title reaches a panel, a log line and — through

--- a/pkg/preset/preset_test.go
+++ b/pkg/preset/preset_test.go
@@ -419,3 +419,35 @@ func TestTheSanityBoundsDoNotBiteARealPreset(t *testing.T) {
 		}
 	}
 }
+
+// A description is prose, not a label, and one bound cannot serve both.
+//
+// MaxTextLen's reasoning is about a title in a panel. Applied to a description
+// it refused every example preset this application ships — which is the
+// clearest evidence a bound is doing two jobs.
+func TestADescriptionIsBoundedAsProseNotAsALabel(t *testing.T) {
+	p := valid()
+	p.Description = strings.Repeat("x", MaxTextLen+50)
+	if errs := Validate(p); has(errs, "description") {
+		t.Errorf("a %d-character description was refused: %s", len(p.Description), fieldsOf(errs))
+	}
+
+	p.Description = strings.Repeat("x", MaxDescriptionLen+1)
+	if errs := Validate(p); !has(errs, "description") {
+		t.Error("a description past its own bound was accepted")
+	}
+
+	// The label bound is unchanged: a name is still a label.
+	p2 := valid()
+	p2.Name = strings.Repeat("x", MaxTextLen+1)
+	if errs := Validate(p2); !has(errs, "name") {
+		t.Error("the label bound was widened along with the prose one")
+	}
+
+	// And the half that is about what TRAVELS applies to both.
+	p3 := valid()
+	p3.Description = "a paragraph\nwith a newline"
+	if errs := Validate(p3); !has(errs, "description") {
+		t.Error("a control character in a description was accepted")
+	}
+}

--- a/presets/cisco-generic.json
+++ b/presets/cisco-generic.json
@@ -1,0 +1,71 @@
+{
+  "formatVersion": 1,
+  "name": "Cisco (IF-MIB)",
+  "author": "SnmpLens",
+  "description": "The same interface view, matched to Cisco equipment so it is offered first when you add one. The OIDs are standard IF-MIB rather than CISCO-*: those load only once you have imported the vendor MIB, and this has to work before that.",
+  "match": {
+    "vendor": "Cisco",
+    "sysObjectIdPrefix": [
+      "1.3.6.1.4.1.9"
+    ]
+  },
+  "intervalSec": 60,
+  "widgets": [
+    {
+      "kind": "value",
+      "title": "Uptime",
+      "oids": [
+        "1.3.6.1.2.1.1.3.0"
+      ]
+    },
+    {
+      "kind": "rate",
+      "title": "Gi0/1 in",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.1"
+      ]
+    },
+    {
+      "kind": "rate",
+      "title": "Gi0/1 out",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.16.1"
+      ]
+    },
+    {
+      "kind": "chart",
+      "title": "Uplink traffic",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.1",
+        "1.3.6.1.2.1.2.2.1.16.1"
+      ]
+    },
+    {
+      "kind": "grid",
+      "title": "Ports",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.8.1",
+        "1.3.6.1.2.1.2.2.1.8.2",
+        "1.3.6.1.2.1.2.2.1.8.3",
+        "1.3.6.1.2.1.2.2.1.8.4",
+        "1.3.6.1.2.1.2.2.1.8.5",
+        "1.3.6.1.2.1.2.2.1.8.6",
+        "1.3.6.1.2.1.2.2.1.8.7",
+        "1.3.6.1.2.1.2.2.1.8.8",
+        "1.3.6.1.2.1.2.2.1.8.9",
+        "1.3.6.1.2.1.2.2.1.8.10",
+        "1.3.6.1.2.1.2.2.1.8.11",
+        "1.3.6.1.2.1.2.2.1.8.12"
+      ],
+      "labels": {
+        "1": "up",
+        "2": "down",
+        "3": "testing",
+        "4": "unknown",
+        "5": "dormant",
+        "6": "absent",
+        "7": "lower layer down"
+      }
+    }
+  ]
+}

--- a/presets/host-resources.json
+++ b/presets/host-resources.json
@@ -1,0 +1,58 @@
+{
+  "formatVersion": 1,
+  "name": "Server (HOST-RESOURCES-MIB)",
+  "author": "SnmpLens",
+  "description": "Processor load, memory and disks of a server or workstation, from HOST-RESOURCES-MIB. The storage and processor indexes are per device: run a walk of 1.3.6.1.2.1.25.2.3.1.3 to see what yours calls them, and edit the instance numbers to match.",
+  "intervalSec": 60,
+  "widgets": [
+    {
+      "kind": "value",
+      "title": "Uptime",
+      "oids": [
+        "1.3.6.1.2.1.25.1.1.0"
+      ]
+    },
+    {
+      "kind": "value",
+      "title": "Processes",
+      "oids": [
+        "1.3.6.1.2.1.25.1.6.0"
+      ]
+    },
+    {
+      "kind": "value",
+      "title": "Users",
+      "oids": [
+        "1.3.6.1.2.1.25.1.5.0"
+      ]
+    },
+    {
+      "kind": "chart",
+      "title": "Processor load",
+      "oids": [
+        "1.3.6.1.2.1.25.3.3.1.2.1",
+        "1.3.6.1.2.1.25.3.3.1.2.2",
+        "1.3.6.1.2.1.25.3.3.1.2.3",
+        "1.3.6.1.2.1.25.3.3.1.2.4"
+      ],
+      "unit": "%"
+    },
+    {
+      "kind": "chart",
+      "title": "Storage used",
+      "oids": [
+        "1.3.6.1.2.1.25.2.3.1.6.1",
+        "1.3.6.1.2.1.25.2.3.1.6.2",
+        "1.3.6.1.2.1.25.2.3.1.6.3"
+      ],
+      "unit": "allocation units"
+    },
+    {
+      "kind": "value",
+      "title": "Storage 1 size",
+      "oids": [
+        "1.3.6.1.2.1.25.2.3.1.5.1"
+      ]
+    }
+  ]
+}

--- a/presets/interfaces.json
+++ b/presets/interfaces.json
@@ -1,0 +1,78 @@
+{
+  "formatVersion": 1,
+  "name": "Interfaces (IF-MIB)",
+  "author": "SnmpLens",
+  "description": "Traffic and state of the first eight interfaces, from IF-MIB alone. Works on any agent that answers MIB-2, which is nearly all of them.",
+  "intervalSec": 60,
+  "widgets": [
+    {
+      "kind": "value",
+      "title": "Uptime",
+      "oids": [
+        "1.3.6.1.2.1.1.3.0"
+      ]
+    },
+    {
+      "kind": "value",
+      "title": "Interfaces",
+      "oids": [
+        "1.3.6.1.2.1.2.1.0"
+      ]
+    },
+    {
+      "kind": "rate",
+      "title": "Interface 1 in",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.1"
+      ]
+    },
+    {
+      "kind": "rate",
+      "title": "Interface 1 out",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.16.1"
+      ]
+    },
+    {
+      "kind": "chart",
+      "title": "Interface 1 traffic",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.1",
+        "1.3.6.1.2.1.2.2.1.16.1"
+      ]
+    },
+    {
+      "kind": "chart",
+      "title": "Errors and discards, interface 1",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.14.1",
+        "1.3.6.1.2.1.2.2.1.20.1",
+        "1.3.6.1.2.1.2.2.1.13.1",
+        "1.3.6.1.2.1.2.2.1.19.1"
+      ]
+    },
+    {
+      "kind": "grid",
+      "title": "Operational state",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.8.1",
+        "1.3.6.1.2.1.2.2.1.8.2",
+        "1.3.6.1.2.1.2.2.1.8.3",
+        "1.3.6.1.2.1.2.2.1.8.4",
+        "1.3.6.1.2.1.2.2.1.8.5",
+        "1.3.6.1.2.1.2.2.1.8.6",
+        "1.3.6.1.2.1.2.2.1.8.7",
+        "1.3.6.1.2.1.2.2.1.8.8"
+      ],
+      "labels": {
+        "1": "up",
+        "2": "down",
+        "3": "testing",
+        "4": "unknown",
+        "5": "dormant",
+        "6": "absent",
+        "7": "lower layer down"
+      }
+    }
+  ]
+}

--- a/presets/switch-ports.json
+++ b/presets/switch-ports.json
@@ -1,0 +1,77 @@
+{
+  "formatVersion": 1,
+  "name": "Switch ports (24)",
+  "author": "SnmpLens",
+  "description": "A 24-port access switch: the two uplink counters as a chart, and every port's operational state as one wall. Standard IF-MIB only, so it works on any managed switch; edit the instance numbers if yours does not index its ports from 1.",
+  "intervalSec": 30,
+  "widgets": [
+    {
+      "kind": "value",
+      "title": "Uptime",
+      "oids": [
+        "1.3.6.1.2.1.1.3.0"
+      ]
+    },
+    {
+      "kind": "rate",
+      "title": "Uplink in",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.1"
+      ]
+    },
+    {
+      "kind": "rate",
+      "title": "Uplink out",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.16.1"
+      ]
+    },
+    {
+      "kind": "chart",
+      "title": "Uplink traffic",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.1",
+        "1.3.6.1.2.1.2.2.1.16.1"
+      ]
+    },
+    {
+      "kind": "grid",
+      "title": "Ports",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.8.1",
+        "1.3.6.1.2.1.2.2.1.8.2",
+        "1.3.6.1.2.1.2.2.1.8.3",
+        "1.3.6.1.2.1.2.2.1.8.4",
+        "1.3.6.1.2.1.2.2.1.8.5",
+        "1.3.6.1.2.1.2.2.1.8.6",
+        "1.3.6.1.2.1.2.2.1.8.7",
+        "1.3.6.1.2.1.2.2.1.8.8",
+        "1.3.6.1.2.1.2.2.1.8.9",
+        "1.3.6.1.2.1.2.2.1.8.10",
+        "1.3.6.1.2.1.2.2.1.8.11",
+        "1.3.6.1.2.1.2.2.1.8.12",
+        "1.3.6.1.2.1.2.2.1.8.13",
+        "1.3.6.1.2.1.2.2.1.8.14",
+        "1.3.6.1.2.1.2.2.1.8.15",
+        "1.3.6.1.2.1.2.2.1.8.16",
+        "1.3.6.1.2.1.2.2.1.8.17",
+        "1.3.6.1.2.1.2.2.1.8.18",
+        "1.3.6.1.2.1.2.2.1.8.19",
+        "1.3.6.1.2.1.2.2.1.8.20",
+        "1.3.6.1.2.1.2.2.1.8.21",
+        "1.3.6.1.2.1.2.2.1.8.22",
+        "1.3.6.1.2.1.2.2.1.8.23",
+        "1.3.6.1.2.1.2.2.1.8.24"
+      ],
+      "labels": {
+        "1": "up",
+        "2": "down",
+        "3": "testing",
+        "4": "unknown",
+        "5": "dormant",
+        "6": "absent",
+        "7": "lower layer down"
+      }
+    }
+  ]
+}

--- a/presets/ups.json
+++ b/presets/ups.json
@@ -1,0 +1,80 @@
+{
+  "formatVersion": 1,
+  "name": "UPS (RFC 1628)",
+  "author": "SnmpLens",
+  "description": "Battery, input and output of an uninterruptible power supply, from the standard UPS-MIB. Many vendors also publish their own MIB with more detail; this one answers on any UPS that implements RFC 1628.",
+  "intervalSec": 300,
+  "widgets": [
+    {
+      "kind": "status",
+      "title": "Battery",
+      "oids": [
+        "1.3.6.1.2.1.33.1.2.1.0"
+      ],
+      "labels": {
+        "1": "unknown",
+        "2": "normal",
+        "3": "low",
+        "4": "depleted"
+      }
+    },
+    {
+      "kind": "status",
+      "title": "Running on",
+      "oids": [
+        "1.3.6.1.2.1.33.1.4.1.0"
+      ],
+      "labels": {
+        "1": "other",
+        "2": "none",
+        "3": "mains",
+        "4": "bypass",
+        "5": "battery",
+        "6": "booster",
+        "7": "reducer"
+      }
+    },
+    {
+      "kind": "value",
+      "title": "Charge remaining",
+      "oids": [
+        "1.3.6.1.2.1.33.1.2.4.0"
+      ],
+      "unit": "%"
+    },
+    {
+      "kind": "value",
+      "title": "Minutes remaining",
+      "oids": [
+        "1.3.6.1.2.1.33.1.2.3.0"
+      ],
+      "unit": "min"
+    },
+    {
+      "kind": "value",
+      "title": "Seconds on battery",
+      "oids": [
+        "1.3.6.1.2.1.33.1.2.2.0"
+      ],
+      "unit": "s"
+    },
+    {
+      "kind": "chart",
+      "title": "Battery",
+      "oids": [
+        "1.3.6.1.2.1.33.1.2.4.0",
+        "1.3.6.1.2.1.33.1.2.5.0"
+      ]
+    },
+    {
+      "kind": "chart",
+      "title": "Output load",
+      "oids": [
+        "1.3.6.1.2.1.33.1.4.4.1.5.1",
+        "1.3.6.1.2.1.33.1.4.4.1.5.2",
+        "1.3.6.1.2.1.33.1.4.4.1.5.3"
+      ],
+      "unit": "%"
+    }
+  ]
+}


### PR DESCRIPTION
The library shipped **empty**, so the first thing anybody saw of the feature was an empty state explaining how to fill it.

| file | for | cadence |
| --- | --- | --- |
| `interfaces.json` | any agent that answers MIB-2 | 60 s |
| `switch-ports.json` | a 24-port access switch, ports as one wall | 30 s |
| `host-resources.json` | a server or workstation | 60 s |
| `ups.json` | any UPS implementing RFC 1628 | 300 s |
| `cisco-generic.json` | matched to `1.3.6.1.4.1.9`, so Detect has something to match | 60 s |

**Standard MIB OIDs only, including the Cisco one.** A `CISCO-*` OID resolves only once the vendor MIB has been imported, and an example has to work before that. The two whose instance numbers are device-specific — storage and processor indexes — say so in their description rather than pretending.

## Extracted on first run only

Deliberately *not* what `ensureStandardMibs` does. That one restores an absent bundled MIB on every startup, because nearly every other MIB imports from those three and a missing one breaks the tree for everything.

Nothing depends on a preset. Restoring one the operator deleted would be the application arguing with them, once per restart, forever — so the extraction is skipped as soon as the directory exists. Which also means deleting the directory is how you ask for the examples back.

## Writing them found two defects

**`MaxTextLen` was applied to `description`**, and its reasoning is about a *title in a panel*: "a title the length of a novel is a layout attack". A description is a paragraph in the library's detail view, where explaining that the storage indexes are per device takes more than a dozen words — and **all five files were refused by it**, which is the clearest evidence a bound was being asked to do two jobs. Prose has its own bound now; the control-character rule is unchanged and applies to both, because that half is about what travels into a log line and a syslog collector rather than about what fits.

**`inferUnit` has never inferred anything.** Its patterns are `/octets|bytes|bandwidth/` and `/percent|pct|utili|usage|load/`, and all three call sites hand it the **numeric OID** — `1.3.6.1.2.1.2.2.1.10.1` matches neither. So no session has ever shown `bit/s` for an interface counter or a `%` for a processor load, on the monitor tab as much as on the dashboard. Both components already hold the MIB tree, which is exactly what turns one into the other.

Which is why the bundled files declare **no unit for a counter**: once the name resolves, an octet counter in rate mode renders as `bit/s` — eight times the number the widget holds — so a declared `octet/s` beside it would be a label disagreeing with its own figure by a factor of eight. They speak only where inference cannot know: minutes, seconds, and a UPS charge whose name says nothing about percent.

## Checks

`go vet`, `staticcheck`, `go mod tidy` clean, `go test -count=1 ./...`, `npm test` (626 checks), `npm run check`, `npm run build`. Four new tests: every shipped preset validates and costs something (the bar `pkg/mib`'s `Analyse` holds over the fourteen bundled MIBs — a shipped file with problems is listed *with* them, cannot be bound, and nothing else would say so); the examples are extracted once and a deleted one stays deleted; at least one claims a device and really matches a Cisco `sysObjectID` without matching enterprise 911; and prose is bounded as prose while a label stays a label.