### PR TITLE
Discover a preset's instances instead of guessing them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -548,7 +548,8 @@ gosmi lock to validate a FILE, and would make what a preset polls depend on whic
 **There is no `table` kind, and that is a correction rather than a gap.** A conceptual table is a WALK, and the
 poll path a preset feeds is GET-only — `PollOIDs` → `snmp.GetMany` → `g.Get`, and a table's OID GET'd answers
 `noSuchObject`. `grid` is what that want reduces to here: one widget, one cell per OID, one label map — a
-switch's port panel, with the instances named explicitly, which is also what keeps the cost knowable.
+switch's port panel. Which instances it has is settled BEFORE the first poll, by hand or by one walk at bind
+time (see **Discovery** below), and that is what keeps the poll path GET-only and the cost knowable.
 
 **The cost is stated over a DAY.** `MaxIntervalSec` is 86400, so an hourly base is integer-divided to zero for
 every cadence past 3600 s — a third of the legal range reported "0 requests, 0 varbinds" on the one screen whose
@@ -577,6 +578,46 @@ library is for, and you cannot fix a file you were not allowed to keep. What it 
 as its screenshot fixture and everything else `null`, and `null` throws on the first `.map` in a generated file
 nobody reads. For the same class of reason `Validate` returning `nil` on success is normalised to `[]` before it
 crosses — otherwise the VALID path is the one that breaks.
+
+### Discovery, and why the walk happens exactly once
+
+The five presets that shipped first enumerated `…2.2.1.8.1` through `.24` BY HAND, and their descriptions said
+"edit the instance numbers if yours does not index from 1". That is an admission rather than a note: a preset
+written for a 24-port switch is a preset for exactly one shape of switch, and a library of those is not
+shareable. So a widget may say WHERE its instances come from instead of listing them — `"discover": {"walk":
+"1.3.6.1.2.1.2.2.1.2"}` — with `{#}` in its OIDs where the instance goes (`preset.InstancePlaceholder`).
+
+**The walk happens at BIND TIME and nowhere else** (`app_preset.go`, `discoverFor`). What is stored afterwards is
+a plain preset with concrete OIDs, so the poll path stays GET-only, the cost is arithmetic before the first tick,
+and `pkg/monitor`'s guardrail sees no difference at all — nothing about discovery survives into polling. One walk
+per COLUMN, not per widget: a grid of port states and a chart of port counters both discover from ifDescr, and
+that is one walk (`DiscoveryWalks` deduplicates).
+
+**The walked column is the LABEL source as well as the instance source**, which is half of why it is worth its
+round trip: walking ifDescr answers "which interfaces exist" and "what the equipment calls them" together, so a
+discovered grid reads `Gi0/1` rather than `8`. That is `Widget.OIDLabels`, filled by `ExpandWidget`.
+
+**A walk that fails refuses the bind.** An empty instance list expands every template to nothing, and the result
+would be a session that looks bound, polls whatever scalars the preset also had, and draws empty widgets — which
+is the one failure mode a monitoring tool must not have. The error names the column, because "bind failed" sends
+the operator to read the preset when the problem is the community or an ACL.
+
+**The expanded preset is validated AGAIN**, which is not belt-and-braces: the walk decides how many OIDs there
+are, so a device with four hundred interfaces pushes a preset past a sanity bound its author never came close to.
+
+**Two bounds meet on each widget and the SMALLER wins** (`discoverInstanceLimit`): the walk bound
+(`MaxDiscoveredPerWidget`, 128, or the preset's own `max`), which stops a forty-thousand-row table from becoming
+a dashboard; and the KIND's `MaxOIDs`, which is what the widget can actually draw. Discovering 128 states for a
+grid that renders 96 is polling 32 readings nobody sees. The consequence worth knowing is that a chart is capped
+at eight series by the colour plan, so a chart discovering an in and an out counter shows FOUR ports — a real
+limitation, stated rather than worked around.
+
+**`preset.Cost` is a CEILING once `Discovered` is non-zero**, and the settings screen says so
+(`preset.costAtMost`). A figure presented as a count that is really an upper bound is worse than no figure.
+
+Templates expand INSTANCE-MAJOR — every OID of instance 1, then every OID of instance 2 — which keeps a port's in
+and out counters beside each other instead of interleaving twenty-four ins with twenty-four outs. Order is the
+walk's, which is the agent's own order for the column: the order the ports are in on the device.
 
 ### Binding, and the snapshot rule
 

--- a/app_bundledpresets_test.go
+++ b/app_bundledpresets_test.go
@@ -63,9 +63,18 @@ func TestEveryBundledPresetIsValid(t *testing.T) {
 		if c.OIDs == 0 || c.VarbindsPerDay == 0 {
 			t.Errorf("%s costs nothing: %+v", e.Name(), c)
 		}
-		// One round in one request keeps the example cheap to reason about.
-		if c.OIDs > snmp.MaxVarbindsPerGet*2 {
-			t.Errorf("%s polls %d OIDs, more than two requests a round", e.Name(), c.OIDs)
+		// A CEILING, not a count: a discovering preset polls whatever the
+		// equipment has, and its estimate is the upper bound it agreed to. The
+		// bar here is that even at that ceiling a shipped example is a
+		// dashboard rather than a stress test — a full 96-port chassis is four
+		// requests a round, and that is fine.
+		const maxRoundsPerPoll = 8
+		rounds := (c.OIDs + snmp.MaxVarbindsPerGet - 1) / snmp.MaxVarbindsPerGet
+		if rounds > maxRoundsPerPoll {
+			t.Errorf("%s polls at most %d OIDs, %d requests a round", e.Name(), c.OIDs, rounds)
+		}
+		if c.Discovered > 0 && !strings.Contains(strings.ToLower(p.Description), "discover") {
+			t.Errorf("%s discovers its instances and its description does not say so", e.Name())
 		}
 	}
 }

--- a/app_preset.go
+++ b/app_preset.go
@@ -448,6 +448,69 @@ func rankForDevice(list []preset.Info, sysObjectID string) ([]preset.Info, int) 
 	return ranked, matched
 }
 
+// discoverFor walks what a preset asks for and expands its templates.
+//
+// One walk per COLUMN, not per widget: a grid of port states and a chart of
+// port counters discover from the same ifDescr, and that is one walk. Then each
+// widget takes the instances of its own column.
+//
+// A walk that fails leaves that widget with NO OIDs, and Validate then refuses
+// the expanded preset — which is the honest outcome. Binding a discovering
+// preset to a device that cannot answer the walk would otherwise produce a
+// dashboard of empty widgets polling nothing, and a session that looks bound.
+func (a *App) discoverFor(p preset.Preset, target, snmpVersion string, conn MonitorConnection) (preset.Preset, error) {
+	walks := preset.DiscoveryWalks(p)
+	if len(walks) == 0 {
+		return p, nil
+	}
+	if a.snmpClient == nil {
+		return p, fmt.Errorf("no SNMP client")
+	}
+	sessConn, creds := conn.split()
+	v3 := snmp.V3Params{
+		User: sessConn.V3User, AuthProto: sessConn.V3AuthProto, PrivProto: sessConn.V3PrivProto,
+		SecLevel: sessConn.V3SecLevel, ContextName: sessConn.V3ContextName,
+		AuthPass: creds.AuthPass, PrivPass: creds.PrivPass,
+	}
+
+	byColumn := map[string][]preset.Instance{}
+	for _, column := range walks {
+		results := a.snmpClient.Walk([]string{target}, column,
+			creds.Community, snmpVersion, sessConn.Port, sessConn.TimeoutSec, sessConn.Retries, v3)
+		if len(results) == 0 || results[0].Error != "" || results[0].Result == nil {
+			why := "no answer"
+			if len(results) > 0 && results[0].Error != "" {
+				why = results[0].Error
+			}
+			return p, fmt.Errorf("discovering %s on %s: %s", column, target, why)
+		}
+
+		rows, ok := results[0].Result.Value.([]*snmp.Result)
+		if !ok {
+			return p, fmt.Errorf("discovering %s on %s: unexpected walk result", column, target)
+		}
+		oids := make([]string, 0, len(rows))
+		values := make(map[string]string, len(rows))
+		for _, r := range rows {
+			if r == nil {
+				continue
+			}
+			oids = append(oids, r.Oid)
+			values[r.Oid] = fmt.Sprintf("%v", r.Value)
+		}
+		byColumn[column] = preset.InstancesFrom(column, oids, func(oid string) string { return values[oid] })
+	}
+
+	found := map[int][]preset.Instance{}
+	for i, w := range p.Widgets {
+		if w.Discover == nil {
+			continue
+		}
+		found[i] = byColumn[strings.TrimPrefix(w.Discover.Walk, ".")]
+	}
+	return preset.Expand(p, found), nil
+}
+
 // PresetBind is the moment a preset stops being a file and starts being a
 // monitoring: it creates one session for one equipment and starts it.
 //
