### PR TITLE
Let a preset say what it thinks is too much

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -662,6 +662,48 @@ placed it at the top — which is how a preset is ordinarily edited.
 Every shipped preset arranges itself, and that is a test rather than a habit: these are the files somebody copies
 to write their own, and the reflowing fallback looks identical to a layout that failed to load.
 
+### What the preset thinks is too much
+
+`PresetBind` passed `nil` where the session's thresholds go, with a comment saying a preset describes what to
+WATCH and that what counts as too much is the operator's judgement about their own network. That is true of a
+percentage on a link the author has never seen and false of most of what a preset is written for: a UPS running
+on anything but mains, a battery reporting low, a disk at 95%. Those are properties of the MIB, and the author
+knows them better than whoever binds the file.
+
+So a widget may carry `"threshold": {"min": 30, "max": 90, "forSeconds": 300}`, and binding MATERIALISES it into
+the session's own threshold map — the same column `MonitorCreateSession` fills, read by the same evaluator.
+Nothing new evaluates anything; a preset fills in a form the operator would otherwise fill in by hand and can
+edit afterwards. The band is per WIDGET, not per OID, because that is what makes it writeable for a discovering
+preset: "no port may be anything but up" is one statement about however many ports the walk turns up.
+
+Three facts decide the shape, and all three are read out of the code rather than assumed.
+
+**The evaluator compares the RAW reading.** `Sample.Value` is what was polled; `Rate` is derived for the chart
+and the tile and is never evaluated. So a band on a counter is a band on a number that only goes up — it fires on
+the first sample and never resolves. A `rate` widget SAYS its OID is a counter, so that one kind is refused
+outright; a chart of counters cannot be detected and is left to the author.
+
+**`alertEnabled` is not "notify", it is "evaluate at all".** `classify` returns nothing without it, in
+`pkg/monitor/breach.go` and in `utils/thresholdAlerts.js` alike: no episode, no journal entry, nothing. The band
+is still drawn on the chart as a reference line, and that is its whole effect. Since `encoding/json` decodes an
+absent bool to false, a plain `bool` would make every threshold an author writes the obvious way INERT, with the
+dashboard looking exactly as though it were armed. Hence `AlertEnabled *bool` and `Alerts()`: **absent means
+yes**, and false has to be written on purpose.
+
+**A reading can carry one band.** The session holds one map keyed by OID, so two widgets watching the same OID
+with different bands is a question with no answer — the later one would win silently and the earlier widget would
+be drawn under a rule not applied to it. Identical bands are one band and are fine; that is the ordinary case of
+a tile and a chart showing the same reading.
+
+`Cost` counts `Watched` and `Alerting`, and the settings screen states them before binding beside the request
+count. That is the same gate the traffic goes through: an evaluated band raises an incident, which the operator's
+own notification rules may route to a sink, so the file reaching outside the machine is said out loud first.
+
+Two of the five shipped presets watch something, and the three interface ones deliberately do not. `ifOperStatus`
+looks like the obvious candidate and is the wrong one: most ports of a real access switch are legitimately down,
+so a band there opens an episode per unused port the moment the preset is bound — and everything those presets
+chart is a counter.
+
 ### Binding, and the snapshot rule
 
 `PresetBind` creates **one session per target**, never one session across several: the cost was stated per

