### PR TITLE
Stop a poll round from being able to end the process

### DIFF
--- a/app_monitor.go
+++ b/app_monitor.go
@@ -150,6 +150,22 @@ func (a *App) initScheduler() {
 		})
 	}
 
+	// A poll round that panicked is contained by the scheduler; this is what
+	// makes it VISIBLE. A recovered panic that nobody records is a session
+	// quietly returning nothing, which reads as a device that stopped
+	// answering — the one explanation that is wrong.
+	s.OnPanic = func(sessionID, name, recovered, stack string) {
+		detail := fmt.Sprintf("the poll of %q panicked and was recovered: %s", name, recovered)
+		_ = a.recordEvent(events.Event{
+			Category: events.CategorySystem,
+			Kind:     events.KindSystemPollFailed,
+			Severity: events.SevMajor.String(),
+			TitleKey: "events.kind." + events.KindSystemPollFailed,
+			Params:   map[string]any{"detail": detail, "sessionId": sessionID},
+			Summary:  detail,
+		}, stack)
+	}
+
 	s.OnStateChange = a.refreshTrayStatus
 
 	// The guardrail's report. Two destinations, because the two questions are
@@ -235,6 +251,21 @@ func (a *App) buildFetch(sess storage.Session) monitor.FetchFunc {
 	// window closed, and the scheduler could only check for a stop between
 	// OIDs, so it could not be interrupted.
 	return func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
+		// A session cannot poll without a client, and reaching through a nil one
+		// panics inside newGoSNMP — on the poll goroutine, which used to end the
+		// process. Reported as a failed reading per pair instead, which is the
+		// shape every other failure on this path takes.
+		if a.snmpClient == nil {
+			readings := make([]monitor.Reading, 0, len(targets)*len(oids))
+			for _, t := range targets {
+				for _, oid := range oids {
+					readings = append(readings, monitor.Reading{
+						Target: t, OID: oid, Error: "no SNMP client",
+					})
+				}
+			}
+			return readings
+		}
 		// The poll's context reaches the wire. Chunking is serial within a
 		// target, so without it a stop waited for every remaining chunk's
 		// timeout — measured at 12.0 s for 90 OIDs against a silent device.

--- a/app_presetbind_test.go
+++ b/app_presetbind_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 	"SnmpLens/pkg/monitor"
 	"SnmpLens/pkg/secrets"
+	"SnmpLens/pkg/snmp"
 	"SnmpLens/pkg/storage"
 )
 
@@ -34,6 +36,12 @@ func newBindApp(t *testing.T) (*App, string) {
 	}
 
 	a := &App{storage: st, secrets: sec, persistentMibDir: mibDir}
+	// A real client, because PresetBind STARTS the session: without one the
+	// poll goroutine dereferenced nil inside newGoSNMP and killed the test
+	// binary — on macOS only, because the other platforms finished before the
+	// first tick landed. The targets below are addresses nothing answers on, so
+	// no packet ever reaches anything.
+	a.snmpClient = snmp.NewClient(context.Background())
 	a.scheduler = monitor.NewScheduler()
 	// The clock must not actually reach a network in a unit test, and Persist
 	// is required by the scheduler.

--- a/pkg/monitor/overrun_test.go
+++ b/pkg/monitor/overrun_test.go
@@ -2,6 +2,7 @@ package monitor
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -367,5 +368,65 @@ func TestAcceptSlowRestoresTheCadenceOfARunningSession(t *testing.T) {
 	// Back to running flat out, which is what accepting the slowdown means.
 	if gap := after[1].Sub(after[0]); gap > round+120*time.Millisecond {
 		t.Errorf("gap after accepting is %v; the cadence was not restored", gap.Round(time.Millisecond))
+	}
+}
+
+// A poll round must not be able to end the process.
+//
+// The round runs on its own goroutine and calls out to four callbacks the
+// scheduler did not write — Fetch, Persist, Evaluate, Emit. An unrecovered
+// panic in any of them does not end the session: it ends the PROCESS, taking
+// every other session, the trap listener and the notification outbox with it.
+//
+// Found for real: a session started with no SNMP client dereferenced nil inside
+// newGoSNMP, on the poll goroutine, and killed the test binary — on macOS only,
+// because the other two platforms finished before the first tick landed.
+func TestAPanicInAPollDoesNotEndTheProcess(t *testing.T) {
+	var mu sync.Mutex
+	rounds := 0
+	var reported []string
+
+	s := NewScheduler()
+	s.Persist = func([]Point) {}
+	s.OnPanic = func(sessionID, name, recovered, stack string) {
+		mu.Lock()
+		reported = append(reported, sessionID+": "+recovered)
+		mu.Unlock()
+	}
+
+	s.Start(SessionSpec{
+		ID: "explodes", Name: "boom", OIDs: []string{"1.1"}, Targets: []string{"a"},
+		Interval: minInterval,
+		Fetch: func(_ context.Context, oids, targets []string) []Reading {
+			mu.Lock()
+			rounds++
+			n := rounds
+			mu.Unlock()
+			if n == 1 {
+				var nilMap map[string]int
+				//lint:ignore SA5000 the panic is the subject of this test
+				nilMap["boom"] = 1
+			}
+			v := 1.0
+			return []Reading{{Target: targets[0], OID: oids[0], Value: &v, SnmpType: "Counter32"}}
+		},
+	})
+
+	time.Sleep(minInterval*3 + 400*time.Millisecond)
+	s.StopAll()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(reported) == 0 {
+		t.Fatal("the panic was swallowed with nothing said about it")
+	}
+	if !strings.Contains(reported[0], "explodes") {
+		t.Errorf("the report does not name the session: %q", reported[0])
+	}
+
+	// Recovered per ROUND, not per session: the next tick must still poll, or a
+	// single transient panic stops a monitoring for good and silently.
+	if rounds < 2 {
+		t.Errorf("%d round(s); the session stopped polling after the panic", rounds)
 	}
 }