@@ -485,6 +548,25 @@ func (a *App) PresetBind(fileName, target, snmpVersion string, conn MonitorConne
 	if len(errs) > 0 {
 		return storage.Session{}, fmt.Errorf(
 			"%s has %d problem(s) and cannot be bound until they are fixed", filepath.Base(path), len(errs))
+	}
+
+	// The walk happens HERE and only here. What is stored afterwards is a plain
+	// preset with concrete OIDs, so the poll path stays GET-only and the cost is
+	// arithmetic before the first tick.
+	if preset.HasDiscovery(p) {
+		expanded, err := a.discoverFor(p, target, snmpVersion, conn)
+		if err != nil {
+			return storage.Session{}, err
+		}
+		// Validated AGAIN, because the walk decides how many OIDs there are: a
+		// device with four hundred interfaces can push a preset past the sanity
+		// bound its author never came close to.
+		if errs := preset.Validate(expanded); len(errs) > 0 {
+			return storage.Session{}, fmt.Errorf(
+				"%s does not fit this equipment: %s (%d problem(s) after discovery)",
+				filepath.Base(path), errs[0].Field, len(errs))
+		}
+		p = expanded
 	}
 
 	oids := preset.PollOIDs(p)

--- a/app_presetdiscover_test.go
+++ b/app_presetdiscover_test.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/preset"
+)
+
+// A preset that discovers its ports, of the shape the shipped ones now have:
+// one walk of ifDescr feeding a grid of states and a chart of counters.
+const discoveringPreset = `{
+  "formatVersion": 1, "name": "Ports", "intervalSec": 60,
+  "widgets": [
+    {"kind": "value", "title": "Uptime", "oids": ["1.3.6.1.2.1.1.3.0"]},
+    {"kind": "grid", "title": "Ports", "oids": ["1.3.6.1.2.1.2.2.1.8.{#}"],
+     "labels": {"1": "up", "2": "down"},
+     "discover": {"walk": "1.3.6.1.2.1.2.2.1.2"}},
+    {"kind": "chart", "title": "Traffic", "oids": ["1.3.6.1.2.1.2.2.1.10.{#}"],
+     "discover": {"walk": "1.3.6.1.2.1.2.2.1.2"}}
+  ]
+}`
+
+// Binding a discovering preset to a device that cannot answer the walk is
+// refused, and nothing is left behind.
+//
+// The alternative is what the first version did: an empty instance list expands
+// every template to nothing, the widgets end up with no OIDs at all, and what
+// the operator gets is a session that looks bound, polls one scalar, and draws
+// two empty boxes. The walk failing is the most likely thing to go wrong when
+// somebody binds a preset — wrong community, wrong version, an ACL on the
+// column — so it is the case that must not be quiet.
+func TestBindingADiscoveringPresetToASilentDeviceIsRefused(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ports.json", discoveringPreset)
+
+	// A port nothing listens on, on the loopback: the answer is an ICMP
+	// unreachable rather than a timeout, so this costs milliseconds.
+	_, err := a.PresetBind("ports.json", "127.0.0.1", "v2c", MonitorConnection{
+		Port: closedUDPPort(t), TimeoutSec: 1, Retries: 0, Community: "public",
+	})
+	if err == nil {
+		t.Fatal("a preset was bound to a device that could not answer its walk")
+	}
+	// The message names the column, because "bind failed" sends the operator
+	// looking at the preset rather than at the device.
+	if !strings.Contains(err.Error(), "1.3.6.1.2.1.2.2.1.2") {
+		t.Errorf("the refusal does not say what could not be walked: %v", err)
+	}
+
+	if sessions, _ := a.storage.ListSessions(); len(sessions) != 0 {
+		t.Errorf("%d session(s) left behind by a refused bind", len(sessions))
+	}
+}
+
+// A preset that lists its OIDs does not pay for the discovery path.
+//
+// The client is nil here on purpose: discoverFor must decide there is nothing
+// to walk BEFORE it reaches for anything, or every hand-written preset acquires
+// a round trip — and a nil dereference in a unit test that has no network.
+func TestAPresetWithoutDiscoveryIsNeverWalked(t *testing.T) {
+	a, _ := newBindApp(t)
+	a.snmpClient = nil
+
+	p := preset.Preset{
+		FormatVersion: 1, Name: "Plain", IntervalSec: 60,
+		Widgets: []preset.Widget{{
+			Kind: "value", Title: "Uptime", OIDs: []string{"1.3.6.1.2.1.1.3.0"},
+		}},
+	}
+	out, err := a.discoverFor(p, "10.0.0.1", "v2c", MonitorConnection{Port: 161})
+	if err != nil {
+		t.Fatalf("discoverFor on a preset that discovers nothing: %v", err)
+	}
+	if len(out.Widgets) != 1 || len(out.Widgets[0].OIDs) != 1 ||
+		out.Widgets[0].OIDs[0] != "1.3.6.1.2.1.1.3.0" {
+		t.Errorf("the preset came back changed: %+v", out.Widgets)
+	}
+}
+
+// The whole of discovery against a real agent: bind, and the session polls the
+// interfaces the equipment actually has, named as it names them.
+//
+// Skipped unless you point it at the bundled simulator, the way pkg/monitor's
+// integration tests are:
+//
+//	python tools/snmp_test_agent.py --port 11611 --no-traps
+//	SNMPLENS_TEST_AGENT=127.0.0.1:11611 go test . -run Integration -v
+func TestPresetDiscoveryIntegration(t *testing.T) {
+	host, port := testAgent(t)
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ports.json", discoveringPreset)
+
+	sess, err := a.PresetBind("ports.json", host, "v2c", MonitorConnection{
+		Port: port, TimeoutSec: 2, Retries: 1, Community: "public",
+	})
+	if err != nil {
+		t.Fatalf("PresetBind: %v", err)
+	}
+
+	// The scalar plus one state and one counter per interface the agent serves.
+	// The count is not hard-coded: the point of discovery is that the preset
+	// does not know it either.
+	oids := strings.Split(sess.OID, ",")
+	states, counters := 0, 0
+	for _, oid := range oids {
+		switch {
+		case strings.HasPrefix(oid, "1.3.6.1.2.1.2.2.1.8."):
+			states++
+		case strings.HasPrefix(oid, "1.3.6.1.2.1.2.2.1.10."):
+			counters++
+		}
+	}
+	if states < 2 || states != counters {
+		t.Fatalf("discovered %d state(s) and %d counter(s) from %q", states, counters, sess.OID)
+	}
+	t.Logf("discovered %d interface(s)", states)
+
+	// The templates are gone: what is stored is a plain preset, which is what
+	// keeps the poll path GET-only.
+	for _, w := range sess.Preset.Widgets {
+		if w.Discover != nil {
+			t.Errorf("widget %q still carries a discovery declaration", w.Title)
+		}
+		for _, oid := range w.OIDs {
+			if strings.Contains(oid, preset.InstancePlaceholder) {
+				t.Errorf("widget %q still has a template: %s", w.Title, oid)
+			}
+		}
+	}
+
+	// And the labels came off the walked column, which is the other half of why
+	// the walk is worth its round trip: a grid reading "eth0" rather than "8".
+	grid := sess.Preset.Widgets[1]
+	if len(grid.OIDLabels) != states {
+		t.Fatalf("%d label(s) for %d cell(s)", len(grid.OIDLabels), states)
+	}
+	for oid, label := range grid.OIDLabels {
+		if strings.TrimSpace(label) == "" {
+			t.Errorf("%s has an empty label", oid)
+		}
+		if _, err := strconv.Atoi(label); err == nil {
+			t.Errorf("%s is labelled %q, which is an index rather than a name", oid, label)
+		}
+	}
+}
+
+// testAgent reads SNMPLENS_TEST_AGENT, the variable CLAUDE.md documents.
+func testAgent(t *testing.T) (string, int) {
+	t.Helper()
+	addr := os.Getenv("SNMPLENS_TEST_AGENT")
+	if addr == "" {
+		t.Skip("set SNMPLENS_TEST_AGENT=127.0.0.1:11611 to run against the bundled simulator")
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SNMPLENS_TEST_AGENT must be host:port, got %q: %v", addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("bad port in SNMPLENS_TEST_AGENT: %v", err)
+	}
+	return host, port
+}
+
+// closedUDPPort returns a loopback UDP port nothing is listening on.
+//
+// Bound and released rather than picked: a hard-coded number is a port somebody
+// else's agent is on, and this test's whole premise is that nothing answers.
+func closedUDPPort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	if err := c.Close(); err != nil {
+		t.Fatalf("releasing %d: %v", port, err)
+	}
+	return port
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1156,8 +1156,11 @@
       "oidTooDeep": "{found} Unterkennungen; eine OID trägt höchstens {max}.",
       "oidOutOfRange": "„{value}“ enthält eine Unterkennung, die nicht auf die Leitung passt.",
       "notJson": "Diese Datei ist kein JSON ({detail}).",
