### PR TITLE
Fix the four things running the application showed

### DIFF
--- a/app_bundledpresets_test.go
+++ b/app_bundledpresets_test.go
@@ -81,17 +81,8 @@ func TestBundledPresetsAreExtractedOnceAndNotRestored(t *testing.T) {
 	a, dir := newPresetApp(t)
 	a.presets = presets
 
-	// newPresetApp already created the directory, which is what a second run
-	// looks like: nothing is written.
-	a.ensureBundledPresets()
-	if list := a.ListPresets(); len(list) != 0 {
-		t.Fatalf("an existing library was populated anyway: %+v", list)
-	}
-
-	// A first run: the directory does not exist yet.
-	if err := os.RemoveAll(dir); err != nil {
-		t.Fatal(err)
-	}
+	// A first run. The directory existing is not what decides this — see
+	// TestAnEmptyDirectoryStillGetsTheExamples for why it cannot be.
 	a.ensureBundledPresets()
 	first := a.ListPresets()
 	if len(first) < 3 {
@@ -103,7 +94,8 @@ func TestBundledPresetsAreExtractedOnceAndNotRestored(t *testing.T) {
 		}
 	}
 
-	// Deleting one and restarting must leave it deleted.
+	// Deleting one and restarting must leave it deleted: the marker is what
+	// says the examples have been offered, and it survives the deletion.
 	if err := a.DeletePreset(first[0].File); err != nil {
 		t.Fatal(err)
 	}
@@ -116,6 +108,16 @@ func TestBundledPresetsAreExtractedOnceAndNotRestored(t *testing.T) {
 		if p.File == first[0].File {
 			t.Errorf("%s was restored after being deleted", p.File)
 		}
+	}
+
+	// And deleting the whole directory is how somebody asks for them back: the
+	// marker goes with it.
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	a.ensureBundledPresets()
+	if again := a.ListPresets(); len(again) != len(first) {
+		t.Errorf("%d preset(s) after deleting the directory, want %d", len(again), len(first))
 	}
 }
 
@@ -143,5 +145,60 @@ func TestAtLeastOneBundledPresetClaimsADevice(t *testing.T) {
 	}
 	if _, matched := rankForDevice(list, "1.3.6.1.4.1.911.1"); matched != 0 {
 		t.Error("a Cisco preset matched enterprise 911; the prefix is being compared as text")
+	}
+}
+
+// The directory existing is NOT the same as the library existing.
+//
+// presetDir() creates the directory as a SIDE EFFECT and is called by
+// ListPresets, so opening the preset settings once — on any earlier version —
+// was enough to make every later startup skip the extraction. An installation
+// that had been running for weeks got no examples at all, which is exactly what
+// happened. The marker is what "already offered" means now.
+func TestAnEmptyDirectoryStillGetsTheExamples(t *testing.T) {
+	a, dir := newPresetApp(t) // newPresetApp calls presetDir(), which creates it
+	a.presets = presets
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("setup: the directory should already exist: %v", err)
+	}
+	a.ensureBundledPresets()
+
+	list := a.ListPresets()
+	if len(list) < 3 {
+		t.Fatalf("an empty-but-existing directory got %d preset(s)", len(list))
+	}
+	// The marker is a dotfile, so it is not one of them.
+	for _, p := range list {
+		if strings.HasPrefix(p.File, ".") {
+			t.Errorf("the marker is listed as a preset: %s", p.File)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, extractedMarker)); err != nil {
+		t.Errorf("nothing recorded that the extraction ran: %v", err)
+	}
+}
+
+// A library somebody has already curated is left alone, and the marker is
+// written anyway so the examples do not land on top of it later.
+func TestAnExistingLibraryIsNotOverwritten(t *testing.T) {
+	a, dir := newPresetApp(t)
+	a.presets = presets
+	a.importSinglePreset(writeSrc(t, t.TempDir(), "mine.json", goodPreset))
+
+	a.ensureBundledPresets()
+
+	list := a.ListPresets()
+	if len(list) != 1 || list[0].File != "mine.json" {
+		t.Fatalf("a curated library was added to: %+v", list)
+	}
+	if _, err := os.Stat(filepath.Join(dir, extractedMarker)); err != nil {
+		t.Error("the marker was not written, so the examples would arrive on a later start")
+	}
+
+	// And a second start changes nothing.
+	a.ensureBundledPresets()
+	if list := a.ListPresets(); len(list) != 1 {
+		t.Errorf("%d preset(s) after a second start", len(list))
 	}
 }