--- a/app_bundledpresets_test.go
+++ b/app_bundledpresets_test.go
@@ -76,6 +76,13 @@ func TestEveryBundledPresetIsValid(t *testing.T) {
 		if c.Discovered > 0 && !strings.Contains(strings.ToLower(p.Description), "discover") {
 			t.Errorf("%s discovers its instances and its description does not say so", e.Name())
 		}
+		// A band that is evaluated raises an incident, which the operator's own
+		// rules may route to a sink. Binding one of these is a decision, and it
+		// is made from the description in the library list — where the cost
+		// screen has not been opened yet.
+		if c.Alerting > 0 && !strings.Contains(strings.ToLower(p.Description), "watch") {
+			t.Errorf("%s arms %d incident(s) and its description does not say so", e.Name(), c.Alerting)
+		}
 
 		// Every shipped preset ARRANGES itself. These are the files somebody
 		// copies to write their own, so a library where none of them places a

--- a/app_preset.go
+++ b/app_preset.go
@@ -584,9 +584,18 @@ func (a *App) PresetBind(fileName, target, snmpVersion string, conn MonitorConne
 	id, err := a.storage.CreateSession(
 		name, strings.Join(oids, ","), []string{target},
 		p.IntervalSec*1000, snmpVersion, now,
-		// No thresholds: a preset describes what to WATCH, and what counts as
-		// too much is the operator's judgement about their own network.
-		nil, sessConn,
+		// The bands the preset carries, materialised into the session's OWN
+		// threshold map — the same column MonitorCreateSession fills and the
+		// same one the evaluator reads. Nothing new evaluates anything, and the
+		// operator can edit them afterwards like any other session's.
+		//
+		// This used to be nil, with a comment saying what counts as too much is
+		// the operator's judgement about their own network. That is true of a
+		// percentage on a link the author has never seen and false of what a
+		// preset is mostly written for: a port that is not up(1), a UPS running
+		// on battery. Those are properties of the MIB, and the author knows
+		// them better than whoever binds the file.
+		presetThresholds(p), sessConn,
 		&storage.SessionPreset{
 			File:          filepath.Base(path),
 			Name:          p.Name,
@@ -636,6 +645,29 @@ func presetCost(p preset.Preset) PresetCost {
 	// Ceiling: thirty-one OIDs is two requests, not one and a bit.
 	perRound := (c.OIDs + snmp.MaxVarbindsPerGet - 1) / snmp.MaxVarbindsPerGet
 	out.RequestsPerDay = c.PollsPerDay * perRound
+	return out
+}
+
+// presetThresholds turns the bands a preset carries into the map a session
+// stores, keyed by the full OID exactly as MonitorCreateSession's is.
+//
+// Called AFTER discovery, so a widget that watches its ports watches the ports
+// the equipment turned out to have. nil when the preset carries none, which is
+// the same value the column held before presets could carry any — a session
+// with an empty map and one with no map behave identically, and nil is the one
+// storage already knows.
+func presetThresholds(p preset.Preset) map[string]*storage.Thresholds {
+	bands := preset.ThresholdsFor(p)
+	if len(bands) == 0 {
+		return nil
+	}
+	out := make(map[string]*storage.Thresholds, len(bands))
+	for oid, b := range bands {
+		out[oid] = &storage.Thresholds{
+			Min: b.Min, Max: b.Max,
+			ForSeconds: b.ForSeconds, AlertEnabled: b.Alerts(),
+		}
+	}
 	return out
 }
 

--- a/app_presetthreshold_test.go
+++ b/app_presetthreshold_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"testing"
+)
+
+// A preset carrying a band ends up watching, through the ordinary path.
+//
+// The mistake this catches is materialising the bands into the SNAPSHOT alone.
+// The dashboard would draw them, the detail screen would count them, and the
+// evaluator — which reads sess.Thresholds and nothing else — would never
+// compare a single reading. A monitoring that looks armed and is not is worse
+// than one that plainly is not.
+func TestBindingMaterialisesThePresetsThresholds(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ups.json", `{
+	  "formatVersion": 1, "name": "UPS", "intervalSec": 60,
+	  "widgets": [
+	    {"kind": "status", "title": "Battery", "oids": ["1.3.6.1.2.1.33.1.2.1.0"],
+	     "labels": {"1": "unknown", "2": "normal", "3": "low"},
+	     "threshold": {"max": 2, "forSeconds": 120, "alertEnabled": true}},
+	    {"kind": "value", "title": "Charge", "oids": [".1.3.6.1.2.1.33.1.2.4.0"],
+	     "unit": "%", "threshold": {"min": 20}},
+	    {"kind": "chart", "title": "Line", "oids": ["1.3.6.1.2.1.33.1.2.5.0"],
+	     "threshold": {"min": 228, "alertEnabled": false}},
+	    {"kind": "value", "title": "Uptime", "oids": ["1.3.6.1.2.1.1.3.0"]}
+	  ]
+	}`)
+
+	sess, err := a.PresetBind("ups.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161, TimeoutSec: 2})
+	if err != nil {
+		t.Fatalf("PresetBind: %v", err)
+	}
+
+	if len(sess.Thresholds) != 3 {
+		t.Fatalf("%d band(s) on the session, want 3: %v", len(sess.Thresholds), sess.Thresholds)
+	}
+	// Keyed by the FULL OID without its leading dot — the same key the poll
+	// results carry, or the lookup silently finds nothing.
+	battery := sess.Thresholds["1.3.6.1.2.1.33.1.2.1.0"]
+	if battery == nil || battery.Max == nil || *battery.Max != 2 {
+		t.Fatalf("the battery band did not survive: %+v", battery)
+	}
+	if battery.ForSeconds != 120 || !battery.AlertEnabled {
+		t.Errorf("the hold or the alert flag was dropped: %+v", battery)
+	}
+	charge := sess.Thresholds["1.3.6.1.2.1.33.1.2.4.0"]
+	if charge == nil || charge.Min == nil || *charge.Min != 20 {
+		t.Errorf("a leading dot lost a band: %v", sess.Thresholds)
+	}
+	// The flag was OMITTED on that widget, and omitted means yes. A plain bool
+	// would have decoded it to false, which does not mean "notify me less" —
+	// classify() returns nothing without it, so the band would be compared to
+	// nothing at all while the dashboard looked armed.
+	if charge != nil && !charge.AlertEnabled {
+		t.Error("an omitted alertEnabled disarmed the band")
+	}
+	// Explicitly off, on the other hand, is the reference line: stored, drawn,
+	// never evaluated.
+	if line := sess.Thresholds["1.3.6.1.2.1.33.1.2.5.0"]; line == nil || line.AlertEnabled {
+		t.Errorf("an explicit alertEnabled:false was not honoured: %+v", line)
+	}
+	if _, watched := sess.Thresholds["1.3.6.1.2.1.1.3.0"]; watched {
+		t.Error("a widget with no band came back watched")
+	}
+
+	// And the shape the evaluator is actually handed.
+	spec := a.specFor(sess)
+	if len(spec.Thresholds) != 3 {
+		t.Fatalf("the poll clock would evaluate %d band(s)", len(spec.Thresholds))
+	}
+	if th := spec.Thresholds["1.3.6.1.2.1.33.1.2.1.0"]; th == nil || !th.AlertEnabled {
+		t.Errorf("the evaluator's copy is not the preset's: %+v", th)
+	}
+}
+
+// A preset that carries no band is bound exactly as it was before presets could
+// carry any: nil, not an empty map that reads as "watched, with no rules".
+func TestAPresetWithoutBandsWatchesNothing(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "ok.json", goodPreset)
+
+	sess, err := a.PresetBind("ok.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161})
+	if err != nil {
+		t.Fatalf("PresetBind: %v", err)
+	}
+	if len(sess.Thresholds) != 0 {
+		t.Errorf("%d band(s) invented: %v", len(sess.Thresholds), sess.Thresholds)
+	}
+}
+
+// A band the format refuses stops the bind, like any other problem: binding is
+// the step that puts traffic on somebody's network AND arms notifications, and
+// doing either from a file this application has said it does not understand is
+// not a thing to do quietly.
+func TestABrokenBandCannotBeBound(t *testing.T) {
+	a, dir := newBindApp(t)
+	putPreset(t, dir, "bad.json", `{
+	  "formatVersion": 1, "name": "Bad band", "intervalSec": 60,
+	  "widgets": [
+	    {"kind": "rate", "title": "In", "oids": ["1.3.6.1.2.1.2.2.1.10.1"],
+	     "threshold": {"max": 1000000, "alertEnabled": true}}
+	  ]
+	}`)
+
+	if _, err := a.PresetBind("bad.json", "10.0.0.1", "v2c", MonitorConnection{Port: 161}); err == nil {
+		t.Fatal("a band on a counter was bound")
+	}
+	if sessions, _ := a.storage.ListSessions(); len(sessions) != 0 {
+		t.Errorf("%d session(s) left behind", len(sessions))
+	}
+}

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1160,9 +1160,15 @@
       "placeholderWithoutDiscover": "Diese OID enthält einen Instanz-Platzhalter, aber das Widget sagt nicht, wo seine Instanzen zu finden sind.",
       "discoverWithoutPlaceholder": "Dieses Widget ermittelt seine Instanzen, doch keine OID enthält {placeholder} — der Walk wäre umsonst.",
       "layoutOverflow": "Spalte {x} mit Breite {w} reicht über das {columns}-Spalten-Raster hinaus.",
-      "layoutOverlap": "Dies liegt über Widget {other}, wodurch eines von beiden verdeckt würde."
+      "layoutOverlap": "Dies liegt über Widget {other}, wodurch eines von beiden verdeckt würde.",
+      "thresholdWithoutBound": "Ein Schwellenwert braucht ein Minimum, ein Maximum oder beides — ohne beides kann er nie auslösen.",
+      "thresholdInverted": "Das Minimum ({min}) liegt über dem Maximum ({max}); kein Messwert kann im Band liegen.",
+      "thresholdOnRate": "Ein Schwellenwert wird mit dem Rohwert verglichen, und ein „{kind}“-Widget zeigt einen Zähler: Das Band wäre schon beim ersten Messwert verletzt und nie wieder eingehalten.",
+      "thresholdConflict": "Widget {other} überwacht {oid} bereits mit einem anderen Band, und ein Messwert kann nur eines haben."
     },
-    "costAtMost": "Höchstens — {discovered} dieser OIDs werden beim Binden auf dem Gerät ermittelt; die echten Zahlen stehen dann fest und können nur niedriger sein."
+    "costAtMost": "Höchstens — {discovered} dieser OIDs werden beim Binden auf dem Gerät ermittelt; die echten Zahlen stehen dann fest und können nur niedriger sein.",
+    "costWatched": "Schwellenwerte",
+    "costAlerts": "{alerting} davon werden ausgewertet und lösen bei Verletzung einen Vorfall aus, den Ihre Benachrichtigungsregeln an ein Ziel weiterleiten können; die übrigen sind nur eine Referenzlinie."
   },
   "dashboard": {
     "empty": "Noch kein Dashboard.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1160,9 +1160,15 @@
       "placeholderWithoutDiscover": "This OID carries an instance placeholder, but the widget does not say where to discover its instances.",
       "discoverWithoutPlaceholder": "This widget discovers its instances but no OID carries {placeholder}, so the walk would be paid for and thrown away.",
       "layoutOverflow": "Column {x} with a width of {w} runs past the {columns}-column grid.",
-      "layoutOverlap": "This is placed on top of widget {other}, which would hide one of them."
+      "layoutOverlap": "This is placed on top of widget {other}, which would hide one of them.",
+      "thresholdWithoutBound": "A threshold needs a minimum, a maximum, or both — with neither it can never fire.",
+      "thresholdInverted": "The minimum ({min}) is above the maximum ({max}), so no reading can be inside the band.",
+      "thresholdOnRate": "A threshold is compared against the raw reading, and a \"{kind}\" widget shows a counter: the band would be breached on the first sample and never recover.",
+      "thresholdConflict": "Widget {other} already watches {oid} with a different band, and a reading can only have one."
     },
-    "costAtMost": "At most — {discovered} of these OIDs are discovered on the equipment when you bind it, so the real figures are known then and can only be lower."
+    "costAtMost": "At most — {discovered} of these OIDs are discovered on the equipment when you bind it, so the real figures are known then and can only be lower.",
+    "costWatched": "Thresholds",
+    "costAlerts": "{alerting} of them are evaluated and raise an incident when breached, which your notification rules may then route to a sink; any others are drawn as a reference line only."
   },
   "dashboard": {
     "empty": "No dashboard yet.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1160,9 +1160,15 @@
       "placeholderWithoutDiscover": "Este OID lleva un marcador de instancia, pero el widget no indica dónde descubrir sus instancias.",
       "discoverWithoutPlaceholder": "Este widget descubre sus instancias pero ningún OID lleva {placeholder}, así que el walk se pagaría en vano.",
       "layoutOverflow": "La columna {x} con una anchura de {w} se sale de la rejilla de {columns} columnas.",
-      "layoutOverlap": "Esto se coloca encima del widget {other}, lo que ocultaría uno de los dos."
+      "layoutOverlap": "Esto se coloca encima del widget {other}, lo que ocultaría uno de los dos.",
+      "thresholdWithoutBound": "Un umbral necesita un mínimo, un máximo o ambos: sin ninguno no puede activarse nunca.",
+      "thresholdInverted": "El mínimo ({min}) es mayor que el máximo ({max}), así que ninguna lectura puede estar dentro del rango.",
+      "thresholdOnRate": "Un umbral se compara con la lectura en bruto, y un widget «{kind}» muestra un contador: el rango se superaría en la primera muestra y no se recuperaría nunca.",
+      "thresholdConflict": "El widget {other} ya vigila {oid} con otro rango, y una lectura solo puede tener uno."
     },
-    "costAtMost": "Como máximo — {discovered} de estos OID se descubren en el equipo al vincularlo, así que las cifras reales se conocen entonces y solo pueden ser menores."
+    "costAtMost": "Como máximo — {discovered} de estos OID se descubren en el equipo al vincularlo, así que las cifras reales se conocen entonces y solo pueden ser menores.",
+    "costWatched": "Umbrales",
+    "costAlerts": "{alerting} de ellos se evalúan y abren un incidente al superarse, que sus reglas de notificación pueden enrutar a un destino; los demás son solo una línea de referencia."
   },
   "dashboard": {
     "empty": "Aún no hay panel.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1160,9 +1160,15 @@
       "placeholderWithoutDiscover": "Cet OID porte un marqueur d'instance, mais le widget n'indique pas où découvrir ses instances.",
       "discoverWithoutPlaceholder": "Ce widget découvre ses instances mais aucun OID ne porte {placeholder} : le walk serait payé pour rien.",
       "layoutOverflow": "La colonne {x} avec une largeur de {w} dépasse la grille de {columns} colonnes.",
-      "layoutOverlap": "Ceci est placé par-dessus le widget {other}, ce qui en masquerait un des deux."
+      "layoutOverlap": "Ceci est placé par-dessus le widget {other}, ce qui en masquerait un des deux.",
+      "thresholdWithoutBound": "Un seuil a besoin d’un minimum, d’un maximum ou des deux : sans aucun, il ne peut jamais se déclencher.",
+      "thresholdInverted": "Le minimum ({min}) est supérieur au maximum ({max}) : aucune valeur ne peut se trouver dans la plage.",
+      "thresholdOnRate": "Un seuil est comparé à la valeur brute, et un widget « {kind} » affiche un compteur : la plage serait dépassée dès la première mesure et ne reviendrait jamais.",
+      "thresholdConflict": "Le widget {other} surveille déjà {oid} avec une autre plage, et une valeur ne peut en avoir qu’une."
     },
-    "costAtMost": "Au plus — {discovered} de ces OID sont découverts sur l'équipement au moment de la liaison : les chiffres réels sont connus à ce moment-là et ne peuvent qu'être inférieurs."
+    "costAtMost": "Au plus — {discovered} de ces OID sont découverts sur l'équipement au moment de la liaison : les chiffres réels sont connus à ce moment-là et ne peuvent qu'être inférieurs.",
+    "costWatched": "Seuils",
+    "costAlerts": "{alerting} d’entre eux sont évalués et ouvrent un incident en cas de dépassement, que vos règles de notification peuvent ensuite router vers une destination ; les autres ne sont qu’une ligne de repère."
   },
   "dashboard": {
     "empty": "Aucun tableau de bord pour l'instant.",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1160,9 +1160,15 @@
       "placeholderWithoutDiscover": "此 OID 含有实例占位符，但该部件未说明到哪里发现其实例。",
       "discoverWithoutPlaceholder": "此部件会发现实例，但没有 OID 含有 {placeholder}，这次 walk 将白白付出代价。",
       "layoutOverflow": "列 {x} 加上宽度 {w} 超出了 {columns} 列网格。",
-      "layoutOverlap": "它被放置在部件 {other} 之上，会遮挡其中之一。"
+      "layoutOverlap": "它被放置在部件 {other} 之上，会遮挡其中之一。",
+      "thresholdWithoutBound": "阈值需要最小值、最大值或两者：都没有时它永远不会触发。",
+      "thresholdInverted": "最小值 {min} 大于最大值 {max}，任何读数都无法落在区间内。",
+      "thresholdOnRate": "阈值与原始读数比较，而“{kind}”部件显示的是计数器：第一次采样就会越界且永不恢复。",
+      "thresholdConflict": "部件 {other} 已用另一个区间监视 {oid}，而一个读数只能有一个区间。"
     },
-    "costAtMost": "至多如此 —— 其中 {discovered} 个 OID 在绑定时于设备上发现，实际数字届时确定，且只会更少。"
+    "costAtMost": "至多如此 —— 其中 {discovered} 个 OID 在绑定时于设备上发现，实际数字届时确定，且只会更少。",
+    "costWatched": "阈值",
+    "costAlerts": "其中 {alerting} 个会被评估，越界时开启事件，您的通知规则可将其路由到目标；其余仅作为参考线绘制。"
   },
   "dashboard": {
     "empty": "尚无仪表板。",

--- a/frontend/src/settings/PresetSettings.svelte
+++ b/frontend/src/settings/PresetSettings.svelte
@@ -169,7 +169,20 @@
                   <div><span class="k">{$_('preset.costCadence')}</span><span class="v">{formatCadence(detail.cost.intervalSec * 1000)}</span></div>
                   <div><span class="k">{$_('preset.costRequests')}</span><span class="v">{detail.cost.requestsPerDay}</span></div>
                   <div><span class="k">{$_('preset.costVarbinds')}</span><span class="v">{detail.cost.varbindsPerDay}</span></div>
+                  {#if detail.cost.watched > 0}
+                    <div><span class="k">{$_('preset.costWatched')}</span><span class="v">{detail.cost.watched}</span></div>
+                  {/if}
                 </div>
+                {#if detail.cost.alerting > 0}
+                  <!-- The one thing on this screen that is not about this
+                       machine: a band that alerts sends mail, or POSTs to a
+                       webhook, when it is breached. Said BEFORE binding, beside
+                       the request count, because the gate is the same one — the
+                       operator sees what the file will do before it does it. -->
+                  <p class="hint at-most">
+                    {$_('preset.costAlerts', { values: { alerting: detail.cost.alerting } })}
+                  </p>
+                {/if}
                 {#if detail.cost.discovered > 0}
                   <!-- A discovering preset does not know how many instances the
                        equipment has, so every figure above is a CEILING: the

--- a/pkg/preset/preset.go
+++ b/pkg/preset/preset.go
@@ -211,6 +211,11 @@ type Widget struct {
 	// own name rather than its index. Written by expansion, never by an author:
 	// a hand-written preset titles its own widgets.
 	OIDLabels map[string]string `json:"oidLabels,omitempty"`
+	// Threshold is the band this widget's readings should stay inside. It is
+	// materialised into the session's own threshold map at bind time and read
+	// by the ordinary evaluator; see threshold.go for what it can and cannot
+	// be put on.
+	Threshold *Threshold `json:"threshold,omitempty"`
 	// Layout is where this widget goes on the twelve-column grid. Optional and
 	// per widget: a preset that places nothing keeps the reflowing list of
 	// cards, and one that places some widgets lets the browser find room for
@@ -357,6 +362,7 @@ func Validate(p Preset) []Error {
 		}
 		errs = append(errs, checkDiscovery(at, w)...)
 		errs = append(errs, checkLayout(at+".layout", w.Layout)...)
+		errs = append(errs, checkThreshold(at+".threshold", w.Kind, w.Threshold)...)
 		// A discovering widget contributes its BOUND, not its template count:
 		// the sanity limit has to hold after the walk, and the walk happens on
 		// equipment nobody has seen yet.
@@ -382,9 +388,10 @@ func Validate(p Preset) []Error {
 		}
 	}
 
-	// After the loop, because an overlap is a relationship between two widgets
-	// rather than a property of either one.
+	// After the loop, because both of these are relationships BETWEEN widgets
+	// rather than properties of either one.
 	errs = append(errs, checkLayoutOverlaps(p.Widgets)...)
+	errs = append(errs, checkThresholdConflicts(p.Widgets)...)
 
 	if total > MaxOIDsPerPreset {
 		errs = append(errs, errf("widgets", "tooManyOids", map[string]string{
@@ -432,6 +439,15 @@ type Cost struct {
 	// takes depends on the transport's chunk size, which is pkg/snmp's to know
 	// and not this package's — a copy of it here is a copy that drifts.
 	VarbindsPerDay int `json:"varbindsPerDay"`
+	// Watched is how many readings carry a band, and Alerting how many of those
+	// route an episode to the notification sinks.
+	//
+	// Alerting is the one figure here that is not about this machine: a preset
+	// with it set will, on a breach, send mail or POST to a webhook the operator
+	// configured. That is the file reaching outside, so it is stated before
+	// binding beside the request count rather than discovered afterwards.
+	Watched  int `json:"watched"`
+	Alerting int `json:"alerting"`
 }
 
 // secondsPerDay is the base Estimate divides. Equal to MaxIntervalSec, and
@@ -441,38 +457,49 @@ const secondsPerDay = 86400
 // Estimate reports what one target bound to this preset will ask for.
 func Estimate(p Preset) Cost {
 	c := Cost{Widgets: len(p.Widgets), IntervalSec: p.IntervalSec}
-	seen := map[string]bool{}
+	// Two widgets showing the same OID are polled once: the scheduler asks for
+	// a SET, and counting it twice would overstate the cost of exactly the
+	// presets that are well written. The watched set is counted separately
+	// because a band and a reading are different things to deduplicate — one
+	// widget may watch an OID that another merely draws.
+	seen, watched := map[string]bool{}, map[string]bool{}
+
 	for _, w := range p.Widgets {
+		per := 0
 		if w.Discover != nil {
 			// Not yet walked: the ceiling the preset agreed to, counted once
 			// per template. Deduplication cannot apply — the OIDs do not exist
 			// yet — so this is the only figure available before binding.
-			per := discoverInstanceLimit(w)
-			n := 0
-			for _, oid := range w.OIDs {
-				if strings.Contains(oid, InstancePlaceholder) {
-					n += per
-				} else if !seen[strings.TrimPrefix(oid, ".")] {
-					seen[strings.TrimPrefix(oid, ".")] = true
-					c.OIDs++
-				}
-			}
-			c.OIDs += n
-			c.Discovered += n
-			continue
+			per = discoverInstanceLimit(w)
 		}
 		for _, oid := range w.OIDs {
-			// Two widgets showing the same OID are polled once: the scheduler
-			// asks for a set, and counting it twice would overstate the cost
-			// of exactly the presets that are well written.
-			key := strings.TrimPrefix(oid, ".")
-			if seen[key] {
-				continue
+			n := 1
+			key := normaliseOID(oid)
+			if hasPlaceholder(oid) {
+				if per == 0 {
+					continue
+				}
+				n = per
+				key = "" // a template is never the same reading twice
 			}
-			seen[key] = true
-			c.OIDs++
+
+			if key == "" || !seen[key] {
+				seen[key] = true
+				c.OIDs += n
+				if key == "" {
+					c.Discovered += n
+				}
+			}
+			if w.Threshold != nil && (key == "" || !watched[key]) {
+				watched[key] = true
+				c.Watched += n
+				if w.Threshold.Alerts() {
+					c.Alerting += n
+				}
+			}
 		}
 	}
+
 	if c.IntervalSec <= 0 {
 		return c
 	}
@@ -492,10 +519,10 @@ func PollOIDs(p Preset) []string {
 			// so reaching one here means somebody polled an unexpanded preset —
 			// and "1.3.6.1.2.1.2.2.1.8.{#}" on the wire is a failure far from
 			// its cause.
-			if strings.Contains(oid, InstancePlaceholder) {
+			if hasPlaceholder(oid) {
 				continue
 			}
-			key := strings.TrimPrefix(oid, ".")
+			key := normaliseOID(oid)
 			if seen[key] {
 				continue
 			}
@@ -505,6 +532,17 @@ func PollOIDs(p Preset) []string {
 	}
 	return out
 }
+
+// hasPlaceholder reports whether an OID is a discovery TEMPLATE rather than an
+// address. One rule, because three places ask: validation substitutes an
+// instance before checking it, PollOIDs refuses to put one on the wire, and a
+// threshold cannot be keyed by an OID that does not exist yet.
+func hasPlaceholder(oid string) bool { return strings.Contains(oid, InstancePlaceholder) }
+
+// normaliseOID is the form an OID is keyed and polled by. ".1.3.6.1" and
+// "1.3.6.1" are the same reading, and a map keyed by the raw string would hold
+// two entries for it — so the leading dot comes off once, here.
+func normaliseOID(oid string) string { return strings.TrimPrefix(oid, ".") }
 
 // checkText bounds a LABEL. checkProse bounds the one field that is a
 // paragraph; both refuse control characters, which is the half that is about

--- a/pkg/preset/threshold.go
+++ b/pkg/preset/threshold.go
@@ -1,0 +1,198 @@
+package preset
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// Thresholds: what the preset's author thinks is too much.
+//
+// The first version deliberately carried none, with a comment saying that what
+// counts as too much is the operator's judgement about their own network. That
+// is true of a percentage on a link the author has never seen and false of
+// almost everything else a preset is written for: a port that is not up(1), a
+// UPS running on battery, a disk at 95%. Those are properties of the MIB, not
+// of the network, and the person who wrote the preset knows them better than
+// the person binding it.
+//
+// So a widget may carry a band, and binding materialises it into the session's
+// own threshold map — the same column MonitorCreateSession fills, read by the
+// same evaluator. Nothing new evaluates anything; a preset simply fills in a
+// form the operator would otherwise fill in by hand, and can then edit.
+//
+// Two facts decide the whole shape of this, and both are measured rather than
+// assumed:
+//
+//   - The evaluator compares Sample.Value, which is the RAW reading. Rate is
+//     derived for the chart and the tile and is never evaluated. So a band on a
+//     counter is a band on a number that only goes up: it fires on the first
+//     sample and never resolves. A `rate` widget SAYS its OID is a counter, so
+//     that one is refused here rather than discovered in production.
+//   - AlertEnabled does not mean "notify"; it is the switch that decides
+//     whether the band is EVALUATED AT ALL. `classify` returns nothing without
+//     it, in Go and in the renderer alike, so a band with it off opens no
+//     episode and records nothing — it is drawn on the chart as a reference
+//     line and that is the whole of its effect. An omitted field decoding to
+//     false would therefore make every threshold an author writes inert, with
+//     the dashboard looking exactly as though it were armed. Hence a POINTER,
+//     and hence Alerts() below: absent means yes.
+//
+// An evaluated band raises an incident, which the operator's own notification
+// rules may then route to a sink. That is the preset reaching outside the
+// machine, so it is COUNTED IN THE COST and stated before binding, beside the
+// request count — the same gate the traffic goes through.
+
+// MaxThresholdHoldSec bounds ForSeconds.
+//
+// A day, matching MaxIntervalSec: a hold longer than that is not a hold, it is
+// a threshold that never fires, and the author meant something else.
+const MaxThresholdHoldSec = 86400
+
+// Threshold is a band one widget's readings should stay inside.
+//
+// The field names are storage.Thresholds', deliberately: the same vocabulary in
+// the file, in the database and in the evaluator means one thing to learn and
+// nothing to translate.
+type Threshold struct {
+	// Min and Max are the band. At least one is required — a band with no
+	// bound is a threshold that cannot fire, which is not a default, it is a
+	// mistake with no symptom.
+	Min *float64 `json:"min,omitempty"`
+	Max *float64 `json:"max,omitempty"`
+	// ForSeconds is how long a reading must stay outside the band before it
+	// counts. 0 fires on the first sample, which is right for a state and wrong
+	// for anything that fluctuates.
+	ForSeconds int `json:"forSeconds,omitempty"`
+	// AlertEnabled decides whether the band is evaluated. ABSENT MEANS YES:
+	// somebody writing a threshold means it to fire, and a plain bool would
+	// make the ordinary preset — one that simply omits the field — carry a
+	// band that is never compared to anything. Set to false explicitly, the
+	// band is a reference line on the chart and nothing more.
+	AlertEnabled *bool `json:"alertEnabled,omitempty"`
+}
+
+// Alerts reports whether this band is evaluated at all. See AlertEnabled.
+func (t Threshold) Alerts() bool { return t.AlertEnabled == nil || *t.AlertEnabled }
+
+// Equal reports whether two bands say the same thing.
+//
+// Needed because a threshold map is keyed by OID and two widgets may show the
+// same reading: identical bands are one band, and different ones are a question
+// only the author can answer.
+func (t Threshold) Equal(other Threshold) bool {
+	same := func(a, b *float64) bool {
+		if a == nil || b == nil {
+			return a == nil && b == nil
+		}
+		return *a == *b
+	}
+	return same(t.Min, other.Min) && same(t.Max, other.Max) &&
+		t.ForSeconds == other.ForSeconds && t.Alerts() == other.Alerts()
+}
+
+// ThresholdsFor maps every OID a preset watches to the band it should stay in.
+//
+// Per WIDGET rather than per OID, because a band belongs to what the widget
+// MEANS: "no port may be anything but up" is one statement about twenty-four
+// readings, and after discovery it is one statement about however many the
+// equipment turned out to have. Writing it per OID would make it unwriteable
+// for a discovering preset — the OIDs do not exist yet.
+func ThresholdsFor(p Preset) map[string]Threshold {
+	out := map[string]Threshold{}
+	for _, w := range p.Widgets {
+		if w.Threshold == nil {
+			continue
+		}
+		for _, oid := range w.OIDs {
+			// A template is not an OID. Discovery replaces it before this is
+			// ever asked, and a preset bound before that has nothing to watch
+			// here.
+			if hasPlaceholder(oid) {
+				continue
+			}
+			out[normaliseOID(oid)] = *w.Threshold
+		}
+	}
+	return out
+}
+
+// checkThreshold validates one band.
+func checkThreshold(at string, kind string, t *Threshold) []Error {
+	if t == nil {
+		return nil
+	}
+	var errs []Error
+
+	if t.Min == nil && t.Max == nil {
+		errs = append(errs, errf(at, "thresholdWithoutBound", nil))
+	}
+	if t.Min != nil && t.Max != nil && *t.Min > *t.Max {
+		errs = append(errs, errf(at, "thresholdInverted", map[string]string{
+			"min": trimFloat(*t.Min), "max": trimFloat(*t.Max),
+		}))
+	}
+	if t.ForSeconds < 0 || t.ForSeconds > MaxThresholdHoldSec {
+		errs = append(errs, errf(at+".forSeconds", "outOfRange", map[string]string{
+			"min": "0", "max": fmt.Sprint(MaxThresholdHoldSec),
+		}))
+	}
+
+	// The one kind that cannot carry a band. `rate` says its OID is a counter,
+	// the evaluator compares the RAW reading, and a counter only goes up: the
+	// episode opens on the first sample and never closes. Refused here because
+	// the author cannot see it — the tile beside it shows the rate they meant.
+	if kind == KindRate {
+		errs = append(errs, errf(at, "thresholdOnRate", map[string]string{"kind": kind}))
+	}
+	return errs
+}
+
+// checkThresholdConflicts refuses two different bands on one reading.
+//
+// The session holds ONE map keyed by OID, so two widgets watching the same OID
+// with different bands is a question with no answer: whichever is written last
+// would win silently, and the other widget would be drawn under a rule that is
+// not being applied to it.
+func checkThresholdConflicts(widgets []Widget) []Error {
+	type claim struct {
+		widget int
+		band   Threshold
+	}
+	first := map[string]claim{}
+	seen := map[string]bool{}
+	var errs []Error
+
+	for i, w := range widgets {
+		if w.Threshold == nil {
+			continue
+		}
+		for _, oid := range w.OIDs {
+			if hasPlaceholder(oid) {
+				continue
+			}
+			key := normaliseOID(oid)
+			held, taken := first[key]
+			if !taken {
+				first[key] = claim{widget: i, band: *w.Threshold}
+				continue
+			}
+			if held.band.Equal(*w.Threshold) {
+				continue // one band said twice is one band
+			}
+			if seen[key] {
+				continue // already reported for this reading
+			}
+			seen[key] = true
+			errs = append(errs, errf(
+				fmt.Sprintf("widgets[%d].threshold", i), "thresholdConflict",
+				map[string]string{"oid": clip(key), "other": fmt.Sprint(held.widget + 1)}))
+		}
+	}
+	sort.SliceStable(errs, func(i, j int) bool { return errs[i].Field < errs[j].Field })
+	return errs
+}
+
+// trimFloat prints a bound the way an author wrote it, without a trailing zero
+// nobody typed.
+func trimFloat(v float64) string { return strconv.FormatFloat(v, 'g', -1, 64) }

--- a/pkg/preset/threshold_test.go
+++ b/pkg/preset/threshold_test.go
@@ -1,0 +1,288 @@
+package preset
+
+import (
+	"strings"
+	"testing"
+)
+
+func f(v float64) *float64 { return &v }
+
+// yes is an explicit "evaluate this band". Absent means the same thing;
+// spelling it out here is what makes the tests that turn it OFF readable.
+func yes() *bool { t := true; return &t }
+
+func withThreshold(kind string, oids []string, t *Threshold) Preset {
+	return Preset{
+		FormatVersion: 1, Name: "Watched", IntervalSec: 60,
+		Widgets: []Widget{{Kind: kind, Title: "W", OIDs: oids, Threshold: t}},
+	}
+}
+
+// A band belongs to the WIDGET and reaches every reading in it: "no port may be
+// anything but up" is one statement about however many ports there are.
+func TestABandCoversEveryReadingOfItsWidget(t *testing.T) {
+	p := withThreshold(KindGrid,
+		[]string{"1.3.6.1.2.1.2.2.1.8.1", ".1.3.6.1.2.1.2.2.1.8.2"},
+		&Threshold{Max: f(1), ForSeconds: 60, AlertEnabled: yes()})
+	p.Widgets[0].Labels = map[string]string{"1": "up", "2": "down"}
+
+	if errs := Validate(p); len(errs) > 0 {
+		t.Fatalf("a valid band was refused: %v", errs)
+	}
+	bands := ThresholdsFor(p)
+	if len(bands) != 2 {
+		t.Fatalf("%d band(s) for two readings: %v", len(bands), bands)
+	}
+	// Keyed WITHOUT the leading dot, because that is how the session stores its
+	// OIDs and how the evaluator looks a band up. ".1.3.6" and "1.3.6" are one
+	// reading, and two entries for it would apply to neither.
+	if _, ok := bands["1.3.6.1.2.1.2.2.1.8.2"]; !ok {
+		t.Errorf("a leading dot made a second reading: %v", bands)
+	}
+	if b := bands["1.3.6.1.2.1.2.2.1.8.1"]; b.Max == nil || *b.Max != 1 || !b.Alerts() {
+		t.Errorf("the band did not survive: %+v", b)
+	}
+}
+
+// A band with no bound cannot fire. It is not a default — it is a mistake with
+// no symptom at all: the dashboard draws, the session polls, and the thing the
+// author wrote it to catch never raises anything.
+func TestABandNeedsABound(t *testing.T) {
+	p := withThreshold(KindValue, []string{"1.3.6.1.2.1.1.3.0"}, &Threshold{ForSeconds: 30})
+	errs := Validate(p)
+	if len(errs) != 1 || !strings.HasSuffix(errs[0].Message, "thresholdWithoutBound") {
+		t.Fatalf("errors = %v", errs)
+	}
+	if errs[0].Field != "widgets[0].threshold" {
+		t.Errorf("field = %q", errs[0].Field)
+	}
+}
+
+// A minimum above the maximum is a band no reading can be inside, so every
+// sample is a breach.
+func TestABandCannotBeInverted(t *testing.T) {
+	p := withThreshold(KindValue, []string{"1.3.6.1.2.1.1.3.0"},
+		&Threshold{Min: f(90), Max: f(10)})
+	errs := Validate(p)
+	if len(errs) != 1 || !strings.HasSuffix(errs[0].Message, "thresholdInverted") {
+		t.Fatalf("errors = %v", errs)
+	}
+	// The numbers are in the message: "invalid threshold" leaves the author to
+	// work out which of the two they mistyped.
+	if errs[0].Args["min"] != "90" || errs[0].Args["max"] != "10" {
+		t.Errorf("args = %v", errs[0].Args)
+	}
+}
+
+// The hold is bounded for the reason the interval is: a hold longer than a day
+// is not a hold, it is a threshold that never fires.
+func TestTheHoldIsBounded(t *testing.T) {
+	for _, hold := range []int{-1, MaxThresholdHoldSec + 1} {
+		p := withThreshold(KindValue, []string{"1.3.6.1.2.1.1.3.0"},
+			&Threshold{Max: f(10), ForSeconds: hold})
+		errs := Validate(p)
+		if len(errs) != 1 || errs[0].Field != "widgets[0].threshold.forSeconds" {
+			t.Errorf("forSeconds %d gave %v", hold, errs)
+		}
+	}
+	// And the edges are legal: 0 fires on the first sample, which is right for
+	// a state, and a day is the longest hold the format admits.
+	for _, hold := range []int{0, MaxThresholdHoldSec} {
+		p := withThreshold(KindValue, []string{"1.3.6.1.2.1.1.3.0"},
+			&Threshold{Max: f(10), ForSeconds: hold})
+		if errs := Validate(p); len(errs) > 0 {
+			t.Errorf("forSeconds %d was refused: %v", hold, errs)
+		}
+	}
+}
+
+// The one kind that cannot carry a band, and the reason is measured rather than
+// stylistic: the evaluator compares Sample.Value, which is the RAW reading. A
+// `rate` widget says its OID is a counter, and a counter only goes up — so a
+// maximum is breached on the first sample and never recovers, while the tile
+// beside it shows the rate the author meant.
+func TestABandCannotBePutOnARateWidget(t *testing.T) {
+	p := withThreshold(KindRate, []string{"1.3.6.1.2.1.2.2.1.10.1"},
+		&Threshold{Max: f(1000000)})
+	errs := Validate(p)
+	if len(errs) != 1 || !strings.HasSuffix(errs[0].Message, "thresholdOnRate") {
+		t.Fatalf("a band on a counter was accepted: %v", errs)
+	}
+	if errs[0].Args["kind"] != KindRate {
+		t.Errorf("args = %v", errs[0].Args)
+	}
+}
+
+// The session holds ONE map keyed by OID. Two different bands on one reading is
+// a question with no answer: whichever is written last would win silently, and
+// the other widget would be drawn under a rule not being applied to it.
+func TestTwoDifferentBandsOnOneReadingAreRefused(t *testing.T) {
+	p := Preset{
+		FormatVersion: 1, Name: "Clash", IntervalSec: 60,
+		Widgets: []Widget{
+			{Kind: KindValue, Title: "A", OIDs: []string{"1.3.6.1.2.1.1.3.0"},
+				Threshold: &Threshold{Max: f(10)}},
+			{Kind: KindChart, Title: "B", OIDs: []string{".1.3.6.1.2.1.1.3.0"},
+				Threshold: &Threshold{Max: f(20)}},
+		},
+	}
+	errs := Validate(p)
+	if len(errs) != 1 || !strings.HasSuffix(errs[0].Message, "thresholdConflict") {
+		t.Fatalf("errors = %v", errs)
+	}
+	if errs[0].Field != "widgets[1].threshold" || errs[0].Args["other"] != "1" {
+		t.Errorf("the conflict does not point anywhere useful: %+v", errs[0])
+	}
+}
+
+// The same band said twice is one band. Refusing that would make it impossible
+// to show a reading in two widgets — a tile and a chart of the same thing is
+// the ordinary shape of a dashboard.
+func TestTheSameBandTwiceIsFine(t *testing.T) {
+	band := func() *Threshold { return &Threshold{Max: f(10), ForSeconds: 30, AlertEnabled: yes()} }
+	p := Preset{
+		FormatVersion: 1, Name: "Same", IntervalSec: 60,
+		Widgets: []Widget{
+			{Kind: KindValue, Title: "A", OIDs: []string{"1.3.6.1.2.1.1.3.0"}, Threshold: band()},
+			{Kind: KindChart, Title: "B", OIDs: []string{"1.3.6.1.2.1.1.3.0"}, Threshold: band()},
+		},
+	}
+	if errs := Validate(p); len(errs) > 0 {
+		t.Fatalf("one band written twice was refused: %v", errs)
+	}
+	if len(ThresholdsFor(p)) != 1 {
+		t.Errorf("one reading, %d band(s)", len(ThresholdsFor(p)))
+	}
+}
+
+// A band on a discovering widget is written before its OIDs exist, which is the
+// whole reason it is per widget. Expansion is what turns it into readings.
+func TestABandOnADiscoveringWidgetLandsOnWhatTheWalkFound(t *testing.T) {
+	p := Preset{
+		FormatVersion: 1, Name: "Ports", IntervalSec: 60,
+		Widgets: []Widget{{
+			Kind: KindGrid, Title: "Ports",
+			OIDs:      []string{"1.3.6.1.2.1.2.2.1.8.{#}"},
+			Labels:    map[string]string{"1": "up"},
+			Discover:  &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+			Threshold: &Threshold{Max: f(1), AlertEnabled: yes()},
+		}},
+	}
+	if errs := Validate(p); len(errs) > 0 {
+		t.Fatalf("refused before discovery: %v", errs)
+	}
+	// Before the walk there is nothing to key a band by, and a map entry for
+	// "…8.{#}" would be a threshold on an OID that never arrives.
+	if got := ThresholdsFor(p); len(got) != 0 {
+		t.Errorf("a template was keyed as a reading: %v", got)
+	}
+
+	expanded := Expand(p, map[int][]Instance{
+		0: {{Suffix: "1", Label: "eth0"}, {Suffix: "2", Label: "eth1"}},
+	})
+	bands := ThresholdsFor(expanded)
+	if len(bands) != 2 {
+		t.Fatalf("%d band(s) after discovering two ports: %v", len(bands), bands)
+	}
+	for _, oid := range []string{"1.3.6.1.2.1.2.2.1.8.1", "1.3.6.1.2.1.2.2.1.8.2"} {
+		if b, ok := bands[oid]; !ok || b.Max == nil || *b.Max != 1 {
+			t.Errorf("%s is not watched: %+v", oid, b)
+		}
+	}
+}
+
+// What binding will do is stated before it does it, and the figure that matters
+// is the one that leaves the machine.
+func TestTheCostCountsWhatIsWatchedAndWhatAlerts(t *testing.T) {
+	p := Preset{
+		FormatVersion: 1, Name: "Mixed", IntervalSec: 60,
+		Widgets: []Widget{
+			{Kind: KindValue, Title: "Uptime", OIDs: []string{"1.3.6.1.2.1.1.3.0"}},
+			// Explicitly not evaluated: drawn as a reference line and nothing
+			// more. Omitting the flag would mean the opposite.
+			{Kind: KindStatus, Title: "Battery", OIDs: []string{"1.3.6.1.2.1.33.1.2.1.0"},
+				Labels:    map[string]string{"1": "unknown"},
+				Threshold: &Threshold{Max: f(2), AlertEnabled: new(bool)}},
+			{Kind: KindChart, Title: "Load", OIDs: []string{"1.3.6.1.2.1.25.3.3.1.2.1", "1.3.6.1.2.1.25.3.3.1.2.2"},
+				Threshold: &Threshold{Max: f(90), AlertEnabled: yes()}},
+		},
+	}
+	c := Estimate(p)
+	if c.OIDs != 4 {
+		t.Errorf("oids = %d, want 4", c.OIDs)
+	}
+	if c.Watched != 3 {
+		t.Errorf("watched = %d, want 3 (one state and two processors)", c.Watched)
+	}
+	if c.Alerting != 2 {
+		t.Errorf("alerting = %d, want 2 (the chart, on two processors; the state says no)", c.Alerting)
+	}
+}
+
+// A discovering widget's band is counted at the SAME ceiling its OIDs are, or
+// the one screen that says what binding will do would report two thresholds for
+// a preset that is about to create ninety-six.
+func TestAWatchedCountIsACeilingToo(t *testing.T) {
+	p := Preset{
+		FormatVersion: 1, Name: "Ports", IntervalSec: 60,
+		Widgets: []Widget{{
+			Kind: KindGrid, Title: "Ports",
+			OIDs:      []string{"1.3.6.1.2.1.2.2.1.8.{#}"},
+			Labels:    map[string]string{"1": "up"},
+			Discover:  &Discover{Walk: "1.3.6.1.2.1.2.2.1.2"},
+			Threshold: &Threshold{Max: f(1), AlertEnabled: yes()},
+		}},
+	}
+	c := Estimate(p)
+	if c.Watched != c.OIDs || c.Watched == 0 {
+		t.Fatalf("watched = %d for %d OID(s)", c.Watched, c.OIDs)
+	}
+	if c.Alerting != c.Watched {
+		t.Errorf("alerting = %d, want all %d", c.Alerting, c.Watched)
+	}
+	if c.Discovered != c.OIDs {
+		t.Errorf("discovered = %d of %d", c.Discovered, c.OIDs)
+	}
+}
+
+// An omitted alertEnabled means YES, and that is the whole reason the field is
+// a pointer.
+//
+// encoding/json decodes an absent bool to false, and false is not "notify me
+// less" — classify() returns nothing without it, in Go and in the renderer
+// alike, so the band opens no episode and records nothing at all. A plain bool
+// would make every threshold written the obvious way inert, with the dashboard
+// looking exactly as though it were armed. That failure has no symptom: the
+// preset validates, the session polls, and the incident it was written to catch
+// simply never arrives.
+func TestAnOmittedAlertFlagStillEvaluates(t *testing.T) {
+	var quiet = false
+	cases := []struct {
+		why    string
+		flag   *bool
+		alerts bool
+	}{
+		{"omitted, as an author would write it", nil, true},
+		{"explicitly on", yes(), true},
+		{"explicitly off — a reference line and nothing more", &quiet, false},
+	}
+	for _, c := range cases {
+		p := withThreshold(KindValue, []string{"1.3.6.1.2.1.1.3.0"},
+			&Threshold{Max: f(10), AlertEnabled: c.flag})
+		if errs := Validate(p); len(errs) > 0 {
+			t.Fatalf("%s: refused: %v", c.why, errs)
+		}
+		if got := ThresholdsFor(p)["1.3.6.1.2.1.1.3.0"].Alerts(); got != c.alerts {
+			t.Errorf("%s: Alerts() = %v, want %v", c.why, got, c.alerts)
+		}
+		// And the figure the operator is shown before binding follows it.
+		c2 := Estimate(p)
+		want := 0
+		if c.alerts {
+			want = 1
+		}
+		if c2.Alerting != want || c2.Watched != 1 {
+			t.Errorf("%s: watched %d, alerting %d", c.why, c2.Watched, c2.Alerting)
+		}
+	}
+}

--- a/presets/host-resources.json
+++ b/presets/host-resources.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "name": "Server (HOST-RESOURCES-MIB)",
   "author": "SnmpLens",
-  "description": "Processor load and storage of a server or workstation, discovered when you bind it — the indexes differ from one machine to the next, which is exactly what a walk answers and a hand-written list cannot.",
+  "description": "Processor load and storage of a server or workstation, discovered when you bind it — the indexes differ from one machine to the next, which is exactly what a walk answers and a hand-written list cannot. Processor load is watched above 90% held for ten minutes, which is long enough that a build or a backup does not raise anything.",
   "intervalSec": 60,
   "widgets": [
     {
@@ -56,6 +56,10 @@
         "y": 1,
         "w": 6,
         "h": 2
+      },
+      "threshold": {
+        "max": 90,
+        "forSeconds": 600
       }
     },
     {

--- a/presets/ups.json
+++ b/presets/ups.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "name": "UPS (RFC 1628)",
   "author": "SnmpLens",
-  "description": "Battery, input and output of an uninterruptible power supply, from the standard UPS-MIB. Many vendors also publish their own MIB with more detail; this one answers on any UPS that implements RFC 1628.",
+  "description": "Battery, input and output of an uninterruptible power supply, from the standard UPS-MIB. Many vendors also publish their own MIB with more detail; this one answers on any UPS that implements RFC 1628. It watches three things: the battery status, the output source — anything but mains — and a charge under 30% held for five minutes.",
   "intervalSec": 300,
   "widgets": [
     {
@@ -21,6 +21,9 @@
         "x": 0,
         "y": 0,
         "w": 6
+      },
+      "threshold": {
+        "max": 2
       }
     },
     {
@@ -42,6 +45,10 @@
         "x": 6,
         "y": 0,
         "w": 6
+      },
+      "threshold": {
+        "min": 3,
+        "max": 3
       }
     },
     {
@@ -55,6 +62,10 @@
         "x": 0,
         "y": 1,
         "w": 4
+      },
+      "threshold": {
+        "min": 30,
+        "forSeconds": 300
       }
     },
     {
@@ -85,7 +96,7 @@
     },
     {
       "kind": "chart",
-      "title": "Battery",
+      "title": "Battery trend",
       "oids": [
         "1.3.6.1.2.1.33.1.2.4.0",
         "1.3.6.1.2.1.33.1.2.5.0"


### PR DESCRIPTION
Stacked on #55.

`PresetBind` passed `nil` where the session's thresholds go, with a comment saying a preset describes what to *watch* and that what counts as too much is the operator's judgement about their own network. That is true of a percentage on a link the author has never seen, and false of most of what a preset is written for: a UPS running on anything but mains, a battery reporting low, a disk at 95%. Those are properties of the MIB, and the author knows them better than whoever binds the file.

```json
{"kind": "status", "title": "Running on",
 "oids": ["1.3.6.1.2.1.33.1.4.1.0"],
 "threshold": {"min": 3, "max": 3}}
```

Binding **materialises** it into the session's own threshold map — the same column `MonitorCreateSession` fills, read by the same evaluator. Nothing new evaluates anything: a preset fills in a form the operator would otherwise fill in by hand and can edit afterwards. The band is per **widget**, not per OID, which is what makes it writeable for a discovering preset — "no port may be anything but up" is one statement about however many ports the walk turns up.

## Three facts, all read out of the code rather than assumed

**The evaluator compares the raw reading.** `Sample.Value` is what was polled; `Rate` is derived for the chart and the tile and is never evaluated. So a band on a counter is a band on a number that only goes up — it fires on the first sample and never resolves. A `rate` widget *says* its OID is a counter, so that kind is refused outright. A chart of counters cannot be detected and is left to the author.

**`alertEnabled` is not "notify", it is "evaluate at all".** `classify()` returns nothing without it, in `pkg/monitor/breach.go` and in `utils/thresholdAlerts.js` alike: no episode, no journal entry, nothing. The band is still drawn on the chart as a reference line, and that is its whole effect. Since `encoding/json` decodes an absent bool to `false`, a plain `bool` would make every threshold written the obvious way **inert**, with the dashboard looking exactly as though it were armed. Hence `AlertEnabled *bool` and `Alerts()`: absent means yes, and false has to be written on purpose.

**A reading can carry one band.** The session holds one map keyed by OID, so two widgets watching the same OID with different bands is a question with no answer — the later would win silently and the earlier widget would be drawn under a rule not applied to it. Identical bands are one band, which is the ordinary case of a tile and a chart showing the same reading.

## Said before it happens

`Cost` gained `Watched` and `Alerting`, stated on the settings screen beside the request count. That is the same gate the traffic goes through: an evaluated band raises an incident, which the operator's own notification rules may route to a sink, so the file reaching outside the machine is said out loud before it is bound. A shipped preset that arms one must also say so in its description — that is a test.

## The library

Two of the five shipped presets now watch something (`ups.json`: battery status, output source, charge under 30% held five minutes; `host-resources.json`: processor load over 90% held ten minutes, on every processor the walk finds).

The three interface presets deliberately watch nothing. `ifOperStatus` looks like the obvious candidate and is the wrong one: most ports of a real access switch are legitimately down, so a band there opens an episode per unused port the moment the preset is bound — and everything those presets chart is a counter.

The conflict check earned itself immediately: `ups.json` had two widgets called "Battery", the state tile and the chart, and the first attempt at these bands put the state's band on the chart's OIDs. The chart is renamed here so the file does not repeat the trap.

Gate: `go vet`, `go test -race`, `staticcheck`, `npm test`, `npm run check`, `npm run build` — all clean.