-      "tooBig": "Diese Datei hat {found} Bytes; höchstens {max}."
-    }
+      "tooBig": "Diese Datei hat {found} Bytes; höchstens {max}.",
+      "placeholderWithoutDiscover": "Diese OID enthält einen Instanz-Platzhalter, aber das Widget sagt nicht, wo seine Instanzen zu finden sind.",
+      "discoverWithoutPlaceholder": "Dieses Widget ermittelt seine Instanzen, doch keine OID enthält {placeholder} — der Walk wäre umsonst."
+    },
+    "costAtMost": "Höchstens — {discovered} dieser OIDs werden beim Binden auf dem Gerät ermittelt; die echten Zahlen stehen dann fest und können nur niedriger sein."
   },
   "dashboard": {
     "empty": "Noch kein Dashboard.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1156,8 +1156,11 @@
       "oidTooDeep": "{found} sub-identifiers; an OID carries at most {max}.",
       "oidOutOfRange": "\"{value}\" has a sub-identifier that does not fit on the wire.",
       "notJson": "This file is not JSON ({detail}).",
-      "tooBig": "This file is {found} bytes; at most {max}."
-    }
+      "tooBig": "This file is {found} bytes; at most {max}.",
+      "placeholderWithoutDiscover": "This OID carries an instance placeholder, but the widget does not say where to discover its instances.",
+      "discoverWithoutPlaceholder": "This widget discovers its instances but no OID carries {placeholder}, so the walk would be paid for and thrown away."
+    },
+    "costAtMost": "At most — {discovered} of these OIDs are discovered on the equipment when you bind it, so the real figures are known then and can only be lower."
   },
   "dashboard": {
     "empty": "No dashboard yet.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1156,8 +1156,11 @@
       "oidTooDeep": "{found} subidentificadores; un OID lleva {max} como máximo.",
       "oidOutOfRange": "«{value}» tiene un subidentificador que no cabe en la red.",
       "notJson": "Este archivo no es JSON ({detail}).",
-      "tooBig": "Este archivo ocupa {found} bytes; {max} como máximo."
-    }
+      "tooBig": "Este archivo ocupa {found} bytes; {max} como máximo.",
+      "placeholderWithoutDiscover": "Este OID lleva un marcador de instancia, pero el widget no indica dónde descubrir sus instancias.",
+      "discoverWithoutPlaceholder": "Este widget descubre sus instancias pero ningún OID lleva {placeholder}, así que el walk se pagaría en vano."
+    },
+    "costAtMost": "Como máximo — {discovered} de estos OID se descubren en el equipo al vincularlo, así que las cifras reales se conocen entonces y solo pueden ser menores."
   },
   "dashboard": {
     "empty": "Aún no hay panel.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1156,8 +1156,11 @@
       "oidTooDeep": "{found} sous-identifiants ; un OID en porte {max} au maximum.",
       "oidOutOfRange": "« {value} » contient un sous-identifiant qui ne tient pas sur le réseau.",
       "notJson": "Ce fichier n'est pas du JSON ({detail}).",
-      "tooBig": "Ce fichier fait {found} octets ; {max} au maximum."
-    }
+      "tooBig": "Ce fichier fait {found} octets ; {max} au maximum.",
+      "placeholderWithoutDiscover": "Cet OID porte un marqueur d'instance, mais le widget n'indique pas où découvrir ses instances.",
+      "discoverWithoutPlaceholder": "Ce widget découvre ses instances mais aucun OID ne porte {placeholder} : le walk serait payé pour rien."
+    },
+    "costAtMost": "Au plus — {discovered} de ces OID sont découverts sur l'équipement au moment de la liaison : les chiffres réels sont connus à ce moment-là et ne peuvent qu'être inférieurs."
   },
   "dashboard": {
     "empty": "Aucun tableau de bord pour l'instant.",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1156,8 +1156,11 @@
       "oidTooDeep": "{found} 个子标识；一个 OID 最多 {max} 个。",
       "oidOutOfRange": "“{value}”中的子标识超出了传输范围。",
       "notJson": "此文件不是 JSON（{detail}）。",
-      "tooBig": "此文件为 {found} 字节；最多 {max}。"
-    }
+      "tooBig": "此文件为 {found} 字节；最多 {max}。",
+      "placeholderWithoutDiscover": "此 OID 含有实例占位符，但该部件未说明到哪里发现其实例。",
+      "discoverWithoutPlaceholder": "此部件会发现实例，但没有 OID 含有 {placeholder}，这次 walk 将白白付出代价。"
+    },
+    "costAtMost": "至多如此 —— 其中 {discovered} 个 OID 在绑定时于设备上发现，实际数字届时确定，且只会更少。"
   },
   "dashboard": {
     "empty": "尚无仪表板。",

--- a/frontend/src/settings/PresetSettings.svelte
+++ b/frontend/src/settings/PresetSettings.svelte
@@ -170,6 +170,16 @@
                   <div><span class="k">{$_('preset.costRequests')}</span><span class="v">{detail.cost.requestsPerDay}</span></div>
                   <div><span class="k">{$_('preset.costVarbinds')}</span><span class="v">{detail.cost.varbindsPerDay}</span></div>
                 </div>
+                {#if detail.cost.discovered > 0}
+                  <!-- A discovering preset does not know how many instances the
+                       equipment has, so every figure above is a CEILING: the
+                       widget bounds, not a count of what will be polled. Saying
+                       so here is the difference between a number that is wrong
+                       and a number that is honest about what it is. -->
+                  <p class="hint at-most">
+                    {$_('preset.costAtMost', { values: { discovered: detail.cost.discovered } })}
+                  </p>
+                {/if}
                 <p class="hint">
                   {$_('preset.costPerTarget', { values: { chunk: detail.cost.varbindsPerRequest } })}
                 </p>
@@ -234,6 +244,12 @@
     margin: 0.2rem 0 0;
     color: var(--text-secondary);
     font-size: 0.78rem;
+  }
+
+  /* The ceiling notice is the one hint that changes how the figures above it
+     are read, so it is not the same grey as the two that merely explain them. */
+  .at-most {
+    color: var(--text-primary);
   }
 
   .empty {

--- a/pkg/preset/discover.go
+++ b/pkg/preset/discover.go
@@ -1,0 +1,258 @@
+package preset
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Discovery: a preset that works on the equipment in front of you.
+//
+// The presets that shipped first enumerated `…2.2.1.8.1` through `.24` by hand
+// and their descriptions said "edit the instance numbers if yours does not
+// index from 1". That is an admission: a preset written for a 24-port switch is
+// a preset for exactly one shape of switch, and a library of those is not
+// shareable.
+//
+// So a widget may say WHERE to find its instances instead of listing them. One
+// walk, at BIND TIME, turns the templates into concrete OIDs which are then
+// stored in the session exactly as a hand-written preset's are — so the poll
+// path stays GET-only, the cost is arithmetic before the first tick, and the
+// guardrail sees no difference. Nothing about discovery survives into polling.
+//
+// The walked COLUMN is the label source as well as the instance source: walking
+// ifDescr gives you both "which interfaces exist" and "what they are called",
+// which is why a discovered port grid reads "Gi0/1" rather than "8".
+
+// InstancePlaceholder is what a template OID carries where the instance goes.
+const InstancePlaceholder = "{#}"
+
+// MaxDiscoveredPerWidget bounds one walk when the preset does not.
+//
+// A default rather than a requirement, because the number somebody would write
+// is a guess about equipment they have not seen — and the honest bound is the
+// one that stops a walk of a 40 000-row table from becoming a dashboard.
+const MaxDiscoveredPerWidget = 128
+
+// Discover says where a widget's instances come from.
+type Discover struct {
+	// Walk is the numeric OID of a COLUMN to walk. Its instances become the
+	// widget's, and its values become their labels.
+	Walk string `json:"walk"`
+	// Max bounds what one walk may produce for this widget. Zero means
+	// MaxDiscoveredPerWidget.
+	Max int `json:"max,omitempty"`
+}
+
+// Instance is one row a walk found.
+type Instance struct {
+	// Suffix is what follows the walked column's OID — "1", or "1.3.6.1.2" for
+	// a table indexed by an address.
+	Suffix string `json:"suffix"`
+	// Label is the walked value, which is what makes a discovered grid readable.
+	Label string `json:"label"`
+}
+
+// HasDiscovery reports whether anything in this preset needs a walk before it
+// can be polled.
+func HasDiscovery(p Preset) bool {
+	for _, w := range p.Widgets {
+		if w.Discover != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// discoverInstanceLimit is how many INSTANCES one widget may take.
+//
+// Two bounds meet here and the smaller wins, which is the whole of the rule:
+//
+//   - the WALK bound, declared or defaulted, which stops a forty-thousand-row
+//     table from becoming a dashboard;
+//   - the KIND's own MaxOIDs, which is what the widget can actually draw.
+//
+// Discovering ninety-six states for a grid that renders ninety-six of them is
+// right; discovering a hundred and twenty-eight is polling thirty-two readings
+// nobody sees. And a chart is capped at eight series by the palette, so a chart
+// discovering an in and an out counter can show four ports — which is a real
+// limitation and is better stated than worked around.
+func discoverInstanceLimit(w Widget) int {
+	if w.Discover == nil {
+		return 0
+	}
+	limit := MaxDiscoveredPerWidget
+	if w.Discover.Max > 0 {
+		limit = w.Discover.Max
+	}
+
+	templates := 0
+	for _, oid := range w.OIDs {
+		if strings.Contains(oid, InstancePlaceholder) {
+			templates++
+		}
+	}
+	if templates == 0 {
+		return 0
+	}
+
+	if doc, known := widgetDoc(w.Kind); known && doc.MaxOIDs > 0 {
+		// The fixed OIDs of a mixed widget take their share of the kind's room
+		// before the discovered ones get any.
+		room := doc.MaxOIDs - (len(w.OIDs) - templates)
+		if room < 0 {
+			room = 0
+		}
+		if byKind := room / templates; byKind < limit {
+			limit = byKind
+		}
+	}
+	return limit
+}
+
+// ExpandWidget turns one widget's templates into concrete OIDs.
+//
+// Order is the walk's, which is the agent's own order for the column — the
+// order the ports are in on the device, not alphabetical and not numeric on a
+// string. Templates expand INSTANCE-MAJOR: every OID of instance 1, then every
+// OID of instance 2. For a grid that is one cell per port; for a chart it keeps
+// a port's in and out counters next to each other rather than interleaving
+// twenty-four ins with twenty-four outs.
+//
+// A widget with no Discover comes back unchanged, so a caller can run this over
+// every widget without asking first.
+func ExpandWidget(w Widget, found []Instance) Widget {
+	if w.Discover == nil {
+		return w
+	}
+	if limit := discoverInstanceLimit(w); len(found) > limit {
+		found = found[:limit]
+	}
+
+	out := w
+	out.Discover = nil // it has been done; what remains is a plain widget
+	out.OIDs = make([]string, 0, len(w.OIDs)*len(found))
+	labels := map[string]string{}
+
+	for _, in := range found {
+		for _, tmpl := range w.OIDs {
+			if !strings.Contains(tmpl, InstancePlaceholder) {
+				continue
+			}
+			oid := strings.ReplaceAll(tmpl, InstancePlaceholder, in.Suffix)
+			out.OIDs = append(out.OIDs, oid)
+			if in.Label != "" {
+				labels[oid] = in.Label
+			}
+		}
+	}
+
+	// An OID that carried no placeholder is kept as it was: a widget may mix a
+	// fixed reading with discovered ones.
+	for _, tmpl := range w.OIDs {
+		if !strings.Contains(tmpl, InstancePlaceholder) {
+			out.OIDs = append(out.OIDs, tmpl)
+		}
+	}
+
+	if len(labels) > 0 {
+		out.OIDLabels = labels
+	}
+	return out
+}
+
+// Expand runs ExpandWidget over a preset, given what each widget's walk found.
+//
+// Keyed by widget INDEX because a widget has no identity of its own — a title
+// is author text and two widgets may share one. The caller walked in the same
+// order, so the index is the only thing that cannot drift.
+func Expand(p Preset, found map[int][]Instance) Preset {
+	out := p
+	out.Widgets = make([]Widget, len(p.Widgets))
+	for i, w := range p.Widgets {
+		out.Widgets[i] = ExpandWidget(w, found[i])
+	}
+	return out
+}
+
+// DiscoveryWalks lists the columns that have to be walked, deduplicated.
+//
+// Two widgets discovering from the same column — a grid of states and a chart
+// of counters, both indexed by interface — is the ordinary case, and it is one
+// walk, not two.
+func DiscoveryWalks(p Preset) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, w := range p.Widgets {
+		if w.Discover == nil {
+			continue
+		}
+		key := strings.TrimPrefix(w.Discover.Walk, ".")
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, key)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// InstancesFrom turns a walk's results into instances.
+//
+// The walked OIDs come back with the column's own prefix; what identifies a row
+// is what FOLLOWS it. A result outside the column is ignored rather than
+// mis-parsed: gosnmp's walk stops at the subtree, but a device answering
+// something else must not become a row addressed at random.
+func InstancesFrom(column string, oids []string, valueOf func(string) string) []Instance {
+	prefix := strings.TrimPrefix(strings.TrimSpace(column), ".")
+	if prefix == "" {
+		return nil
+	}
+	out := []Instance{}
+	for _, raw := range oids {
+		oid := strings.TrimPrefix(strings.TrimSpace(raw), ".")
+		if !strings.HasPrefix(oid, prefix+".") {
+			continue
+		}
+		suffix := oid[len(prefix)+1:]
+		if suffix == "" {
+			continue
+		}
+		out = append(out, Instance{Suffix: suffix, Label: valueOf(raw)})
+	}
+	return out
+}
+
+// checkDiscovery validates a widget's discovery declaration.
+func checkDiscovery(at string, w Widget) []Error {
+	templates := 0
+	for _, oid := range w.OIDs {
+		if strings.Contains(oid, InstancePlaceholder) {
+			templates++
+		}
+	}
+
+	if w.Discover == nil {
+		if templates > 0 {
+			return []Error{errf(at+".oids", "placeholderWithoutDiscover", nil)}
+		}
+		return nil
+	}
+
+	var errs []Error
+	errs = append(errs, checkOID(at+".discover.walk", w.Discover.Walk)...)
+	if templates == 0 {
+		// Otherwise the walk is paid for and nothing uses it, which reads as a
+		// preset that discovers and then ignores what it found.
+		errs = append(errs, errf(at+".oids", "discoverWithoutPlaceholder", map[string]string{
+			"placeholder": InstancePlaceholder,
+		}))
+	}
+	if w.Discover.Max < 0 || w.Discover.Max > MaxOIDsPerPreset {
+		errs = append(errs, errf(at+".discover.max", "outOfRange", map[string]string{
+			"min": "1", "max": fmt.Sprint(MaxOIDsPerPreset),
+		}))
+	}
+	return errs
+}

--- a/pkg/preset/discover_test.go
+++ b/pkg/preset/discover_test.go
@@ -1,0 +1,315 @@
+package preset
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func discovering() Preset {
+	p := valid()
+	p.Widgets = []Widget{
+		{Kind: KindValue, Title: "Uptime", OIDs: []string{"1.3.6.1.2.1.1.3.0"}},
+		{
+			Kind: KindGrid, Title: "Ports",
+			OIDs:     []string{"1.3.6.1.2.1.2.2.1.8.{#}"},
+			Labels:   map[string]string{"1": "up", "2": "down"},
+			Discover: &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+		},
+	}
+	return p
+}
+
+func ports(n int) []Instance {
+	out := make([]Instance, 0, n)
+	for i := 1; i <= n; i++ {
+		out = append(out, Instance{Suffix: strconv.Itoa(i), Label: "Gi0/" + strconv.Itoa(i)})
+	}
+	return out
+}
+
+// The whole point: one file, any equipment.
+func TestExpansionTurnsATemplateIntoTheInstancesFound(t *testing.T) {
+	w := discovering().Widgets[1]
+	got := ExpandWidget(w, ports(3))
+
+	if got.Discover != nil {
+		t.Error("the expanded widget still asks to be discovered")
+	}
+	want := []string{"1.3.6.1.2.1.2.2.1.8.1", "1.3.6.1.2.1.2.2.1.8.2", "1.3.6.1.2.1.2.2.1.8.3"}
+	if strings.Join(got.OIDs, ",") != strings.Join(want, ",") {
+		t.Errorf("OIDs = %v", got.OIDs)
+	}
+
+	// The walked column is the LABEL source as well as the instance source,
+	// which is why a discovered grid reads "Gi0/1" rather than "8".
+	if got.OIDLabels["1.3.6.1.2.1.2.2.1.8.2"] != "Gi0/2" {
+		t.Errorf("labels = %v", got.OIDLabels)
+	}
+	// And the author's own state map is untouched by it.
+	if got.Labels["1"] != "up" {
+		t.Errorf("the state labels were lost: %v", got.Labels)
+	}
+}
+
+// An index is not always a number: a table keyed by an address has several
+// sub-identifiers, and the suffix is all of them.
+func TestAMultiPartInstanceSurvives(t *testing.T) {
+	w := Widget{
+		Kind: KindStatus, Title: "Neighbours", OIDs: []string{"1.3.6.1.2.1.4.22.1.4.{#}"},
+		Discover: &Discover{Walk: "1.3.6.1.2.1.4.22.1.2"},
+	}
+	got := ExpandWidget(w, []Instance{{Suffix: "3.10.0.0.5", Label: "aa:bb"}})
+	if len(got.OIDs) != 1 || got.OIDs[0] != "1.3.6.1.2.1.4.22.1.4.3.10.0.0.5" {
+		t.Errorf("OIDs = %v", got.OIDs)
+	}
+}
+
+// Instance-major: a port's in and out counters stay next to each other rather
+// than twenty-four ins arriving before the first out.
+func TestTemplatesExpandInstanceMajor(t *testing.T) {
+	w := Widget{
+		Kind: KindChart, Title: "Traffic",
+		OIDs:     []string{"1.3.6.1.2.1.2.2.1.10.{#}", "1.3.6.1.2.1.2.2.1.16.{#}"},
+		Discover: &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+	}
+	got := ExpandWidget(w, ports(2))
+	want := "1.3.6.1.2.1.2.2.1.10.1,1.3.6.1.2.1.2.2.1.16.1,1.3.6.1.2.1.2.2.1.10.2,1.3.6.1.2.1.2.2.1.16.2"
+	if strings.Join(got.OIDs, ",") != want {
+		t.Errorf("OIDs = %v", got.OIDs)
+	}
+}
+
+// A widget may mix a fixed reading with discovered ones.
+func TestAnOidWithNoPlaceholderIsKept(t *testing.T) {
+	w := Widget{
+		Kind: KindChart, Title: "Traffic",
+		OIDs:     []string{"1.3.6.1.2.1.2.2.1.10.{#}", "1.3.6.1.2.1.1.3.0"},
+		Discover: &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+	}
+	got := ExpandWidget(w, ports(2))
+	if len(got.OIDs) != 3 || got.OIDs[2] != "1.3.6.1.2.1.1.3.0" {
+		t.Errorf("OIDs = %v", got.OIDs)
+	}
+}
+
+// The bound applies whether or not the author thought about it — a walk of a
+// forty-thousand-row table must not become a dashboard.
+func TestTheWalkIsBounded(t *testing.T) {
+	// A grid's own MaxOIDs is below the default walk bound, so it is what
+	// applies here; TestTheDisplayBoundCapsTheWalkBound is about that rule.
+	grid, _ := widgetDoc(KindGrid)
+	w := discovering().Widgets[1]
+	if got := ExpandWidget(w, ports(500)); len(got.OIDs) != grid.MaxOIDs {
+		t.Errorf("%d OIDs from 500 instances, want %d", len(got.OIDs), grid.MaxOIDs)
+	}
+
+	// A declared bound below both is the one that applies.
+	w.Discover.Max = 8
+	if got := ExpandWidget(w, ports(500)); len(got.OIDs) != 8 {
+		t.Errorf("%d OIDs with an explicit bound of 8", len(got.OIDs))
+	}
+
+	// And the default is what catches a kind with no ceiling of its own.
+	if MaxDiscoveredPerWidget <= grid.MaxOIDs {
+		t.Errorf("the default walk bound %d is below every kind's, so it can never apply",
+			MaxDiscoveredPerWidget)
+	}
+}
+
+// One walk per COLUMN, not per widget: a grid of states and a chart of counters
+// discover from the same ifDescr.
+func TestTwoWidgetsOnOneColumnAreOneWalk(t *testing.T) {
+	p := discovering()
+	p.Widgets = append(p.Widgets, Widget{
+		Kind: KindChart, Title: "Traffic", OIDs: []string{"1.3.6.1.2.1.2.2.1.10.{#}"},
+		Discover: &Discover{Walk: ".1.3.6.1.2.1.2.2.1.2"},
+	})
+
+	walks := DiscoveryWalks(p)
+	if len(walks) != 1 || walks[0] != "1.3.6.1.2.1.2.2.1.2" {
+		t.Errorf("walks = %v; the leading dot is the same column", walks)
+	}
+	if !HasDiscovery(p) || HasDiscovery(valid()) {
+		t.Error("HasDiscovery does not tell the two apart")
+	}
+}
+
+// A row outside the walked column must not become an instance addressed at
+// random.
+func TestInstancesComeOnlyFromTheWalkedColumn(t *testing.T) {
+	const column = "1.3.6.1.2.1.2.2.1.2"
+	oids := []string{
+		".1.3.6.1.2.1.2.2.1.2.1",
+		"1.3.6.1.2.1.2.2.1.2.2",
+		"1.3.6.1.2.1.2.2.1.3.1", // the next column: not ours
+		"1.3.6.1.2.1.2.2.1.2",   // the column itself, no instance
+		"1.3.6.1.4.1.9.1.1",     // somewhere else entirely
+	}
+	values := map[string]string{".1.3.6.1.2.1.2.2.1.2.1": "Gi0/1", "1.3.6.1.2.1.2.2.1.2.2": "Gi0/2"}
+
+	got := InstancesFrom(column, oids, func(o string) string { return values[o] })
+	if len(got) != 2 {
+		t.Fatalf("%d instances: %+v", len(got), got)
+	}
+	if got[0].Suffix != "1" || got[0].Label != "Gi0/1" {
+		t.Errorf("first = %+v", got[0])
+	}
+	if got[1].Suffix != "2" {
+		t.Errorf("second = %+v", got[1])
+	}
+}
+
+/* --- what the format refuses ---------------------------------------------- */
+
+func TestAPlaceholderNeedsADiscoverAndViceVersa(t *testing.T) {
+	// A template with nothing to fill it would reach the wire as
+	// "…8.{#}", which fails somewhere far from the file that caused it.
+	p := valid()
+	p.Widgets[0].OIDs = []string{"1.3.6.1.2.1.2.2.1.8.{#}"}
+	if errs := Validate(p); !has(errs, "widgets[0].oids") {
+		t.Error("a placeholder without a discover was accepted")
+	}
+
+	// And a walk nothing uses is a walk paid for and thrown away.
+	p2 := valid()
+	p2.Widgets[0].Discover = &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"}
+	if errs := Validate(p2); !has(errs, "widgets[0].oids") {
+		t.Error("a discover with no placeholder was accepted")
+	}
+
+	// The walk is an OID like any other.
+	p3 := discovering()
+	p3.Widgets[1].Discover.Walk = "ifDescr"
+	if errs := Validate(p3); !has(errs, "widgets[1].discover.walk") {
+		t.Error("a walk that is not a numeric OID was accepted")
+	}
+
+	// A template is still checked as the OID it becomes.
+	p4 := discovering()
+	p4.Widgets[1].OIDs = []string{"9.3.6.1.2.1.2.2.1.8.{#}"}
+	if errs := Validate(p4); !has(errs, "widgets[1].oids[0]") {
+		t.Error("a template with a non-root first arc was accepted")
+	}
+
+	// And a well-formed discovering preset passes.
+	if errs := Validate(discovering()); len(errs) != 0 {
+		t.Errorf("a valid discovering preset was refused: %s", fieldsOf(errs))
+	}
+}
+
+// The cost of a discovering preset is an UPPER BOUND, and it says so.
+//
+// "at most 3 072 values a day" and "3 072 values a day" are different
+// statements, and only one of them is true before the walk.
+func TestTheCostOfADiscoveringPresetIsACeiling(t *testing.T) {
+	p := discovering()
+	p.Widgets[1].Discover.Max = 48
+
+	c := Estimate(p)
+	if c.Discovered != 48 {
+		t.Errorf("Discovered = %d, want 48", c.Discovered)
+	}
+	if c.OIDs != 49 { // the uptime, plus the ceiling
+		t.Errorf("OIDs = %d, want 49", c.OIDs)
+	}
+
+	// After the walk it is a plain preset, and the count is exact.
+	expanded := Expand(p, map[int][]Instance{1: ports(3)})
+	after := Estimate(expanded)
+	if after.Discovered != 0 {
+		t.Errorf("an expanded preset still reports %d discovered", after.Discovered)
+	}
+	if after.OIDs != 4 {
+		t.Errorf("OIDs after the walk = %d, want 4", after.OIDs)
+	}
+	if HasDiscovery(expanded) {
+		t.Error("the expanded preset still asks for a walk")
+	}
+}
+
+// A template is not an OID, and polling one would fail far from its cause.
+func TestPollOidsNeverReturnsATemplate(t *testing.T) {
+	for _, oid := range PollOIDs(discovering()) {
+		if strings.Contains(oid, InstancePlaceholder) {
+			t.Errorf("%q would go on the wire", oid)
+		}
+	}
+	// Expanded, they are all there.
+	got := PollOIDs(Expand(discovering(), map[int][]Instance{1: ports(2)}))
+	if len(got) != 3 {
+		t.Errorf("%d OIDs after expansion: %v", len(got), got)
+	}
+}
+
+// Two bounds meet, and the SMALLER wins.
+//
+// The walk bound stops a forty-thousand-row table becoming a dashboard; the
+// kind's own MaxOIDs is what the widget can actually draw. Discovering more
+// than the second is polling readings nobody sees.
+func TestTheDisplayBoundCapsTheWalkBound(t *testing.T) {
+	grid, _ := widgetDoc(KindGrid)
+
+	// A grid asking for more than it can draw gets what it can draw.
+	w := discovering().Widgets[1]
+	w.Discover.Max = MaxOIDsPerPreset
+	if got := ExpandWidget(w, ports(400)); len(got.OIDs) != grid.MaxOIDs {
+		t.Errorf("%d OIDs, want the kind's own bound %d", len(got.OIDs), grid.MaxOIDs)
+	}
+
+	// A chart is capped at eight series by the palette, so a chart discovering
+	// an in and an out counter shows FOUR ports. A real limitation, stated.
+	chart := Widget{
+		Kind: KindChart, Title: "Traffic",
+		OIDs:     []string{"1.3.6.1.2.1.2.2.1.10.{#}", "1.3.6.1.2.1.2.2.1.16.{#}"},
+		Discover: &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+	}
+	if got := ExpandWidget(chart, ports(50)); len(got.OIDs) != 8 {
+		t.Errorf("%d OIDs on a chart, want 8", len(got.OIDs))
+	}
+
+	// A fixed OID takes its share of the room before the discovered ones.
+	mixed := chart
+	mixed.OIDs = []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.2.2.1.10.{#}"}
+	if got := ExpandWidget(mixed, ports(50)); len(got.OIDs) != 8 {
+		t.Errorf("%d OIDs on a mixed chart, want 8 (7 discovered + 1 fixed)", len(got.OIDs))
+	}
+}
+
+// Which means the preset bound is out of reach for ONE widget, and reachable
+// across several — and only after the walk, which is why binding validates
+// again.
+func TestThePresetBoundIsReachedAcrossWidgets(t *testing.T) {
+	one := Expand(discovering(), map[int][]Instance{1: ports(MaxOIDsPerPreset + 10)})
+	if errs := Validate(one); len(errs) != 0 {
+		t.Errorf("a single bounded widget was refused: %s", fieldsOf(errs))
+	}
+
+	grid, _ := widgetDoc(KindGrid)
+	need := MaxOIDsPerPreset/grid.MaxOIDs + 1 // enough grids to overshoot
+
+	// A DIFFERENT column per widget. Six grids on the same column poll the same
+	// ninety-six OIDs, and the cost deduplicates — so a degenerate fixture would
+	// prove nothing about the bound.
+	columns := []string{"8", "10", "14", "16", "19", "20", "13", "21"}
+	many := valid()
+	many.Widgets = nil
+	found := map[int][]Instance{}
+	for i := 0; i < need; i++ {
+		many.Widgets = append(many.Widgets, Widget{
+			Kind: KindGrid, Title: "Ports",
+			OIDs:     []string{"1.3.6.1.2.1.2.2.1." + columns[i%len(columns)] + ".{#}"},
+			Discover: &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+		})
+		found[i] = ports(grid.MaxOIDs)
+	}
+
+	expanded := Expand(many, found)
+	if got := Estimate(expanded).OIDs; got <= MaxOIDsPerPreset {
+		t.Fatalf("setup: %d OIDs does not overshoot %d", got, MaxOIDsPerPreset)
+	}
+	if errs := Validate(expanded); !has(errs, "widgets") {
+		t.Errorf("%d OIDs across %d widgets was accepted: %s",
+			Estimate(expanded).OIDs, need, fieldsOf(errs))
+	}
+}

--- a/pkg/preset/preset.go
+++ b/pkg/preset/preset.go
@@ -200,9 +200,17 @@ type Widget struct {
 	// Unit is an i18n key suffix when it names one this application knows, and
 	// is otherwise shown as written.
 	Unit string `json:"unit,omitempty"`
-	// Labels maps an integer reading to a name, for KindStatus. Nothing else
-	// reads it.
+	// Labels maps an integer reading to a name, for KindStatus and KindGrid.
+	// Nothing else reads it.
 	Labels map[string]string `json:"labels,omitempty"`
+	// Discover says where this widget's instances come from, instead of
+	// listing them. See discover.go: the walk happens ONCE, at bind time, and
+	// what is stored afterwards is a plain widget.
+	Discover *Discover `json:"discover,omitempty"`
+	// OIDLabels names each discovered OID with what the walk found — the port's
+	// own name rather than its index. Written by expansion, never by an author:
+	// a hand-written preset titles its own widgets.
+	OIDLabels map[string]string `json:"oidLabels,omitempty"`
 }
 
 // Error is one reason a preset was refused.
@@ -336,9 +344,21 @@ func Validate(p Preset) []Error {
 			}))
 		}
 		for j, oid := range w.OIDs {
-			errs = append(errs, checkOID(fmt.Sprintf("%s.oids[%d]", at, j), oid)...)
+			// A template is checked as the OID it becomes: substituting a
+			// single instance keeps every other rule — the arcs, the depth,
+			// the root — while allowing the one thing that is not a digit.
+			probe := strings.ReplaceAll(oid, InstancePlaceholder, "1")
+			errs = append(errs, checkOID(fmt.Sprintf("%s.oids[%d]", at, j), probe)...)
 		}
-		total += len(w.OIDs)
+		errs = append(errs, checkDiscovery(at, w)...)
+		// A discovering widget contributes its BOUND, not its template count:
+		// the sanity limit has to hold after the walk, and the walk happens on
+		// equipment nobody has seen yet.
+		if w.Discover != nil {
+			total += len(w.OIDs) * discoverInstanceLimit(w)
+		} else {
+			total += len(w.OIDs)
+		}
 
 		if len(w.Labels) > 0 && !kindTakesLabels(w.Kind) {
 			errs = append(errs, errf(at+".labels", "labelsOnlyForStatus", map[string]string{"kind": clip(w.Kind)}))
@@ -385,6 +405,15 @@ type Cost struct {
 	// whose job is to say what it will cost. A day is the coarsest cadence the
 	// format admits, so the count is at least one for every valid preset.
 	PollsPerDay int `json:"pollsPerDay"`
+	// Discovered is how many of the OIDs counted above come from a BOUND rather
+	// than from a list.
+	//
+	// When it is not zero, every figure here is an UPPER BOUND: a discovering
+	// widget's real count is whatever the walk finds on the equipment, and that
+	// is not knowable from the file. The screen showing this says so, because
+	// "at most 3 072 values a day" and "3 072 values a day" are different
+	// statements and only one of them is true here.
+	Discovered int `json:"discovered"`
 	// VarbindsPerDay is the honest measure of what the device is asked for:
 	// one request carries every OID, so counting rounds alone understates what
 	// the agent does work for.
@@ -404,6 +433,24 @@ func Estimate(p Preset) Cost {
 	c := Cost{Widgets: len(p.Widgets), IntervalSec: p.IntervalSec}
 	seen := map[string]bool{}
 	for _, w := range p.Widgets {
+		if w.Discover != nil {
+			// Not yet walked: the ceiling the preset agreed to, counted once
+			// per template. Deduplication cannot apply — the OIDs do not exist
+			// yet — so this is the only figure available before binding.
+			per := discoverInstanceLimit(w)
+			n := 0
+			for _, oid := range w.OIDs {
+				if strings.Contains(oid, InstancePlaceholder) {
+					n += per
+				} else if !seen[strings.TrimPrefix(oid, ".")] {
+					seen[strings.TrimPrefix(oid, ".")] = true
+					c.OIDs++
+				}
+			}
+			c.OIDs += n
+			c.Discovered += n
+			continue
+		}
 		for _, oid := range w.OIDs {
 			// Two widgets showing the same OID are polled once: the scheduler
 			// asks for a set, and counting it twice would overstate the cost
@@ -431,6 +478,13 @@ func PollOIDs(p Preset) []string {
 	out := []string{}
 	for _, w := range p.Widgets {
 		for _, oid := range w.OIDs {
+			// A template is not an OID. Expand() runs before this at bind time,
+			// so reaching one here means somebody polled an unexpanded preset —
+			// and "1.3.6.1.2.1.2.2.1.8.{#}" on the wire is a failure far from
+			// its cause.
+			if strings.Contains(oid, InstancePlaceholder) {
+				continue
+			}
 			key := strings.TrimPrefix(oid, ".")
 			if seen[key] {
 				continue

--- a/presets/cisco-generic.json
+++ b/presets/cisco-generic.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "name": "Cisco (IF-MIB)",
   "author": "SnmpLens",
-  "description": "The same interface view, matched to Cisco equipment so it is offered first when you add one. The OIDs are standard IF-MIB rather than CISCO-*: those load only once you have imported the vendor MIB, and this has to work before that.",
+  "description": "The interface view, matched to Cisco equipment so it is offered first when you add one. Ports and traffic are discovered when you bind it. The OIDs are standard IF-MIB rather than CISCO-*: those resolve only once the vendor MIB has been imported, and this has to work before that.",
   "match": {
     "vendor": "Cisco",
     "sysObjectIdPrefix": [
@@ -19,43 +19,10 @@
       ]
     },
     {
-      "kind": "rate",
-      "title": "Gi0/1 in",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.10.1"
-      ]
-    },
-    {
-      "kind": "rate",
-      "title": "Gi0/1 out",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.16.1"
-      ]
-    },
-    {
-      "kind": "chart",
-      "title": "Uplink traffic",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.10.1",
-        "1.3.6.1.2.1.2.2.1.16.1"
-      ]
-    },
-    {
       "kind": "grid",
       "title": "Ports",
       "oids": [
-        "1.3.6.1.2.1.2.2.1.8.1",
-        "1.3.6.1.2.1.2.2.1.8.2",
-        "1.3.6.1.2.1.2.2.1.8.3",
-        "1.3.6.1.2.1.2.2.1.8.4",
-        "1.3.6.1.2.1.2.2.1.8.5",
-        "1.3.6.1.2.1.2.2.1.8.6",
-        "1.3.6.1.2.1.2.2.1.8.7",
-        "1.3.6.1.2.1.2.2.1.8.8",
-        "1.3.6.1.2.1.2.2.1.8.9",
-        "1.3.6.1.2.1.2.2.1.8.10",
-        "1.3.6.1.2.1.2.2.1.8.11",
-        "1.3.6.1.2.1.2.2.1.8.12"
+        "1.3.6.1.2.1.2.2.1.8.{#}"
       ],
       "labels": {
         "1": "up",
@@ -65,6 +32,20 @@
         "5": "dormant",
         "6": "absent",
         "7": "lower layer down"
+      },
+      "discover": {
+        "walk": "1.3.6.1.2.1.2.2.1.2"
+      }
+    },
+    {
+      "kind": "chart",
+      "title": "Traffic",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.{#}",
+        "1.3.6.1.2.1.2.2.1.16.{#}"
+      ],
+      "discover": {
+        "walk": "1.3.6.1.2.1.2.2.1.2"
       }
     }
   ]

--- a/presets/host-resources.json
+++ b/presets/host-resources.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "name": "Server (HOST-RESOURCES-MIB)",
   "author": "SnmpLens",
-  "description": "Processor load, memory and disks of a server or workstation, from HOST-RESOURCES-MIB. The storage and processor indexes are per device: run a walk of 1.3.6.1.2.1.25.2.3.1.3 to see what yours calls them, and edit the instance numbers to match.",
+  "description": "Processor load and storage of a server or workstation, discovered when you bind it — the indexes differ from one machine to the next, which is exactly what a walk answers and a hand-written list cannot.",
   "intervalSec": 60,
   "widgets": [
     {
@@ -30,29 +30,22 @@
       "kind": "chart",
       "title": "Processor load",
       "oids": [
-        "1.3.6.1.2.1.25.3.3.1.2.1",
-        "1.3.6.1.2.1.25.3.3.1.2.2",
-        "1.3.6.1.2.1.25.3.3.1.2.3",
-        "1.3.6.1.2.1.25.3.3.1.2.4"
+        "1.3.6.1.2.1.25.3.3.1.2.{#}"
       ],
-      "unit": "%"
+      "unit": "%",
+      "discover": {
+        "walk": "1.3.6.1.2.1.25.3.3.1.2"
+      }
     },
     {
       "kind": "chart",
       "title": "Storage used",
       "oids": [
-        "1.3.6.1.2.1.25.2.3.1.6.1",
-        "1.3.6.1.2.1.25.2.3.1.6.2",
-        "1.3.6.1.2.1.25.2.3.1.6.3"
+        "1.3.6.1.2.1.25.2.3.1.6.{#}"
       ],
-      "unit": "allocation units"
-    },
-    {
-      "kind": "value",
-      "title": "Storage 1 size",
-      "oids": [
-        "1.3.6.1.2.1.25.2.3.1.5.1"
-      ]
+      "discover": {
+        "walk": "1.3.6.1.2.1.25.2.3.1.3"
+      }
     }
   ]
 }

--- a/presets/interfaces.json
+++ b/presets/interfaces.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "name": "Interfaces (IF-MIB)",
   "author": "SnmpLens",
-  "description": "Traffic and state of the first eight interfaces, from IF-MIB alone. Works on any agent that answers MIB-2, which is nearly all of them.",
+  "description": "Every interface the equipment reports, discovered when you bind it: their operational state as one wall, and the traffic of the first few as curves. IF-MIB only, so it answers on any agent that serves MIB-2.",
   "intervalSec": 60,
   "widgets": [
     {
@@ -20,49 +20,10 @@
       ]
     },
     {
-      "kind": "rate",
-      "title": "Interface 1 in",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.10.1"
-      ]
-    },
-    {
-      "kind": "rate",
-      "title": "Interface 1 out",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.16.1"
-      ]
-    },
-    {
-      "kind": "chart",
-      "title": "Interface 1 traffic",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.10.1",
-        "1.3.6.1.2.1.2.2.1.16.1"
-      ]
-    },
-    {
-      "kind": "chart",
-      "title": "Errors and discards, interface 1",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.14.1",
-        "1.3.6.1.2.1.2.2.1.20.1",
-        "1.3.6.1.2.1.2.2.1.13.1",
-        "1.3.6.1.2.1.2.2.1.19.1"
-      ]
-    },
-    {
       "kind": "grid",
       "title": "Operational state",
       "oids": [
-        "1.3.6.1.2.1.2.2.1.8.1",
-        "1.3.6.1.2.1.2.2.1.8.2",
-        "1.3.6.1.2.1.2.2.1.8.3",
-        "1.3.6.1.2.1.2.2.1.8.4",
-        "1.3.6.1.2.1.2.2.1.8.5",
-        "1.3.6.1.2.1.2.2.1.8.6",
-        "1.3.6.1.2.1.2.2.1.8.7",
-        "1.3.6.1.2.1.2.2.1.8.8"
+        "1.3.6.1.2.1.2.2.1.8.{#}"
       ],
       "labels": {
         "1": "up",
@@ -72,6 +33,31 @@
         "5": "dormant",
         "6": "absent",
         "7": "lower layer down"
+      },
+      "discover": {
+        "walk": "1.3.6.1.2.1.2.2.1.2"
+      }
+    },
+    {
+      "kind": "chart",
+      "title": "Traffic",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.10.{#}",
+        "1.3.6.1.2.1.2.2.1.16.{#}"
+      ],
+      "discover": {
+        "walk": "1.3.6.1.2.1.2.2.1.2"
+      }
+    },
+    {
+      "kind": "chart",
+      "title": "Errors",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.14.{#}",
+        "1.3.6.1.2.1.2.2.1.20.{#}"
+      ],
+      "discover": {
+        "walk": "1.3.6.1.2.1.2.2.1.2"
       }
     }
   ]

--- a/presets/switch-ports.json
+++ b/presets/switch-ports.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
-  "name": "Switch ports (24)",
+  "name": "Switch ports",
   "author": "SnmpLens",
-  "description": "A 24-port access switch: the two uplink counters as a chart, and every port's operational state as one wall. Standard IF-MIB only, so it works on any managed switch; edit the instance numbers if yours does not index its ports from 1.",
+  "description": "A switch seen as its ports: one cell per interface the equipment actually has, named as the equipment names them, plus the uplink counters. The ports are discovered when you bind it, so this fits a 24-port access switch and a 48-port chassis without being edited.",
   "intervalSec": 30,
   "widgets": [
     {
@@ -11,6 +11,25 @@
       "oids": [
         "1.3.6.1.2.1.1.3.0"
       ]
+    },
+    {
+      "kind": "grid",
+      "title": "Ports",
+      "oids": [
+        "1.3.6.1.2.1.2.2.1.8.{#}"
+      ],
+      "labels": {
+        "1": "up",
+        "2": "down",
+        "3": "testing",
+        "4": "unknown",
+        "5": "dormant",
+        "6": "absent",
+        "7": "lower layer down"
+      },
+      "discover": {
+        "walk": "1.3.6.1.2.1.2.2.1.2"
+      }
     },
     {
       "kind": "rate",
@@ -33,45 +52,6 @@
         "1.3.6.1.2.1.2.2.1.10.1",
         "1.3.6.1.2.1.2.2.1.16.1"
       ]
-    },
-    {
-      "kind": "grid",
-      "title": "Ports",
-      "oids": [
-        "1.3.6.1.2.1.2.2.1.8.1",
-        "1.3.6.1.2.1.2.2.1.8.2",
-        "1.3.6.1.2.1.2.2.1.8.3",
-        "1.3.6.1.2.1.2.2.1.8.4",
-        "1.3.6.1.2.1.2.2.1.8.5",
-        "1.3.6.1.2.1.2.2.1.8.6",
-        "1.3.6.1.2.1.2.2.1.8.7",
-        "1.3.6.1.2.1.2.2.1.8.8",
-        "1.3.6.1.2.1.2.2.1.8.9",
-        "1.3.6.1.2.1.2.2.1.8.10",
-        "1.3.6.1.2.1.2.2.1.8.11",
-        "1.3.6.1.2.1.2.2.1.8.12",
-        "1.3.6.1.2.1.2.2.1.8.13",
-        "1.3.6.1.2.1.2.2.1.8.14",
-        "1.3.6.1.2.1.2.2.1.8.15",
-        "1.3.6.1.2.1.2.2.1.8.16",
-        "1.3.6.1.2.1.2.2.1.8.17",
-        "1.3.6.1.2.1.2.2.1.8.18",
-        "1.3.6.1.2.1.2.2.1.8.19",
-        "1.3.6.1.2.1.2.2.1.8.20",
-        "1.3.6.1.2.1.2.2.1.8.21",
-        "1.3.6.1.2.1.2.2.1.8.22",
-        "1.3.6.1.2.1.2.2.1.8.23",
-        "1.3.6.1.2.1.2.2.1.8.24"
-      ],
-      "labels": {
-        "1": "up",
-        "2": "down",
-        "3": "testing",
-        "4": "unknown",
-        "5": "dormant",
-        "6": "absent",
-        "7": "lower layer down"
-      }
     }
   ]
 }