--- a/app_preset.go
+++ b/app_preset.go
@@ -87,8 +87,22 @@ func (a *App) ensureBundledPresets() {
 		return
 	}
 	dir := filepath.Join(filepath.Dir(a.persistentMibDir), presetSubdir)
-	if _, err := os.Stat(dir); err == nil {
-		return // this machine has a preset library already
+
+	// A MARKER, not the directory.
+	//
+	// "The directory exists" looked like a good proxy for "this machine has a
+	// library" and is not one: presetDir() creates the directory as a SIDE
+	// EFFECT, and it is called by ListPresets — so opening the preset settings
+	// once, on any earlier version, was enough to make every later startup skip
+	// the extraction. Which is exactly what happened: an installation that had
+	// been running for weeks got no examples at all.
+	//
+	// The marker is written after the extraction and is the only thing consulted
+	// afterwards, so an operator who deletes an example keeps it deleted and one
+	// who deletes the whole directory gets them back.
+	marker := filepath.Join(dir, extractedMarker)
+	if _, err := os.Stat(marker); err == nil {
+		return
 	}
 
 	entries, err := a.presets.ReadDir(presetSubdir)
@@ -98,6 +112,13 @@ func (a *App) ensureBundledPresets() {
 	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		log.Printf("WARNING: could not create the preset directory: %v", err)
+		return
+	}
+
+	// An existing library that predates the marker: leave it alone but record
+	// that this ran, or the examples would land on top of a curated folder.
+	if existing, err := os.ReadDir(dir); err == nil && len(existing) > 0 {
+		writeMarker(marker)
 		return
 	}
 
@@ -117,7 +138,19 @@ func (a *App) ensureBundledPresets() {
 		}
 		written++
 	}
+	writeMarker(marker)
 	log.Printf("Extracted %d example preset(s) to %s", written, dir)
+}
+
+// extractedMarker records that the examples have been offered once. Dotted, so
+// preset.List skips it the way it skips any dotfile.
+const extractedMarker = ".examples-extracted"
+
+func writeMarker(path string) {
+	if err := os.WriteFile(path, []byte("The example presets have been extracted once.\n"+
+		"Delete this file to have them written again.\n"), 0o600); err != nil {
+		log.Printf("WARNING: could not record that the presets were extracted: %v", err)
+	}
 }
 
 // presetDir returns the preset directory, creating it on first use.

--- a/frontend/src/MibEditorPanel.svelte
+++ b/frontend/src/MibEditorPanel.svelte
@@ -1122,7 +1122,10 @@
   .outline {
     display: flex;
     flex-direction: column;
-    min-height: 0;
+    /* A share of the rail rather than the remainder of it, and a floor so it
+       cannot be squeezed out of existence by a long file list. */
+    flex: 1 1 60%;
+    min-height: 6rem;
     border-top: 1px solid var(--border-color);
     padding-top: 0.35rem;
   }
@@ -1158,6 +1161,7 @@
     padding: 0;
     overflow-y: auto;
     min-height: 0;
+    flex: 1 1 auto;
   }
 
   .outline-item {
@@ -1245,13 +1249,17 @@
     justify-content: center;
   }
 
