### PR TITLE
Give a simulated device several SNMPv3 users, and let a target name its port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,10 @@ The frontend calls Go through auto-generated bindings in `frontend/wailsjs/`, wh
 - `pkg/events/`, `pkg/notify/`, `pkg/secrets/`, `pkg/service/`, `pkg/tray/`, `pkg/autostart/` — the event journal vocabulary, notification routing (syslog over UDP/TCP/**TLS per RFC5425**, webhook, email, with a durable outbox), OS-protected credential storage, the pre-GUI preference file, the fail-soft system-tray icon, and the per-user login entry (HKCU Run key / LaunchAgent / XDG autostart — never machine-wide, so it never needs elevation).
 - `pkg/netaddr/address.go` — address handling shared by `pkg/snmp` and `pkg/network`. `NormaliseTarget` strips
   the brackets people paste around an IPv6 literal, because gosnmp adds its own via `JoinHostPort` and
-  `[[::1]]:161` fails naming neither; zones (`fe80::1%eth0`) are kept. `ListenAddress` returns the bare `:port`
+  `[[::1]]:161` fails naming neither; zones (`fe80::1%eth0`) are kept. `SplitTarget` reads a port the target
+  names (`10.0.0.5:1161`, `[2001:db8::5]:1161`) and lets it win over the port field — every dial, the trap
+  sender's included, goes through it, a bare IPv6 literal's colons are never taken for a port, and `portOf` in
+  `utils/targets.js` is the same reading on the renderer's side. `ListenAddress` returns the bare `:port`
   wildcard, which Go opens as a DUAL-STACK socket — `0.0.0.0` behaves identically but reads like a deliberate
   IPv4-only choice, which is how it gets "fixed" into one. `LastAddressIn` parses rather than pattern-matches.
 - `pkg/network/tools.go` — pure-Go ping & traceroute (**pro-bing**); no elevated privileges required. Targets go
@@ -609,12 +612,16 @@ answer for every ID in `pkg/simulator`. The Linux model answers everything the "
 values are pure functions of time (`values.go`): counters that only go up and wrap at 32 bits as a real
 interface's do, gauges that swing, nothing ticking in the background.
 
-**A device becomes a target in the renderer** (`addDeviceAsTarget` in `utils/simulator.js`): its address in the
-list, and an override with its port and its identifiers in the most secure version it answers. The test resolves
-the result through `getEffectiveSettings`, which every request is built from. A target IS an address, so on macOS
-— 127.0.0.1 alone unless aliases are added — devices differ by port and only one of them can be a target until
-targets take `host:port`; `SimulatorSuggestAddress` gives each device an address of its own on Windows and Linux
-for that reason.
+**A device becomes a target in the renderer** (`addDeviceAsTarget` in `utils/simulator.js`): the target in the
+list, and an override with its identifiers in the most secure version it answers — its FIRST user for v3, since a
+device may have several. The target is the device's address, with its port unless that is 161 (`targetOf`:
+`127.0.0.1:1162`), because a target is what tells devices apart and on macOS — 127.0.0.1 alone unless aliases
+were added — the port is all that does. A port the target names wins over every port field, in Go
+(`netaddr.SplitTarget`) and in `getEffectiveSettings`, so the override leaves it out and `TargetOverrideForm`
+shows it as the target's rather than offering a field that would be ignored. The test resolves the result through
+`getEffectiveSettings`, which every request is built from, with two devices sharing 127.0.0.1.
+`SimulatorSuggestAddress` still offers an address of its own first, finding by binding which ones exist: once
+devices send traps, their source address is what will tell them apart.
 
 One trap for whoever adds a model: a file named `model_linux.go` is compiled on Linux ONLY — `_linux` is a GOOS
 suffix, and the build on Windows reported the model as undefined — so the Linux model lives in `linuxserver.go`.

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -186,10 +186,12 @@ type SimulatorAddress struct {
 // port no other device is configured on, that nothing holds right now, and that
 // an ordinary user may bind.
 //
-// Windows and Linux answer on the whole of 127.0.0.0/8, so each device gets an
-// address of its own — which is what lets it be a target of its own, since a
-// target is an address. macOS configures only 127.0.0.1 unless aliases are
-// added, so there the devices differ by port. A port below 1024 needs
+// An address of its own first, so the device is a target without a port — and,
+// once devices send traps, tells its traps apart by their source. Windows and
+// Linux answer on the whole of 127.0.0.0/8; macOS on 127.0.0.1 and on the aliases
+// someone added, and trying to bind is how to find out which. Failing that,
+// 127.0.0.1 at the next free port: a target names its port ("127.0.0.1:1162"),
+// so each device is still a target of its own. A port below 1024 needs
 // privileges everywhere but Windows.
 func (a *App) SimulatorSuggestAddress() SimulatorAddress {
 	s := a.sim
@@ -209,24 +211,21 @@ func suggestAddress(goos string, taken []string, free func(listen string) bool) 
 		listen := net.JoinHostPort(address, strconv.Itoa(port))
 		return !slices.Contains(taken, listen) && free(listen)
 	}
-	if goos == "darwin" {
-		for port := 1161; port < 1261; port++ {
-			if usable("127.0.0.1", port) {
-				return SimulatorAddress{"127.0.0.1", port}
-			}
-		}
-	} else {
-		port := 1161
-		if goos == "windows" {
-			port = 161
-		}
-		for host := 2; host < 255; host++ {
-			if address := "127.0.0." + strconv.Itoa(host); usable(address, port) {
-				return SimulatorAddress{address, port}
-			}
+	port := 1161
+	if goos == "windows" {
+		port = 161
+	}
+	for host := 2; host < 255; host++ {
+		if address := "127.0.0." + strconv.Itoa(host); usable(address, port) {
+			return SimulatorAddress{address, port}
 		}
 	}
-	return SimulatorAddress{"127.0.0.1", 1161}
+	for p := port; p < port+100; p++ {
+		if usable("127.0.0.1", p) {
+			return SimulatorAddress{"127.0.0.1", p}
+		}
+	}
+	return SimulatorAddress{"127.0.0.1", port}
 }
 
 func canBindUDP(listen string) bool {

--- a/app_simulator_test.go
+++ b/app_simulator_test.go
@@ -221,8 +221,15 @@ func TestANewDeviceIsOfferedAnAddressOfItsOwn(t *testing.T) {
 	if got := suggestAddress("linux", nil, free); got != (SimulatorAddress{"127.0.0.2", 1161}) {
 		t.Errorf("linux: %+v", got)
 	}
-	if got := suggestAddress("darwin", []string{"127.0.0.1:1161"}, free); got != (SimulatorAddress{"127.0.0.1", 1162}) {
+	// macOS answers on 127.0.0.1 alone unless aliases were added: a bind anywhere
+	// else fails, and the device goes to 127.0.0.1 at the next free port...
+	onlyLoopbackOne := func(listen string) bool { return strings.HasPrefix(listen, "127.0.0.1:") }
+	if got := suggestAddress("darwin", []string{"127.0.0.1:1161"}, onlyLoopbackOne); got != (SimulatorAddress{"127.0.0.1", 1162}) {
 		t.Errorf("darwin: %+v", got)
+	}
+	// ...and with aliases it gets an address of its own, like the others.
+	if got := suggestAddress("darwin", nil, free); got != (SimulatorAddress{"127.0.0.2", 1161}) {
+		t.Errorf("darwin with aliases: %+v", got)
 	}
 	busy := func(listen string) bool { return listen != "127.0.0.2:1161" }
 	if got := suggestAddress("linux", nil, busy); got.Address != "127.0.0.3" {

--- a/frontend/screenshots/scenes.js
+++ b/frontend/screenshots/scenes.js
@@ -354,15 +354,16 @@ const CATALOGUE = [
   {
     base: 'simulator-editor',
     tab: TABS.operations,
-    height: 1000,
+    height: 1400,
     bindings: {
       ListSimulatorModels: [{ id: 'linux-server', category: 'server' }],
       ListSimulatedDevices: [],
       SimulatorSuggestAddress: { address: '127.0.0.2', port: 161 },
     },
-    // v3 ticked after v2c: both identities, and the passphrases not yet typed.
-    act: ['sel:.status-item.simulator|0', 'New device', 'sel:.versions input|2'],
-    describe: 'A new simulated device: its model, its loopback address, and who may ask it.',
+    // v3 ticked after v2c, and a second user added: both identities, and the
+    // passphrases not yet typed.
+    act: ['sel:.status-item.simulator|0', 'New device', 'sel:.versions input|2', 'Add a user'],
+    describe: 'A new simulated device: its model, its loopback address, and who may ask it — two SNMPv3 users here.',
   },
 ];
 

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -5,8 +5,9 @@
   import { simulatorStore } from './stores/simulatorStore';
   import { settingsStore } from './stores/settingsStore';
   import { notificationStore } from './stores/notifications';
+  import { anonMode, maskString } from './utils/anonymize';
   import {
-    SIM_VERSIONS, blankDevice, editableDevice, deviceProblems, devicePayload, addDeviceAsTarget,
+    SIM_VERSIONS, blankDevice, blankV3, editableDevice, deviceProblems, devicePayload, addDeviceAsTarget,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import Icon from './Icon.svelte';
@@ -38,13 +39,15 @@
   $: problems = editing ? deviceProblems(editing) : {};
   $: usmProblems = usmMessages(problems, $_);
 
-  /** The editor's SNMPv3 problems, in the shape UsmFields shows them. */
+  /** The editor's SNMPv3 problems, one set per user, in the shape UsmFields shows them. */
   function usmMessages(p, t) {
-    const out = {};
-    for (const key of ['user', 'authPass', 'privPass']) {
-      if (p[key]) out[key] = { text: t(`simulator.problem.${p[key]}`), level: 'error' };
-    }
-    return out;
+    return (p.users || []).map((u) => {
+      const out = {};
+      for (const key of ['user', 'authPass', 'privPass']) {
+        if (u[key]) out[key] = { text: t(`simulator.problem.${u[key]}`), level: 'error' };
+      }
+      return out;
+    });
   }
 
   function close() {
@@ -83,6 +86,14 @@
       ? editing.versions.filter((v) => v !== version)
       : [...editing.versions, version];
     editing = { ...editing, versions };
+  }
+
+  function addUser() {
+    editing = { ...editing, users: [...editing.users, blankV3(editing.users.length + 1)] };
+  }
+
+  function removeUser(index) {
+    editing = { ...editing, users: editing.users.filter((u, i) => i !== index) };
   }
 
   async function save() {
@@ -128,10 +139,10 @@
   async function addAsTarget(device) {
     try {
       const creds = await simulatorStore.credentials(device.id);
-      const { settings, added, version } = addDeviceAsTarget($settingsStore, device, creds);
+      const { settings, added, version, target } = addDeviceAsTarget($settingsStore, device, creds);
       await settingsStore.save(settings);
       notificationStore.add(
-        $_(added ? 'simulator.targetAdded' : 'simulator.targetUpdated', { values: { address: device.address, version } }),
+        $_(added ? 'simulator.targetAdded' : 'simulator.targetUpdated', { values: { address: target, version } }),
         'success',
       );
     } catch (e) {
@@ -200,9 +211,29 @@
 
         {#if editing.versions.includes('v3')}
           <h4 class="section-title">{$_('simulator.field.v3')}</h4>
-          <!-- bind:, as the settings do: UsmFields edits the object in place, and
-               without it the checks above never see a passphrase being typed. -->
-          <UsmFields bind:v3={editing.v3} idPrefix="sim-v3" problems={usmProblems} showContext={false} />
+          {#each editing.users as u, i (i)}
+            <div class="user-block">
+              <div class="user-head">
+                <span class="user-title">{$_('simulator.userN', { values: { n: i + 1 } })}</span>
+                {#if editing.users.length > 1}
+                  <button class="icon-btn danger" title={$_('simulator.removeUser')} aria-label={$_('simulator.removeUser')}
+                    on:click={() => removeUser(i)}>
+                    <Icon name="trash-2" size={14} />
+                  </button>
+                {/if}
+              </div>
+              <!-- bind:, as the settings do: UsmFields edits the object in place, and
+                   without it the checks above never see a passphrase being typed. -->
+              <UsmFields bind:v3={u} idPrefix="sim-v3-{i}" problems={usmProblems[i] || {}} showContext={false} />
+            </div>
+          {/each}
+          {#if problems.noUser}<span class="problem">{$_(`simulator.problem.${problems.noUser}`)}</span>{/if}
+          <div class="users-foot">
+            <button class="btn tertiary btn-small" on:click={addUser}>
+              <Icon name="plus" size={13} /> {$_('simulator.addUser')}
+            </button>
+            {#if editing.users.length > 1}<span class="users-note">{$_('simulator.firstUserTarget')}</span>{/if}
+          </div>
         {/if}
       </div>
       <footer class="sim-footer">
@@ -232,6 +263,12 @@
                   </span>
                   <span class="meta">
                     {#each d.versions as version (version)}<span class="chip">{version}</span>{/each}
+                    {#if d.users?.length}
+                      <span class="users">
+                        <Icon name="key-round" size={12} />
+                        {$anonMode ? maskString(d.users[0].name) : d.users.map((u) => u.name).join(', ')}
+                      </span>
+                    {/if}
                     <span class="activity">
                       {d.running ? $_('simulator.packets', { values: { count: d.packets } }) : $_('simulator.stopped')}
                     </span>
@@ -566,6 +603,51 @@
   .section-title {
     margin: 16px 0 0;
     font-size: 0.95em;
+  }
+
+  .user-block {
+    margin-top: 10px;
+    padding: 10px 12px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+  }
+
+  .user-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    min-height: 28px;
+  }
+
+  .user-title {
+    font-size: 0.88em;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .users-foot {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+  }
+
+  .users-foot .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .users-note {
+    font-size: 0.82em;
+    color: var(--text-muted);
+  }
+
+  .users {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
   }
 
   .problem {

--- a/frontend/src/TargetOverrideForm.svelte
+++ b/frontend/src/TargetOverrideForm.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher } from 'svelte';
   import { _ } from 'svelte-i18n';
   import { anonMode, maskString } from './utils/anonymize';
+  import { portOf } from './utils/targets';
   import { AUTH_PROTOCOLS, PRIV_PROTOCOLS } from './utils/snmpSecurity.js';
   import {
     blankProfile,
@@ -70,7 +71,9 @@
 
   function transport() {
     const result = {};
-    if (enabled.port && local.port !== '') result.port = Number(local.port);
+    // A target that names its port has no use for an override of it: the one in
+    // the target wins, in Go and in getEffectiveSettings.
+    if (enabled.port && local.port !== '' && !portOf(address)) result.port = Number(local.port);
     if (enabled.timeout && local.timeout !== '') result.timeout = Number(local.timeout);
     if (enabled.retries && local.retries !== '') result.retries = Number(local.retries);
     return result;
@@ -257,14 +260,19 @@
 
   <div class="override-grid transport">
     <div class="override-field">
-      <label class="override-toggle">
-        <input type="checkbox" bind:checked={enabled.port} />
-        <span>Port</span>
-      </label>
-      {#if enabled.port}
-        <input type="number" bind:value={local.port} placeholder={String(globalSettings.port)} />
+      {#if portOf(address)}
+        <span class="override-toggle"><span>Port</span></span>
+        <span class="default-value">{portOf(address)} · {$_('targets.portInAddress')}</span>
       {:else}
-        <span class="default-value">{globalSettings.port}</span>
+        <label class="override-toggle">
+          <input type="checkbox" bind:checked={enabled.port} />
+          <span>Port</span>
+        </label>
+        {#if enabled.port}
+          <input type="number" bind:value={local.port} placeholder={String(globalSettings.port)} />
+        {:else}
+          <span class="default-value">{globalSettings.port}</span>
+        {/if}
       {/if}
     </div>
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -632,7 +632,8 @@
     "presetDeviceMasked": "Gerät erkannt",
     "presetBind": "Binden",
     "presetBindTooltip": "Eine Dashboard-Vorlage an dieses Gerät binden",
-    "presetAlreadyBound": "Bereits gebunden: {names}. Eine weitere fügt eine zweite Abfrageuhr hinzu."
+    "presetAlreadyBound": "Bereits gebunden: {names}. Eine weitere fügt eine zweite Abfrageuhr hinzu.",
+    "portInAddress": "vom Ziel festgelegt"
   },
   "update": {
     "available": "SnmpLens {version} ist verfügbar",
@@ -1314,13 +1315,18 @@
       "versionRequired": "Wählen Sie mindestens eine Version.",
       "communityRequired": "v1 und v2c benötigen eine Community.",
       "userRequired": "Der SNMPv3-Benutzer braucht einen Namen.",
-      "passphraseShort": "Mindestens 8 Zeichen."
+      "passphraseShort": "Mindestens 8 Zeichen.",
+      "userDuplicate": "Zwei Benutzer können nicht denselben Namen tragen."
     },
     "model": {
       "linux-server": {
         "name": "Linux-Server",
         "description": "Ein Ubuntu-Host mit net-snmp: System, drei Schnittstellen, Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
       }
-    }
+    },
+    "userN": "Benutzer {n}",
+    "addUser": "Benutzer hinzufügen",
+    "removeUser": "Diesen Benutzer entfernen",
+    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer."
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -632,7 +632,8 @@
     "presetDeviceMasked": "Equipment identified",
     "presetBind": "Bind",
     "presetBindTooltip": "Bind a dashboard preset to this equipment",
-    "presetAlreadyBound": "Already bound: {names}. Binding another adds a second poll clock."
+    "presetAlreadyBound": "Already bound: {names}. Binding another adds a second poll clock.",
+    "portInAddress": "set by the target"
   },
   "update": {
     "available": "SnmpLens {version} is available",
@@ -1306,7 +1307,7 @@
       "port": "Port",
       "versions": "SNMP versions",
       "community": "Community",
-      "v3": "SNMPv3 user"
+      "v3": "SNMPv3 users"
     },
     "problem": {
       "nameRequired": "Give the device a name.",
@@ -1314,13 +1315,18 @@
       "versionRequired": "Choose at least one version.",
       "communityRequired": "v1 and v2c need a community.",
       "userRequired": "The SNMPv3 user needs a name.",
-      "passphraseShort": "At least 8 characters."
+      "passphraseShort": "At least 8 characters.",
+      "userDuplicate": "Two users cannot share a name."
     },
     "model": {
       "linux-server": {
         "name": "Linux server",
         "description": "An Ubuntu host running net-snmp: system, three interfaces, host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
       }
-    }
+    },
+    "userN": "User {n}",
+    "addUser": "Add a user",
+    "removeUser": "Remove this user",
+    "firstUserTarget": "Add as target uses the first user."
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -632,7 +632,8 @@
     "presetDeviceMasked": "Equipo identificado",
     "presetBind": "Vincular",
     "presetBindTooltip": "Vincular un preset de panel a este equipo",
-    "presetAlreadyBound": "Ya vinculado: {names}. Vincular otro añade un segundo reloj de sondeo."
+    "presetAlreadyBound": "Ya vinculado: {names}. Vincular otro añade un segundo reloj de sondeo.",
+    "portInAddress": "fijado por el destino"
   },
   "update": {
     "available": "SnmpLens {version} está disponible",
@@ -1306,7 +1307,7 @@
       "port": "Puerto",
       "versions": "Versiones SNMP",
       "community": "Comunidad",
-      "v3": "Usuario SNMPv3"
+      "v3": "Usuarios SNMPv3"
     },
     "problem": {
       "nameRequired": "Dé un nombre al dispositivo.",
@@ -1314,13 +1315,18 @@
       "versionRequired": "Elija al menos una versión.",
       "communityRequired": "v1 y v2c necesitan una comunidad.",
       "userRequired": "El usuario SNMPv3 necesita un nombre.",
-      "passphraseShort": "Al menos 8 caracteres."
+      "passphraseShort": "Al menos 8 caracteres.",
+      "userDuplicate": "Dos usuarios no pueden compartir un nombre."
     },
     "model": {
       "linux-server": {
         "name": "Servidor Linux",
         "description": "Un host Ubuntu con net-snmp: sistema, tres interfaces, recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
       }
-    }
+    },
+    "userN": "Usuario {n}",
+    "addUser": "Añadir un usuario",
+    "removeUser": "Quitar este usuario",
+    "firstUserTarget": "«Añadir como destino» usa el primer usuario."
   }
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -632,7 +632,8 @@
     "presetDeviceMasked": "Équipement identifié",
     "presetBind": "Lier",
     "presetBindTooltip": "Lier un preset de tableau de bord à cet équipement",
-    "presetAlreadyBound": "Déjà lié : {names}. En lier un autre ajoute une seconde horloge de scrutation."
+    "presetAlreadyBound": "Déjà lié : {names}. En lier un autre ajoute une seconde horloge de scrutation.",
+    "portInAddress": "fixé par la cible"
   },
   "update": {
     "available": "SnmpLens {version} est disponible",
@@ -1306,7 +1307,7 @@
       "port": "Port",
       "versions": "Versions SNMP",
       "community": "Communauté",
-      "v3": "Utilisateur SNMPv3"
+      "v3": "Utilisateurs SNMPv3"
     },
     "problem": {
       "nameRequired": "Donnez un nom à l'appareil.",
@@ -1314,13 +1315,18 @@
       "versionRequired": "Choisissez au moins une version.",
       "communityRequired": "v1 et v2c demandent une communauté.",
       "userRequired": "L'utilisateur SNMPv3 doit avoir un nom.",
-      "passphraseShort": "8 caractères au minimum."
+      "passphraseShort": "8 caractères au minimum.",
+      "userDuplicate": "Deux utilisateurs ne peuvent pas porter le même nom."
     },
     "model": {
       "linux-server": {
         "name": "Serveur Linux",
         "description": "Un hôte Ubuntu avec net-snmp : système, trois interfaces, ressources de l'hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
       }
-    }
+    },
+    "userN": "Utilisateur {n}",
+    "addUser": "Ajouter un utilisateur",
+    "removeUser": "Retirer cet utilisateur",
+    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur."
   }
 }

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -632,7 +632,8 @@
     "presetDeviceMasked": "设备已识别",
     "presetBind": "绑定",
     "presetBindTooltip": "将仪表板预设绑定到此设备",
-    "presetAlreadyBound": "已绑定：{names}。再绑定一个会增加一个轮询时钟。"
+    "presetAlreadyBound": "已绑定：{names}。再绑定一个会增加一个轮询时钟。",
+    "portInAddress": "由目标指定"
   },
   "update": {
     "available": "SnmpLens {version} 可用",
@@ -1314,13 +1315,18 @@
       "versionRequired": "请至少选择一个版本。",
       "communityRequired": "v1 和 v2c 需要团体名。",
       "userRequired": "SNMPv3 用户需要名称。",
-      "passphraseShort": "至少 8 个字符。"
+      "passphraseShort": "至少 8 个字符。",
+      "userDuplicate": "两个用户不能同名。"
     },
     "model": {
       "linux-server": {
         "name": "Linux 服务器",
         "description": "运行 net-snmp 的 Ubuntu 主机：系统、三个接口、主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
       }
-    }
+    },
+    "userN": "用户 {n}",
+    "addUser": "添加用户",
+    "removeUser": "删除此用户",
+    "firstUserTarget": "“添加为目标”使用第一个用户。"
   }
 }

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -7,8 +7,8 @@
  * one thing Go cannot: how a device becomes a TARGET, which lives in the
  * renderer's settings.
  *
- * The editor holds the SNMPv3 user in the shape UsmFields edits — `user`,
- * `secLevel`, the protocols and passphrases — and devicePayload turns it into
+ * The editor holds each SNMPv3 user in the shape UsmFields edits — `user`,
+ * `secLevel`, the protocols and passphrases — and devicePayload turns them into
  * Go's `users` list.
  */
 import { usesAuth, usesPriv } from './snmpSecurity.js';
@@ -19,8 +19,17 @@ export const SIM_VERSIONS = ['v1', 'v2c', 'v3'];
 /** The shortest passphrase a simulated user may have, as pkg/simulator holds it. */
 export const MIN_PASSPHRASE = 8;
 
-export function blankV3() {
-  return { user: 'simulator', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: '', privProto: 'AES', privPass: '', contextName: '' };
+/** A new SNMPv3 user; `n` numbers the ones after the first. */
+export function blankV3(n = 1) {
+  return {
+    user: n === 1 ? 'simulator' : `user${n}`,
+    secLevel: 'AuthPriv',
+    authProto: 'SHA256',
+    authPass: '',
+    privProto: 'AES',
+    privPass: '',
+    contextName: '',
+  };
 }
 
 /**
@@ -37,16 +46,24 @@ export function blankDevice(model, suggestion) {
     port: suggestion?.port || 1161,
     versions: ['v2c'],
     community: 'public',
-    v3: blankV3(),
+    users: [blankV3()],
   };
 }
 
 /**
  * A listed device in the editor's shape, its credentials filled in. The list
- * never carries them; they come from SimulatorDeviceCredentials.
+ * never carries them; they come from SimulatorDeviceCredentials, by user name.
  */
 export function editableDevice(view, creds) {
-  const u = view.users?.[0];
+  const users = (view.users || []).map((u) => ({
+    user: u.name,
+    secLevel: u.secLevel,
+    authProto: u.authProto || 'SHA256',
+    authPass: creds?.users?.[u.name]?.authPass || '',
+    privProto: u.privProto || 'AES',
+    privPass: creds?.users?.[u.name]?.privPass || '',
+    contextName: '',
+  }));
   return {
     id: view.id,
     name: view.name,
@@ -55,26 +72,18 @@ export function editableDevice(view, creds) {
     port: view.port,
     versions: [...(view.versions || [])],
     community: creds?.community || '',
-    v3: u
-      ? {
-          user: u.name,
-          secLevel: u.secLevel,
-          authProto: u.authProto || 'SHA256',
-          authPass: creds?.users?.[u.name]?.authPass || '',
-          privProto: u.privProto || 'AES',
-          privPass: creds?.users?.[u.name]?.privPass || '',
-          contextName: '',
-        }
-      : blankV3(),
+    users: users.length ? users : [blankV3()],
   };
 }
 
 const usesCommunity = (versions) => versions.includes('v1') || versions.includes('v2c');
 
 /**
- * What a device would be refused for, by field, as i18n key suffixes
- * (simulator.problem.<key>). Mirrors Device.Validate for what a form can get
- * wrong; Go still checks all of it, and the address.
+ * What a device would be refused for, as i18n key suffixes
+ * (simulator.problem.<key>): by field, and under `users`, one entry per SNMPv3
+ * user — present only when one of them has something wrong. Mirrors
+ * Device.Validate for what a form can get wrong; Go still checks all of it, and
+ * the address.
  */
 export function deviceProblems(d) {
   const problems = {};
@@ -85,22 +94,34 @@ export function deviceProblems(d) {
   if (!versions.length) problems.versions = 'versionRequired';
   if (usesCommunity(versions) && !d.community) problems.community = 'communityRequired';
   if (versions.includes('v3')) {
-    const u = d.v3 || {};
-    if (!u.user?.trim()) problems.user = 'userRequired';
-    if (usesAuth(u.secLevel) && (u.authPass || '').length < MIN_PASSPHRASE) problems.authPass = 'passphraseShort';
-    if (usesPriv(u.secLevel) && (u.privPass || '').length < MIN_PASSPHRASE) problems.privPass = 'passphraseShort';
+    const users = d.users || [];
+    if (!users.length) problems.noUser = 'userRequired';
+    const count = new Map();
+    for (const u of users) {
+      const name = (u.user || '').trim();
+      count.set(name, (count.get(name) || 0) + 1);
+    }
+    const perUser = users.map((u) => {
+      const p = {};
+      const name = (u.user || '').trim();
+      if (!name) p.user = 'userRequired';
+      else if (count.get(name) > 1) p.user = 'userDuplicate';
+      if (usesAuth(u.secLevel) && (u.authPass || '').length < MIN_PASSPHRASE) p.authPass = 'passphraseShort';
+      if (usesPriv(u.secLevel) && (u.privPass || '').length < MIN_PASSPHRASE) p.privPass = 'passphraseShort';
+      return p;
+    });
+    if (perUser.some((p) => Object.keys(p).length)) problems.users = perUser;
   }
   return problems;
 }
 
 /**
  * The device as SimulatorSaveDevice takes it: the community only if a version
- * uses one, the user only if v3 is answered. The engine is the backend's to
+ * uses one, the users only if v3 is answered. The engine is the backend's to
  * give, and is not sent.
  */
 export function devicePayload(d) {
   const versions = SIM_VERSIONS.filter((v) => d.versions.includes(v));
-  const u = d.v3 || {};
   return {
     id: d.id || '',
     name: d.name.trim(),
@@ -110,7 +131,14 @@ export function devicePayload(d) {
     versions,
     community: usesCommunity(versions) ? d.community : '',
     users: versions.includes('v3')
-      ? [{ name: (u.user || '').trim(), secLevel: u.secLevel, authProto: u.authProto, authPass: u.authPass, privProto: u.privProto, privPass: u.privPass }]
+      ? (d.users || []).map((u) => ({
+          name: (u.user || '').trim(),
+          secLevel: u.secLevel,
+          authProto: u.authProto,
+          authPass: u.authPass,
+          privProto: u.privProto,
+          privPass: u.privPass,
+        }))
       : [],
     engineId: '',
     engineBoots: 0,
@@ -122,21 +150,37 @@ export function preferredVersion(versions = []) {
   return ['v3', 'v2c', 'v1'].find((v) => versions.includes(v)) || 'v2c';
 }
 
-function addressOf(line) {
+/**
+ * The target a device is reached at: its address, and its port too unless that
+ * is SNMP's own 161 — "127.0.0.1:1162", "[::1]:1161". On macOS, where every
+ * device shares 127.0.0.1, the port is all that tells two devices apart, and a
+ * target that names it is a target of its own.
+ */
+export function targetOf(device) {
+  if (device.port === 161) return device.address;
+  const host = device.address.includes(':') ? `[${device.address}]` : device.address;
+  return `${host}:${device.port}`;
+}
+
+function targetOfLine(line) {
   return line.trim().replace(/^\/\//, '').split('#')[0].trim();
 }
 
 /**
- * The settings with a device added as a target: its address in the list, named
- * after it, and an override carrying its port and its identifiers in the most
- * secure version it answers.
+ * The settings with a device added as a target: the target in the list, named
+ * after the device, and an override carrying its identifiers in the most secure
+ * version it answers — with its FIRST user for v3.
  *
- * A target IS an address, so a device on an address already listed gives that
- * target its identifiers rather than adding a second line; `added` says which.
+ * The port travels in the target when it is not 161, and the override then
+ * leaves it out: the target's would win over it anyway. A device added again
+ * gives its target its identifiers once more instead of listing it twice;
+ * `added` says which.
  */
 export function addDeviceAsTarget(settings, device, creds) {
+  const target = targetOf(device);
   const version = preferredVersion(device.versions);
-  const override = { port: device.port, snmpVersion: version };
+  const override = { snmpVersion: version };
+  if (target === device.address) override.port = device.port;
   if (version === 'v3') {
     const u = device.users[0];
     override.v3 = {
@@ -152,11 +196,12 @@ export function addDeviceAsTarget(settings, device, creds) {
     override.community = creds?.community || '';
   }
   const lines = (settings.targets || '').split('\n').filter((l) => l.trim());
-  const added = !lines.some((l) => addressOf(l) === device.address);
-  const targets = added ? [...lines, `${device.address} # ${device.name}`].join('\n') : settings.targets;
+  const added = !lines.some((l) => targetOfLine(l) === target);
+  const targets = added ? [...lines, `${target} # ${device.name}`].join('\n') : settings.targets;
   return {
-    settings: { ...settings, targets, targetOverrides: { ...(settings.targetOverrides || {}), [device.address]: override } },
+    settings: { ...settings, targets, targetOverrides: { ...(settings.targetOverrides || {}), [target]: override } },
     added,
     version,
+    target,
   };
 }

--- a/frontend/src/utils/targets.js
+++ b/frontend/src/utils/targets.js
@@ -96,6 +96,27 @@ export function targetTitle(address, anon) {
 }
 
 /**
+ * The port a target names, or null. "10.0.0.5:1161", "switch-01:1161" and
+ * "[2001:db8::5]:1161" name one; an address, a host name or a bare IPv6 literal —
+ * whose colons are not a port — do not.
+ *
+ * The same reading as Go's netaddr.SplitTarget, which is what a request is
+ * dialled with, and the same rule: a port the target names wins over every port
+ * field. Simulated devices on macOS all answer on 127.0.0.1 and differ by port
+ * alone, and a target is what tells devices apart.
+ *
+ * @param {string} target
+ * @returns {number|null}
+ */
+export function portOf(target) {
+  const t = String(target || '').trim();
+  const m = t.match(/^\[[^\]]+\]:(\d{1,5})$/) || t.match(/^[^:[\]]+:(\d{1,5})$/);
+  if (!m) return null;
+  const port = Number(m[1]);
+  return port >= 1 && port <= 65535 ? port : null;
+}
+
+/**
  * The settings a request to one target is built from.
  *
  * Identity first — who the request says it is — then transport. The identity
@@ -109,13 +130,19 @@ export function targetTitle(address, anon) {
  * record it and follow the profile afterwards: 'default', a profile id, or ''
  * for the target's own overrides.
  *
+ * A port the target names ("127.0.0.1:1162", portOf) wins over the override's
+ * and the default's, as it does in Go — so what the renderer groups and records
+ * is the port the request is actually sent to.
+ *
  * @param {object} settings - The full $settingsStore value
  * @param {string} address - Target address
  * @returns {object} Merged settings
  */
 export function getEffectiveSettings(settings, address) {
+  const named = portOf(address);
+  const withNamedPort = (s) => (named ? { ...s, port: named } : s);
   const overrides = settings.targetOverrides?.[address];
-  if (!overrides) return { ...settings, credentialRef: DEFAULT_REF };
+  if (!overrides) return withNamedPort({ ...settings, credentialRef: DEFAULT_REF });
 
   const profile = findProfile(settings, overrides.profile);
   let identity;
@@ -132,13 +159,13 @@ export function getEffectiveSettings(settings, address) {
     identity = { credentialRef: DEFAULT_REF };
   }
 
-  return {
+  return withNamedPort({
     ...settings,
     ...identity,
     ...(overrides.port !== undefined && { port: overrides.port }),
     ...(overrides.timeout !== undefined && { timeout: overrides.timeout }),
     ...(overrides.retries !== undefined && { retries: overrides.retries }),
-  };
+  });
 }
 
 /**

--- a/frontend/tests/fixtures/simulator-entry.js
+++ b/frontend/tests/fixtures/simulator-entry.js
@@ -1,6 +1,6 @@
-// The simulator's renderer-side rules, from one bundle, with the function a
-// device added as a target has to satisfy. targets.js reaches the settings store
-// through anonymize.js, and the store reaches the Wails bridge, so it cannot be
-// imported under node directly.
+// The simulator's renderer-side rules, from one bundle, with what a device added
+// as a target has to satisfy. targets.js reaches the settings store through
+// anonymize.js, and the store reaches the Wails bridge, so it cannot be imported
+// under node directly.
 export * from '../../src/utils/simulator.js';
-export { getEffectiveSettings } from '../../src/utils/targets.js';
+export { getEffectiveSettings, portOf } from '../../src/utils/targets.js';

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -1,10 +1,11 @@
-// The simulator's renderer-side rules: the device form, and how a device
-// becomes a target.
+// The simulator's renderer-side rules: the device form, with its SNMPv3 users,
+// and how a device becomes a target.
 //
 // The second is the part only the renderer can get wrong — a target lives in
 // the settings — so it is checked THROUGH getEffectiveSettings, which is what
 // every request is built from: a device added as a target must resolve to its
-// own port and identifiers, in the most secure version it answers.
+// own port and identifiers. On macOS every device shares 127.0.0.1, so that
+// takes a target that names its port.
 import * as esbuild from 'esbuild';
 import { readFileSync, readdirSync, writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -46,12 +47,15 @@ if (!globalThis.navigator) {
 
 const {
   blankDevice,
+  blankV3,
   editableDevice,
   deviceProblems,
   devicePayload,
   preferredVersion,
+  targetOf,
   addDeviceAsTarget,
   getEffectiveSettings,
+  portOf,
 } = await import(pathToFileURL(bundle).href);
 
 let failures = 0;
@@ -69,12 +73,20 @@ check('its one problem is its missing name',
   JSON.stringify(deviceProblems(fresh)) === JSON.stringify({ name: 'nameRequired' }),
   JSON.stringify(deviceProblems(fresh)));
 
-const v3only = { ...fresh, name: 'x', versions: ['v3'], v3: { ...fresh.v3, authPass: 'short', privPass: 'short' } };
-const p3 = deviceProblems(v3only);
-check('a v3 user with short passphrases is refused on both', p3.authPass === 'passphraseShort' && p3.privPass === 'passphraseShort');
-check('and v3 alone needs no community', !p3.community);
-const authOnly = { ...v3only, v3: { ...v3only.v3, secLevel: 'AuthNoPriv', authPass: 'long-enough' } };
-check('a passphrase the level does not use is not asked for', !deviceProblems(authOnly).privPass);
+const v3With = (users) => ({ ...fresh, name: 'x', versions: ['v3'], users });
+const good = (name) => ({ ...blankV3(), user: name, authPass: 'authpass-1', privPass: 'privpass-1' });
+
+const short = deviceProblems(v3With([{ ...blankV3(), authPass: 'short', privPass: 'short' }]));
+check('a v3 user with short passphrases is refused on both',
+  short.users?.[0]?.authPass === 'passphraseShort' && short.users?.[0]?.privPass === 'passphraseShort');
+check('and v3 alone needs no community', !short.community);
+check('a passphrase the level does not use is not asked for',
+  !deviceProblems(v3With([{ ...good('ops'), secLevel: 'AuthNoPriv', privPass: '' }])).users);
+check('two well-formed users are no problem', !deviceProblems(v3With([good('ops'), good('monitor')])).users);
+const dup = deviceProblems(v3With([good('ops'), good(' ops ')]));
+check('two users with one name are both told so',
+  dup.users?.[0]?.user === 'userDuplicate' && dup.users?.[1]?.user === 'userDuplicate');
+check('v3 with no user is refused', deviceProblems(v3With([])).noUser === 'userRequired');
 
 /* --- what is sent -------------------------------------------------------- */
 
@@ -82,25 +94,49 @@ const sent = devicePayload({ ...fresh, name: ' srv ' });
 check('v2c alone sends no user, and the name trimmed',
   sent.users.length === 0 && sent.community === 'public' && sent.name === 'srv');
 check("the engine is not the renderer's to send", sent.engineId === '' && sent.engineBoots === 0);
-const sent3 = devicePayload({ ...v3only, v3: { ...v3only.v3, authPass: 'authpass-1', privPass: 'privpass-1' } });
-check("v3 alone sends no community, and the user under Go's names",
-  sent3.community === '' && sent3.users[0].name === 'simulator' && sent3.users[0].privPass === 'privpass-1',
-  JSON.stringify(sent3.users));
+const sent3 = devicePayload(v3With([good(' ops '), good('monitor')]));
+check("v3 alone sends no community, and every user under Go's names",
+  sent3.community === '' && sent3.users.length === 2 && sent3.users[0].name === 'ops' && sent3.users[1].privPass === 'privpass-1',
+  JSON.stringify(sent3.users.map((u) => u.name)));
 
 /* --- editing brings the credentials back --------------------------------- */
 
 const view = {
   id: 'a1', name: 'srv', model: 'linux-server', address: '127.0.0.2', port: 161,
-  versions: ['v2c', 'v3'], users: [{ name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', privProto: 'AES' }],
+  versions: ['v2c', 'v3'],
+  users: [
+    { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', privProto: 'AES' },
+    { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', privProto: 'AES' },
+  ],
 };
-const creds = { community: 'c0mmunity', users: { ops: { authPass: 'authpass-1', privPass: 'privpass-1' } } };
+const creds = {
+  community: 'c0mmunity',
+  users: { ops: { authPass: 'authpass-1', privPass: 'privpass-1' }, monitor: { authPass: 'monitor-pass', privPass: '' } },
+};
 const form = editableDevice(view, creds);
-check('the editor is given the community and the passphrases',
-  form.community === 'c0mmunity' && form.v3.user === 'ops' && form.v3.privPass === 'privpass-1');
-check('and editing nothing sends back the same user',
-  JSON.stringify(devicePayload(form).users[0]) === JSON.stringify({
-    name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1',
-  }));
+check('the editor is given the community, and every user with its passphrases',
+  form.community === 'c0mmunity' && form.users.length === 2 &&
+  form.users[0].privPass === 'privpass-1' && form.users[1].authPass === 'monitor-pass');
+check('and editing nothing sends back the same users',
+  JSON.stringify(devicePayload(form).users) === JSON.stringify([
+    { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1' },
+    { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', authPass: 'monitor-pass', privProto: 'AES', privPass: '' },
+  ]));
+
+/* --- the port a target names --------------------------------------------- */
+
+check('a target names its port in each form a person writes one',
+  portOf('10.0.0.5:1161') === 1161 && portOf('switch-01:1161') === 1161 &&
+  portOf('[2001:db8::5]:1161') === 1161 && portOf(' 127.0.0.1:1162 ') === 1162);
+check('an address, a name or a bare IPv6 literal names none',
+  portOf('10.0.0.5') === null && portOf('switch-01') === null && portOf('::1') === null &&
+  portOf('2001:db8::5') === null && portOf('[::1]') === null);
+check('what is not a port is not read as one',
+  portOf('10.0.0.5:0') === null && portOf('10.0.0.5:70000') === null && portOf(':1161') === null);
+check("a device's target carries its port unless it is 161",
+  targetOf({ address: '127.0.0.2', port: 161 }) === '127.0.0.2' &&
+  targetOf({ address: '127.0.0.1', port: 1162 }) === '127.0.0.1:1162' &&
+  targetOf({ address: '::1', port: 1161 }) === '[::1]:1161');
 
 /* --- a device as a target, resolved as every request resolves it ---------- */
 
@@ -119,24 +155,38 @@ const settings = {
   v3: { user: 'default-user', authPass: '', authProto: 'SHA', privPass: '', privProto: 'AES', secLevel: 'NoAuthNoPriv', contextName: '' },
 };
 
-const v2cDevice = { ...view, versions: ['v2c'], users: [], port: 1161 };
-const first = addDeviceAsTarget(settings, v2cDevice, creds);
-const eff1 = getEffectiveSettings(first.settings, '127.0.0.2');
-check('the device joins the targets, named after it',
-  first.added && first.settings.targets.split('\n').includes('127.0.0.2 # srv'));
-check('the targets already there stay', first.settings.targets.startsWith('10.0.0.1 # router'));
-check('it resolves to its own port and community, in v2c',
-  eff1.port === 1161 && eff1.community === 'c0mmunity' && eff1.snmpVersion === 'v2c',
-  JSON.stringify({ port: eff1.port, community: eff1.community, version: eff1.snmpVersion }));
+// Windows and Linux: an address of its own, at 161.
+const own = addDeviceAsTarget(settings, view, creds);
+const effOwn = getEffectiveSettings(own.settings, own.target);
+check('a device at 161 is a target by its address, named after it',
+  own.added && own.target === '127.0.0.2' && own.settings.targets.split('\n').includes('127.0.0.2 # srv'));
+check('the targets already there stay', own.settings.targets.startsWith('10.0.0.1 # router'));
+check("it resolves to the device's first SNMPv3 user, at its port",
+  effOwn.snmpVersion === 'v3' && effOwn.v3.user === 'ops' && effOwn.v3.secLevel === 'AuthPriv' &&
+  effOwn.v3.privPass === 'privpass-1' && effOwn.port === 161,
+  JSON.stringify({ version: effOwn.snmpVersion, user: effOwn.v3.user, port: effOwn.port }));
+const again = addDeviceAsTarget(own.settings, view, creds);
+check('a device added twice is listed once',
+  !again.added && again.settings.targets.split('\n').filter((l) => l.startsWith('127.0.0.2')).length === 1);
 
-const second = addDeviceAsTarget(first.settings, view, creds);
-const eff2 = getEffectiveSettings(second.settings, '127.0.0.2');
-check('an address already listed is not listed twice',
-  !second.added && second.settings.targets.split('\n').filter((l) => l.startsWith('127.0.0.2')).length === 1);
-check("and it takes the device's SNMPv3 identity",
-  eff2.snmpVersion === 'v3' && eff2.v3.user === 'ops' && eff2.v3.secLevel === 'AuthPriv' &&
-  eff2.v3.privPass === 'privpass-1' && eff2.port === 161,
-  JSON.stringify({ version: eff2.snmpVersion, user: eff2.v3.user, port: eff2.port }));
+// macOS: every device on 127.0.0.1, told apart by port alone.
+const mac1 = { ...view, id: 'm1', name: 'mac-1', address: '127.0.0.1', port: 1161, versions: ['v2c'], users: [] };
+const mac2 = { ...mac1, id: 'm2', name: 'mac-2', port: 1162 };
+const r1 = addDeviceAsTarget(settings, mac1, creds);
+const r2 = addDeviceAsTarget(r1.settings, mac2, { community: 'other', users: {} });
+const e1 = getEffectiveSettings(r2.settings, '127.0.0.1:1161');
+const e2 = getEffectiveSettings(r2.settings, '127.0.0.1:1162');
+check('two devices sharing 127.0.0.1 are two targets',
+  r1.added && r2.added && r2.settings.targets.split('\n').length === 3, r2.settings.targets);
+check('each resolving to its own port and community',
+  e1.port === 1161 && e1.community === 'c0mmunity' && e2.port === 1162 && e2.community === 'other',
+  JSON.stringify({ one: [e1.port, e1.community], two: [e2.port, e2.community] }));
+check('with no override of a port the target already names',
+  r2.settings.targetOverrides['127.0.0.1:1162'].port === undefined);
+
+const overruled = { ...settings, targetOverrides: { '127.0.0.1:1162': { port: 9999 } } };
+check("a port the target names wins over an override's", getEffectiveSettings(overruled, '127.0.0.1:1162').port === 1162);
+check('and over the default, with no override at all', getEffectiveSettings(settings, '127.0.0.1:1163').port === 1163);
 
 /* --- every model Go serves is named and described ------------------------ */
 

--- a/pkg/netaddr/address.go
+++ b/pkg/netaddr/address.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -19,8 +20,7 @@ import (
 // which names neither the brackets nor the target. Measured against a live
 // agent before this function existed; the unbracketed form worked all along.
 //
-// A host:port pair is deliberately NOT split: the port is its own field in the
-// UI, and quietly overriding what someone typed there is worse than an error.
+// It does not read a port: SplitTarget does, and every dial goes through it.
 func NormaliseTarget(target string) string {
 	t := strings.TrimSpace(target)
 	if len(t) >= 2 && t[0] == '[' && t[len(t)-1] == ']' {
@@ -29,6 +29,30 @@ func NormaliseTarget(target string) string {
 		}
 	}
 	return t
+}
+
+// SplitTarget reads the port a target names, if it names one: "10.0.0.5:1161",
+// "switch-01:1161" and "[2001:db8::5]:1161" are that host at that port. Anything
+// else — an address, a host name, a bare IPv6 literal, whose colons are not a
+// port — is the host at the port given.
+//
+// A port the target names wins over the port field. This package used to refuse
+// to split one, reasoning that the port is its own field and that overriding
+// what someone typed there is worse than an error. What changed it: simulated
+// devices on macOS all answer on 127.0.0.1, the one loopback address it
+// configures, and differ by port alone — and a target is what tells devices
+// apart. A port in the target is also the more specific of the two.
+func SplitTarget(target string, port int) (string, int) {
+	t := strings.TrimSpace(target)
+	host, p, err := net.SplitHostPort(t)
+	if err != nil || host == "" {
+		return NormaliseTarget(t), port
+	}
+	n, err := strconv.Atoi(p)
+	if err != nil || n < 1 || n > 65535 {
+		return NormaliseTarget(t), port
+	}
+	return host, n
 }
 
 // IsIPLiteral reports whether s is an IP address, zone and all.

--- a/pkg/netaddr/address_test.go
+++ b/pkg/netaddr/address_test.go
@@ -56,6 +56,39 @@ func TestNormalisedTargetSurvivesJoinHostPort(t *testing.T) {
 	}
 }
 
+// A target may name its port, in each form a person writes one, and a bare IPv6
+// literal's colons are not taken for one.
+func TestSplitTargetReadsThePortATargetNames(t *testing.T) {
+	cases := []struct {
+		in   string
+		host string
+		port int
+	}{
+		{"10.0.0.5:1161", "10.0.0.5", 1161},
+		{"switch-01.example.com:1161", "switch-01.example.com", 1161},
+		{"[2001:db8::5]:1161", "2001:db8::5", 1161},
+		{"[fe80::1%eth0]:1161", "fe80::1%eth0", 1161},
+		{"  127.0.0.1:1162  ", "127.0.0.1", 1162},
+		// No port named: the one given stands.
+		{"10.0.0.5", "10.0.0.5", 161},
+		{"switch-01.example.com", "switch-01.example.com", 161},
+		{"::1", "::1", 161},
+		{"2001:db8::5", "2001:db8::5", 161},
+		{"[::1]", "::1", 161},
+		{"fe80::1%eth0", "fe80::1%eth0", 161},
+		// What is not a port is not read as one.
+		{"10.0.0.5:0", "10.0.0.5:0", 161},
+		{"10.0.0.5:70000", "10.0.0.5:70000", 161},
+		{"10.0.0.5:snmp", "10.0.0.5:snmp", 161},
+		{":1161", ":1161", 161},
+	}
+	for _, c := range cases {
+		if host, port := SplitTarget(c.in, 161); host != c.host || port != c.port {
+			t.Errorf("SplitTarget(%q) = %q, %d; want %q, %d", c.in, host, port, c.host, c.port)
+		}
+	}
+}
+
 // A wildcard listen must accept both families, or IPv6 traps never arrive.
 // Asserted against the socket rather than the string, because it is Go's
 // wildcard handling — not the text — that decides.

--- a/pkg/network/tools.go
+++ b/pkg/network/tools.go
@@ -46,7 +46,8 @@ func Ping(target string, count int) (PingResult, error) {
 	if count <= 0 {
 		count = 4
 	}
-	target = netaddr.NormaliseTarget(target)
+	// A target that names its SNMP port ("10.0.0.5:1161") is still that host.
+	target, _ = netaddr.SplitTarget(target, 0)
 	result := PingResult{Target: target}
 	if err := netaddr.ValidTarget(target); err != nil {
 		return result, err
@@ -90,7 +91,8 @@ func Ping(target string, count int) (PingResult, error) {
 // Traceroute uses system traceroute/tracert command with OS-specific arguments.
 // Emits "tracerouteProgress" events per hop via Wails runtime.
 func Traceroute(ctx context.Context, target string) ([]TracerouteHop, error) {
-	target = netaddr.NormaliseTarget(target)
+	// A target that names its SNMP port ("10.0.0.5:1161") is still that host.
+	target, _ = netaddr.SplitTarget(target, 0)
 	// Checked before it becomes argv. There is no shell here, so nothing can
 	// be injected as a command — but a value starting with a dash IS read as
 	// an option by tracert and by traceroute, and nothing checked.

--- a/pkg/snmp/client.go
+++ b/pkg/snmp/client.go
@@ -164,8 +164,11 @@ func concurrentExecute(targets []string, fn func(target string) *BulkResult) []*
 
 // newGoSNMP creates and configures a GoSNMP instance.
 func (c *Client) newGoSNMP(target, community, version string, port, timeoutSec, retries int, v3 V3Params) (*gosnmp.GoSNMP, error) {
+	// A target may name its own port ("127.0.0.1:1162"), which then wins over
+	// the port field (netaddr.SplitTarget).
+	host, port := netaddr.SplitTarget(target, port)
 	g := &gosnmp.GoSNMP{
-		Target:    netaddr.NormaliseTarget(target),
+		Target:    host,
 		Port:      normalisePort(port, DefaultPort),
 		Community: community,
 		Timeout:   time.Duration(timeoutSec) * time.Second,

--- a/pkg/snmp/trap.go
+++ b/pkg/snmp/trap.go
@@ -517,8 +517,11 @@ func (c *Client) SendInform(target string, port int, community, version, trapOid
 }
 
 func (c *Client) sendNotification(target string, port int, community, version, trapOid string, variables []TrapVariable, inform bool) (bool, error) {
+	// A destination may name its own port, which then wins over the port field,
+	// as it does for every request (netaddr.SplitTarget).
+	host, port := netaddr.SplitTarget(target, port)
 	g := &gosnmp.GoSNMP{
-		Target:    netaddr.NormaliseTarget(target),
+		Target:    host,
 		Port:      normalisePort(port, DefaultTrapPort),
 		Community: community,
 		Timeout:   5 * time.Second,


### PR DESCRIPTION
## Summary

Two follow-ups to the simulator (#64).

### Several SNMPv3 users per simulated device

- The editor shows one block per user (`UsmFields`, bound), with **Add a user** and a remove button on each block except the last.
- Checks run per user, and a name two users share is refused on both.
- The device list shows each device's user names, masked in Anonymous Mode.
- **Add as target** gives the target the device's first user, and the editor says so once there are several.
- Go needed nothing new: `Device.Users` was already a list, validated for unique names, and its passphrases are in the credential store by user name.

### A target may name its port: macOS made whole

- `netaddr.SplitTarget` reads a port the target names (`10.0.0.5:1161`, `switch-01:1161`, `[2001:db8::5]:1161`), and that port wins over the port field. Every dial goes through it, the trap sender's included. A bare IPv6 literal's colons are never taken for a port.
- `portOf` in `utils/targets.js` is the same reading on the renderer's side. `getEffectiveSettings` applies it last, so what the renderer groups and records is the port the request is actually sent to.
- Ping and traceroute take the host alone.
- `TargetOverrideForm` shows such a port as the target's, instead of offering a port field that would be ignored.
- A simulated device is added as a target with its port unless that is 161 (`127.0.0.1:1162`). On macOS, which answers on 127.0.0.1 alone unless aliases are added, every device is therefore a target of its own.
- `SimulatorSuggestAddress` still offers an address of its own first, and finds out by binding which addresses exist. That also works on a Mac with aliases; failing that, it offers 127.0.0.1 at the next free port.

## Verification

- `TestSplitTargetReadsThePortATargetNames` covers every form, and what must not be read as a port.
- The address suggestion is tested for macOS both without aliases and with them.
- `tests/simulator.test.mjs`:
  - two devices sharing 127.0.0.1 become two targets, each resolving through `getEffectiveSettings` to its own port and community;
  - a port the target names wins over an override's port;
  - multiple users: duplicate names refused, and every user's passphrases round-trip through the editor.
- `go vet`, `go test -race ./...` and staticcheck 0.8.1 are clean. `npm test`, `svelte-check --fail-on-warnings` and the Vite build pass.
- The `simulator-editor` scene now adds a second user; checked in both themes.