### PR DESCRIPTION
The five presets that shipped in #48 enumerated `1.3.6.1.2.1.2.2.1.8.1` through `.24` by hand, and said so in their own descriptions: *"edit the instance numbers if yours does not index from 1"*. That is an admission rather than a note — a preset written for a 24-port switch is a preset for exactly one shape of switch, and a library of those is not shareable.

A widget may now say **where** its instances come from instead of listing them:

```json
{"kind": "grid", "title": "Ports",
 "oids": ["1.3.6.1.2.1.2.2.1.8.{#}"],
 "discover": {"walk": "1.3.6.1.2.1.2.2.1.2"}}
```

Four of the five shipped presets were rewritten that way. `ups.json` reads scalars and needed nothing.

## The walk happens at bind time and nowhere else

What is stored afterwards is a plain preset with concrete OIDs, so the poll path stays GET-only, the cost is arithmetic before the first tick, and `pkg/monitor`'s overrun guardrail sees no difference at all. Nothing about discovery survives into polling.

One walk per **column**, not per widget: a grid of port states and a chart of port counters both discover from ifDescr, and that is one walk.

The walked column is the **label** source as well as the instance source, which is half of why it is worth its round trip — walking ifDescr answers "which interfaces exist" and "what the equipment calls them" together, so a discovered grid reads `Gi0/1` rather than `8`.