--- a/pkg/monitor/scheduler.go
+++ b/pkg/monitor/scheduler.go
@@ -2,6 +2,9 @@ package monitor
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"runtime/debug"
 	"sync"
 	"time"
 )
@@ -91,6 +94,10 @@ type Scheduler struct {
 	Emit func(sessionID string, points []Point)
 	// OnStateChange fires when a session starts or stops, for the tray read-out.
 	OnStateChange func()
+	// OnPanic reports a poll round that panicked, after the loop has recovered
+	// from it. Optional: with nothing wired the panic is still contained and
+	// still logged, and only the journal entry is missing.
+	OnPanic func(sessionID, name string, recovered string, stack string)
 	// OnOverrun reports that a session cannot poll as fast as it promised, and
 	// what the scheduler did about it. Edge-triggered: once when a session
 	// stops keeping up, once when it starts again. Called on the poll
@@ -234,7 +241,7 @@ func (s *Scheduler) loop(ctx context.Context, h *handle, spec SessionSpec) {
 		case <-timer.C:
 		}
 	}
-	report(guard.observe(s.tick(ctx, spec, last)))
+	report(guard.observe(s.safeTick(ctx, spec, last)))
 	recadence()
 
 	for {
@@ -252,10 +259,39 @@ func (s *Scheduler) loop(ctx context.Context, h *handle, spec SessionSpec) {
 			// pile up overlapping rounds against itself — and that coalescing
 			// is exactly why the guardrail is needed: the loop stops being
 			// idle and nothing about it looks wrong.
-			report(guard.observe(s.tick(ctx, spec, last)))
+			report(guard.observe(s.safeTick(ctx, spec, last)))
 			recadence()
 		}
 	}
+}
+
+// safeTick is tick, with the process's life not depending on it.
+//
+// A poll round runs on its own goroutine and calls out to a Fetch the scheduler
+// did not write, then to Persist, Evaluate and Emit — four callbacks, each of
+// which is somebody else's code. An unrecovered panic in any of them does not
+// end the session: it ends the PROCESS, taking every other session, the trap
+// listener and the notification outbox with it. pkg/notify recovers around
+// each delivery for exactly this reason, and this loop has the same shape.
+//
+// Recovered per ROUND rather than per session, so a session that panics once —
+// a nil map from a half-configured target, say — keeps polling on the next
+// tick instead of stopping silently.
+func (s *Scheduler) safeTick(ctx context.Context, spec SessionSpec, last map[string]lastSample) (stat cycleStat) {
+	defer func() {
+		if r := recover(); r != nil {
+			trace := string(debug.Stack())
+			log.Printf("monitor: session %s panicked during a poll and was recovered: %v; %s",
+				spec.ID, r, trace)
+			if s.OnPanic != nil {
+				s.OnPanic(spec.ID, spec.Name, fmt.Sprint(r), trace)
+			}
+			// A round that panicked measured nothing, so the guardrail must not
+			// read it as a fast cycle and conclude the session is keeping up.
+			stat = cycleStat{}
+		}
+	}()
+	return s.tick(ctx, spec, last)
 }
 
 // tick runs one poll round and returns what it cost.


### PR DESCRIPTION
A nil pointer inside `newGoSNMP`, on the poll goroutine, **killed the test binary on macOS** — and only on macOS, because Windows and Linux finished before the first tick landed. CI runs all three for exactly this class.

## Two defects, and the smaller one is the one that was found

`buildFetch` dereferenced `a.snmpClient` without checking. Reaching through a nil one panics inside `newGoSNMP`; it now reports a failed reading per (target, OID) pair, which is the shape every other failure on this path takes.

**The larger one is that the panic was fatal at all.** A poll round runs on its own goroutine and calls out to four callbacks the scheduler did not write — `Fetch`, `Persist`, `Evaluate`, `Emit`. An unrecovered panic in any of them does not end the session: it ends the **process**, taking every other session, the trap listener and the notification outbox with it. `pkg/notify` recovers around each delivery for precisely this reason and says so; this loop has the same shape and did not.

Recovered per **round** rather than per session, so a session that panics once polls again on the next tick instead of stopping for good and silently. A round that panicked reports a **zero** cycle, so the overrun guardrail cannot read it as a fast round and conclude the session is keeping up.

And it is **journalled**, as a major system event with the stack as its payload. A recovered panic nobody records is a session quietly returning nothing, which reads as a device that stopped answering — the one explanation that is wrong.

## Checks

`go vet`, `staticcheck`, `go test -count=1 ./...`. One new test: a `Fetch` that panics on its first round only, then a check that the session is still polling afterwards and that the panic was reported with the session named.