### PR TITLE
Analyse a MIB when it opens, so the outline is not empty

### DIFF
--- a/frontend/src/stores/mibEditorStore.js
+++ b/frontend/src/stores/mibEditorStore.js
@@ -93,7 +93,15 @@ function createMibEditorStore() {
       buffer: recovered ? draft : source.content,
       diagnostics: source.diagnostics || [],
     });
-    if (recovered) refresh();
+    // ALWAYS, not only for a recovered draft.
+    //
+    // Diagnostics arrive with the file because MibEditorRead computes them at
+    // read time; the OUTLINE has no such source — refresh() is the only thing
+    // that fills it. So opening a MIB showed an outline reading "nothing
+    // defined yet" over a file defining forty things, until the first
+    // keystroke happened to trigger an analysis. The panel was right and the
+    // data never came.
+    refresh();
     return { source, recovered };
   }
 
@@ -110,6 +118,9 @@ function createMibEditorStore() {
     openToken++;
     clearTimeout(draftTimer);
     set({ ...EMPTY, source, buffer: source.content, diagnostics: source.diagnostics || [] });
+    // Same reason as in open(): a restored bundled MIB and a file opened from
+    // outside the directory both need their outline computed.
+    refresh();
     discardDraft(draftKey(source));
   }
 

--- a/frontend/tests/mibeditor.store.test.mjs
+++ b/frontend/tests/mibeditor.store.test.mjs
@@ -77,6 +77,11 @@ const check = (name, ok, extra = '') => {
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
 await mibEditorStore.open('A-MIB');
+// open() ANALYSES now, so the analysis it dispatched has to be answered before
+// anything below measures `checking`: an unresolved one keeps inFlight above
+// zero for the rest of the file, and the indicator never clears.
+for (const p of pending.splice(0)) p.resolve({ diagnostics: [], missing: [], outline: [] });
+await tick();
 pending = [];
 calls.length = 0;
 
@@ -317,6 +322,32 @@ check('a pending draft is not written under the newly opened file',
   check('the external file gets a key of its own', keys.length === 2, JSON.stringify(keys));
   check('and it is not the bare name', keys.filter((k) => k === 'L-MIB').length === 1,
     JSON.stringify(keys));
+}
+
+// Opening a file must ANALYSE it, or the outline stays empty until somebody
+// types.
+//
+// Diagnostics arrive with the file — MibEditorRead computes them at read time —
+// so the panel looked alive while the outline read "nothing defined yet" over a
+// MIB defining forty things. refresh() is the only thing that fills it, and it
+// used to run on open only when a draft had been recovered.
+{
+  pending = [];
+  calls.length = 0;
+  await mibEditorStore.open('N-MIB');
+  await tick();
+
+  check('opening a file dispatches an analysis', pending.length === 1,
+    `${pending.length} dispatched`);
+
+  pending[0].resolve({
+    diagnostics: [],
+    missing: [],
+    outline: [{ name: 'nUptime', kind: 'object', line: 12, column: 1, syntax: 'Counter32' }],
+  });
+  await tick();
+  check('so the outline is there before the first keystroke',
+    get(mibEditorStore).outline?.length === 1, JSON.stringify(get(mibEditorStore).outline));
 }
 
 // The outline rides on the analysis, and it must not outlive the file it


### PR DESCRIPTION
Reported from the running application: the outline panel showed **"nothing defined yet"** over `SNMPv2-SMI`, a file that defines about forty things.

The panel was right and the data never came.

Diagnostics arrive **with the file** — `MibEditorRead` computes them at read time and `open()` copies them straight into the store — so the pane looked alive. The outline has no such source: `refresh()` is the only thing that fills it, and it ran on open **only when a draft had been recovered**. Every ordinary open left the outline empty until the first keystroke happened to schedule an analysis.

`openSource` had it worse: restoring a bundled MIB, or opening a file from outside the directory, never analysed at all.

Both call `refresh()` now. It costs one analysis per open — the one the first keystroke would have triggered anyway — and it is the same call that already keeps the outline honest while typing, so there is no second path to keep in step.

## One existing check had to be corrected rather than kept

`"checking is cleared when the answer lands"`. The fixture opened a file and then **discarded the pending analysis without answering it**, which was harmless while `open()` never dispatched one. Now it leaves `inFlight` above zero for the rest of the file and the indicator can never clear — so the fixture answers the open's analysis before measuring anything that depends on it.

## Checks

`npm test` (657 checks), `npm run check`, `npm run build`. Two new checks: opening a file dispatches an analysis, and the outline is populated before any keystroke.