## Four rules, each a defect in the version without it

- **A walk that fails refuses the bind.** An empty instance list expands every template to nothing, and what the operator would get is a session that looks bound, polls whatever scalars the preset also had, and draws empty widgets. The error names the column, because "bind failed" sends someone to read the preset when the problem is the community or an ACL.
- **The expanded preset is validated again.** The walk decides how many OIDs there are, so a device with four hundred interfaces pushes a preset past a sanity bound its author never came close to.
- **Two bounds meet on each widget and the smaller wins:** the walk bound (128, or the preset's own `max`), and the kind's own `MaxOIDs`, which is what it can actually draw. Discovering 128 states for a grid that renders 96 is polling 32 readings nobody sees. The consequence worth stating rather than working around: a chart is capped at eight series by the colour plan, so a chart discovering an in and an out counter shows **four** ports.
- **`preset.Cost` is a ceiling once anything is discovered**, and the settings screen now says so. A figure presented as a count that is really an upper bound is worse than no figure.

## Measured

Against the bundled simulator, binding the port preset discovers its five interfaces, names every cell from ifDescr, and leaves no template behind:

```
$ python tools/snmp_test_agent.py --port 11611 --no-traps
$ SNMPLENS_TEST_AGENT=127.0.0.1:11611 go test . -run Integration -v
    app_presetdiscover_test.go:120: discovered 5 interface(s)
--- PASS: TestPresetDiscoveryIntegration (0.14s)
```

That one skips without the variable, the way `pkg/monitor`'s do. The refusal path and the "a preset that lists its OIDs is never walked" path run everywhere.

## Also

The bar in `app_bundledpresets_test.go` allowed two requests a round. That was right for hand-listed presets and is not a statement about a preset whose count is decided by the equipment: it is now eight requests a round **at the ceiling**, plus a check that a preset which discovers says so in its description.

Gate: `go vet`, `go test -race`, `staticcheck`, `go mod tidy`, `npm test`, `npm run check`, `npm run build` — all clean.