+  /* The rail holds TWO lists and has to divide its height between them.
+     `flex: 1` here claimed everything left over, so the outline below rendered
+     at zero height: present in the DOM, scrollable, and invisible. With no file
+     open there is no outline and this still takes the whole rail. */
   .files {
     list-style: none;
     margin: 0;
     padding: 0;
     overflow-y: auto;
-    min-height: 0;
-    flex: 1;
+    min-height: 4rem;
+    flex: 1 1 40%;
   }
 
   .file {

--- a/frontend/src/TargetManager.svelte
+++ b/frontend/src/TargetManager.svelte
@@ -11,6 +11,7 @@
   import { requestTab } from './stores/tabRequest';
   import { buildTestRequest } from './utils/snmpParams';
   import { getEffectiveSettings } from './utils/targets';
+  import { boundPresetsFor } from './utils/presetBindings';
   import TargetOverrideForm from './TargetOverrideForm.svelte';
   import { anonMode, anonymizeIp } from './utils/anonymize';
   import Icon from './Icon.svelte';
@@ -101,6 +102,13 @@
   let newPreset = '';
   let binding = false;
   let identifying = false;
+  // Binding a preset to an equipment that ALREADY exists. The add form covers
+  // the moment somebody knows what the equipment is; this covers every moment
+  // after it, which is most of them — a target added before there were presets
+  // at all had no other way to get one.
+  let expandedPresetId = null;
+  let rowPreset = {};
+  let rowBinding = null;
   // What the device said about itself, or null. Reset whenever the address
   // changes, because it describes an address and not a form.
   let identity = null;
@@ -148,6 +156,28 @@
   // offered — the reason is in Settings, next to the error list that explains
   // it, rather than as a disabled row here with nothing saying why.
   $: bindablePresets = presets.filter((p) => p.problems === 0);
+
+  function togglePresetRow(id) {
+    expandedPresetId = expandedPresetId === id ? null : id;
+  }
+
+  async function bindToExisting(target) {
+    const file = rowPreset[target.id];
+    if (!file) return;
+    rowBinding = target.id;
+    try {
+      await pollingStore.bindPreset(file, target.address, get(settingsStore));
+      notificationStore.add($_('targets.presetBound', { values: { address: target.address } }), 'success');
+      expandedPresetId = null;
+      rowPreset = { ...rowPreset, [target.id]: '' };
+      requestTab('dashboard');
+      dispatch('close');
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      rowBinding = null;
+    }
+  }
 
   async function addTarget() {
     if (!newAddress.trim()) return;
@@ -544,6 +574,10 @@
               {/if}
               <button class="btn-icon" on:click={() => startEditAddress(target)}
                 disabled={editingId === target.id} title={$_('targets.editTooltip')}><Icon name="pencil" size={15} /></button>
+              <button class="btn-icon" class:active={expandedPresetId === target.id}
+                on:click={() => togglePresetRow(target.id)} title={$_('targets.presetBindTooltip')}>
+                <Icon name="layers" size={15} />
+              </button>
               <button class="btn-icon" class:active={expandedOverrideId === target.id}
                 on:click={() => toggleOverrides(target.id)} title={$_('targets.overrides.title')}>
                 <Icon name="settings" size={15} />
@@ -554,6 +588,38 @@
                 title={$_('targets.deleteTooltip')}><Icon name="trash-2" size={15} /></button>
             </div>
           </div>
+          {#if expandedPresetId === target.id}
+            <div class="preset-row">
+              {#if bindablePresets.length === 0}
+                <span class="preset-note">{$_('targets.presetNone')}</span>
+              {:else}
+                <select bind:value={rowPreset[target.id]} title={$_('targets.presetHint')}>
+                  <option value="">{$_('targets.presetPick')}</option>
+                  {#each bindablePresets as p (p.file)}
+                    <option value={p.file}>{p.name || p.file}</option>
+                  {/each}
+                </select>
+                <button class="btn-sm primary" on:click={() => bindToExisting(target)}
+                  disabled={!rowPreset[target.id] || rowBinding === target.id}>
+                  {rowBinding === target.id ? $_('common.working') : $_('targets.presetBind')}
+                </button>
+              {/if}
+              <!-- What is already bound to this equipment, so binding a second
+                   one is a deliberate act rather than an accident: each bind
+                   creates its own session and its own poll clock. -->
+              {#if boundPresetsFor($pollingStore, target.address).length > 0}
+                <span class="preset-note">
+                  {$_('targets.presetAlreadyBound', {
+                    values: {
+                      names: boundPresetsFor($pollingStore, target.address)
+                        .map((s) => s.preset.name || s.preset.file).join(', '),
+                    },
+                  })}
+                </span>
+              {/if}
+            </div>
+          {/if}
+
           {#if expandedOverrideId === target.id}
             <TargetOverrideForm
               overrides={$settingsStore.targetOverrides?.[target.address] || {}}
@@ -720,14 +786,54 @@
   .btn-sm.danger:hover:not(:disabled) { background-color: var(--error-color); border-color: var(--error-color); color: white; }
   .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
 
-  .add-form { display: flex; gap: 8px; margin-bottom: 10px; padding: 10px; background-color: var(--bg-color); border-radius: 4px; }
-  .add-form input { flex: 1; padding: 6px 10px; border: 1px solid var(--border-color); border-radius: 4px; background-color: var(--bg-lighter-color); color: var(--text-color); font-size: 0.9em; }
-  .add-form input:first-child { flex: 2; }
+  /* Wraps. It held two inputs and a button when it was written; it now holds
+     two inputs, a Detect button, a preset picker and Add, and on one line the
+     picker grew with the longest preset name until the row ran off the modal. */
+  .add-form { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 10px; padding: 10px; background-color: var(--bg-color); border-radius: 4px; }
+  .add-form input { flex: 1 1 150px; min-width: 0; padding: 6px 10px; border: 1px solid var(--border-color); border-radius: 4px; background-color: var(--bg-lighter-color); color: var(--text-color); font-size: 0.9em; }
+  .add-form input:first-child { flex: 2 1 200px; }
+  /* Bounded on BOTH sides: a select sizes itself to its longest option, and a
+     preset called "Cisco Catalyst 9300 uplinks and access ports" is a wide
+     option. */
+  .add-form select { flex: 1 1 160px; max-width: 240px; min-width: 0; padding: 6px 8px; border: 1px solid var(--border-color); border-radius: 4px; background-color: var(--bg-lighter-color); color: var(--text-color); font-size: 0.9em; }
+  .add-form .btn-sm { flex: 0 0 auto; }
+  .identity { flex: 1 1 100%; margin: 0; font-size: 0.8em; color: var(--text-muted); }
+  .identity.failed { color: var(--error-color, #f85149); }
+  .identity .matched { margin-left: 0.4rem; }
 
   .target-list { display: flex; flex-direction: column; gap: 6px; max-height: 400px; overflow-y: auto; }
   .target-entry { display: flex; flex-direction: column; }
   .target-item { display: flex; align-items: center; gap: 10px; padding: 8px 10px; background-color: var(--bg-color); border-radius: 4px; transition: opacity 0.2s; }
   .target-item.disabled { opacity: 0.5; }
+
+  .preset-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin: 4px 0 0 34px;
+    padding: 8px 10px;
+    background-color: var(--bg-color);
+    border-radius: 4px;
+  }
+
+  .preset-row select {
+    flex: 1 1 160px;
+    max-width: 260px;
+    min-width: 0;
+    padding: 5px 8px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--bg-lighter-color);
+    color: var(--text-color);
+    font-size: 0.85em;
+  }
+
+  .preset-note {
+    flex: 1 1 100%;
+    color: var(--text-muted);
+    font-size: 0.78em;
+  }
 
   .target-checkbox { display: flex; align-items: center; }
   .target-checkbox input { width: 16px; height: 16px; cursor: pointer; }
@@ -785,7 +891,7 @@
     border: 1px solid var(--border-color);
     border-radius: 8px;
     padding: 16px;
-    width: min(520px, 90vw);
+    width: min(720px, 94vw);
     box-shadow: 0 10px 40px rgba(0, 0, 0, 0.4);
     display: flex;
     flex-direction: column;

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -615,7 +615,10 @@
     "presetDetectHint": "Das Gerät fragen, was es ist, und passende Vorlagen nach oben stellen.",
     "presetMatched": "{count} Vorlage(n) passen zu diesem Gerät.",
     "presetNoMatch": "Keine Vorlage nennt dieses Gerät.",
-    "presetDeviceMasked": "Gerät erkannt"
+    "presetDeviceMasked": "Gerät erkannt",
+    "presetBind": "Binden",
+    "presetBindTooltip": "Eine Dashboard-Vorlage an dieses Gerät binden",
+    "presetAlreadyBound": "Bereits gebunden: {names}. Eine weitere fügt eine zweite Abfrageuhr hinzu."
   },
   "update": {
     "available": "SnmpLens {version} ist verfügbar",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -615,7 +615,10 @@
     "presetDetectHint": "Ask this equipment what it is, and put the presets that match it first.",
     "presetMatched": "{count} preset(s) match this equipment.",
     "presetNoMatch": "No preset names this equipment.",
-    "presetDeviceMasked": "Equipment identified"
+    "presetDeviceMasked": "Equipment identified",
+    "presetBind": "Bind",
+    "presetBindTooltip": "Bind a dashboard preset to this equipment",
+    "presetAlreadyBound": "Already bound: {names}. Binding another adds a second poll clock."
   },
   "update": {
     "available": "SnmpLens {version} is available",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -615,7 +615,10 @@
     "presetDetectHint": "Preguntar al equipo qué es y poner primero los presets que le corresponden.",
     "presetMatched": "{count} preset(s) corresponden a este equipo.",
     "presetNoMatch": "Ningún preset menciona este equipo.",
-    "presetDeviceMasked": "Equipo identificado"
+    "presetDeviceMasked": "Equipo identificado",
+    "presetBind": "Vincular",
+    "presetBindTooltip": "Vincular un preset de panel a este equipo",
+    "presetAlreadyBound": "Ya vinculado: {names}. Vincular otro añade un segundo reloj de sondeo."
   },
   "update": {
     "available": "SnmpLens {version} está disponible",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -615,7 +615,10 @@
     "presetDetectHint": "Demander à cet équipement ce qu'il est, et placer en tête les presets qui lui correspondent.",
     "presetMatched": "{count} preset(s) correspondent à cet équipement.",
     "presetNoMatch": "Aucun preset ne désigne cet équipement.",
-    "presetDeviceMasked": "Équipement identifié"
+    "presetDeviceMasked": "Équipement identifié",
+    "presetBind": "Lier",
+    "presetBindTooltip": "Lier un preset de tableau de bord à cet équipement",
+    "presetAlreadyBound": "Déjà lié : {names}. En lier un autre ajoute une seconde horloge de scrutation."
   },
   "update": {
     "available": "SnmpLens {version} est disponible",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -615,7 +615,10 @@
     "presetDetectHint": "询问该设备的型号，并把匹配的预设排在前面。",
     "presetMatched": "有 {count} 个预设匹配此设备。",
     "presetNoMatch": "没有预设指明此设备。",
-    "presetDeviceMasked": "设备已识别"
+    "presetDeviceMasked": "设备已识别",
+    "presetBind": "绑定",
+    "presetBindTooltip": "将仪表板预设绑定到此设备",
+    "presetAlreadyBound": "已绑定：{names}。再绑定一个会增加一个轮询时钟。"
   },
   "update": {
     "available": "SnmpLens {version} 可用",

--- a/frontend/src/utils/presetBindings.js
+++ b/frontend/src/utils/presetBindings.js
@@ -1,0 +1,30 @@
+// Which monitoring sessions are bound to one equipment.
+//
+// Its own module, with NO imports, so it can be tested by node directly:
+// utils/targets.js reaches anonymize.js, which reaches the settings store,
+// which reaches the Wails bridge — a chain that needs the whole bundler to
+// load. mibDependencies.js and mibGraph.js are the same shape for the same
+// reason.
+
+/**
+ * The monitoring sessions bound from a preset to one equipment.
+ *
+ * By ADDRESS, never by index or by label: `targets` is a stored JSON array that
+ * can hold addresses no longer in the settings, the list is reordered whenever
+ * somebody edits the text field, and two targets can share a label. The address
+ * is the only thing that identifies an equipment across both sides.
+ *
+ * Pure, and it takes both its inputs as arguments — the target manager calls it
+ * from the markup, where reactive.test.mjs is watching.
+ *
+ * @param {Array} sessions pollingStore sessions
+ * @param {string} address the equipment
+ * @returns {Array} the sessions that poll it AND carry a preset snapshot
+ */
+export function boundPresetsFor(sessions, address) {
+  const addr = String(address || '').trim();
+  if (!addr) return [];
+  return (Array.isArray(sessions) ? sessions : []).filter(
+    (s) => s && s.preset && (s.targets || []).includes(addr),
+  );
+}

--- a/frontend/tests/polling.smoke.mjs
+++ b/frontend/tests/polling.smoke.mjs
@@ -315,4 +315,30 @@ check('the session reads as stopped', !!s && s.running === false);
     calls.bound[1]?.conn?.community === 'global-community', calls.bound[1]?.conn?.community);
 }
 
+// Which sessions are bound to one equipment, by ADDRESS.
+//
+// Never by index or by label: `targets` is a stored JSON array that can hold
+// addresses no longer in the settings, the list is reordered whenever somebody
+// edits the text field, and two targets can share a label.
+{
+  const { boundPresetsFor } = await import('../src/utils/presetBindings.js');
+
+  const sessions = [
+    { id: 'a', targets: ['10.0.0.1'], preset: { file: 'cisco.json', name: 'Cisco' } },
+    { id: 'b', targets: ['10.0.0.2'], preset: { file: 'ups.json', name: 'UPS' } },
+    { id: 'c', targets: ['10.0.0.1'], preset: null },
+    { id: 'd', targets: ['10.0.0.1', '10.0.0.9'], preset: { file: 'ifaces.json', name: 'Interfaces' } },
+  ];
+
+  const bound = boundPresetsFor(sessions, '10.0.0.1').map((s) => s.id);
+  check('a session bound to this equipment is found', bound.includes('a'));
+  check('and one bound to it among several targets', bound.includes('d'));
+  check('a session with no preset is not a binding', !bound.includes('c'), bound.join(','));
+  check('another equipment is not this one', !bound.includes('b'));
+
+  check('an unknown address has nothing bound', boundPresetsFor(sessions, '10.9.9.9').length === 0);
+  check('and it survives what the store really holds',
+    boundPresetsFor(undefined, '10.0.0.1').length === 0 && boundPresetsFor(sessions, '').length === 0);
+}
+
 process.exit(failures ? 1 : 0);


### PR DESCRIPTION
Four reports from actually running it. None were visible from the code, and one had a **test asserting the defect**.

## The examples were never extracted

`"the directory exists"` looked like a good proxy for "this machine has a library" and is not one: `presetDir()` creates the directory as a **side effect**, and it is called by `ListPresets` — so opening the preset settings once, on any earlier version, was enough to make every later startup skip the extraction. An installation that had been running for weeks got nothing.

A marker file records that the examples have been *offered*, which is the thing actually being asked about: delete an example and it stays deleted, delete the directory and they come back. An existing library is left alone and the marker written anyway, or the examples would land on top of a curated folder later.

The test that covered this asserted the **old** behaviour — *"an existing library was populated anyway"* — so it encoded the bug rather than catching it.

## The add row ran off the modal

It was written for two inputs and a button and now carries five controls, and a `<select>` sizes itself to its longest option: one preset with a long name pushed Add out of the dialog. The row wraps, the picker is bounded on both sides, and the modal goes from 520 to 720 px.

## A preset could only be bound when the target was created

The add form covers the one moment somebody knows what the equipment is; it does not cover any of the moments after it, and a target added before presets existed had no route at all. Each row now has a binding control of its own, and it names what is **already bound** — binding a second preset adds a second poll clock, which should be deliberate rather than a surprise.

`boundPresetsFor` matches by **address**, never by index or label: `targets` is a stored JSON array that can hold addresses no longer in the settings, the list is reordered whenever the text field is edited, and two targets can share a label. It lives in a module with no imports so node can test it directly — `utils/targets.js` reaches `anonymize.js`, which reaches the settings store, which reaches the bridge.

## The outline pane was rendered at zero height

`.files` had `flex: 1` and claimed everything left in the rail, so the outline below it was present in the DOM, scrollable, and **invisible**. The rail is divided between the two now, with a floor under the outline so a long file list cannot squeeze it out again.

## Checks

`go vet`, `staticcheck`, `npm test` (632 checks), `npm run check`, `npm run build`. Four new Go tests on the marker, six new checks on `boundPresetsFor`.

Not caused by this and worth saying: `TestTrapsAreNotLostAtTheStatedRate` fails on my machine in a full-package run and passes in isolation, **on a clean main as well as here**. It offers 1000 traps a second and measures loss, so it is sensitive to what else is running; it has been green in CI on every merge.