### PR TITLE
Let a simulated device send traps and INFORMs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ The frontend calls Go through auto-generated bindings in `frontend/wailsjs/`, wh
 - `pkg/snmp/` — SNMP over **gosnmp**: `client.go` (connection config, v3 security-protocol mapping, concurrent fan-out via `concurrentExecute`, debug
   ring-buffer logger — scrubbed at the WRITER, because gosnmp's `SnmpPacket.SafeString` is not safe: it prints
   `Community:%s` on every SENDING PACKET and `Parsed community %s` on every receive, and the buffer is what the
-  debug panel shows), `operations.go` (GET/SET/GETNEXT/GETBULK/WALK), `trap.go` (listener + sender, traps and acknowledged INFORMs — v1 is refused rather than downgraded, since RFC 1157 has no InformRequest PDU), `discovery.go` (CIDR scan, capped at `MaxDiscoveryHosts` — the prefix sizes the allocation before a packet is
+  debug panel shows), `operations.go` (GET/SET/GETNEXT/GETBULK/WALK), `trap.go` (listener + sender, traps and acknowledged INFORMs — v1 is refused rather than downgraded, since RFC 1157 has no InformRequest PDU; the listener's engine ID comes from outside, `SetTrapEngineID`, because it cannot be discovered — see **The simulator**), `discovery.go` (CIDR scan, capped at `MaxDiscoveryHosts` — the prefix sizes the allocation before a packet is
   sent, so `10.0.0.0/8` was 16.7M strings and an IPv6 `/64` never finished expanding), `params.go` (bridge request structs).
 - `pkg/simulator/` — simulated SNMP agents: v1, v2c and v3 with the whole USM, answering from a tree of objects on
   a loopback address, so SnmpLens can be tested and shown without a device. A leaf package — gosnmp and nothing of
@@ -620,8 +620,42 @@ were added — the port is all that does. A port the target names wins over ever
 (`netaddr.SplitTarget`) and in `getEffectiveSettings`, so the override leaves it out and `TargetOverrideForm`
 shows it as the target's rather than offering a field that would be ignored. The test resolves the result through
 `getEffectiveSettings`, which every request is built from, with two devices sharing 127.0.0.1.
-`SimulatorSuggestAddress` still offers an address of its own first, finding by binding which ones exist: once
-devices send traps, their source address is what will tell them apart.
+`SimulatorSuggestAddress` still offers an address of its own first, finding by binding which ones exist: a
+device's notifications to this machine leave from that address, and it is what tells them apart in the trap list.
+
+**Notifications** (`notify.go`). A device sends traps and INFORMs in v1, v2c and v3 to up to eight destinations:
+when it starts (`coldStart`), when a request is refused (`authenticationFailure`), on schedules, and on request
+(`SimulatorSendTrap`). A destination may be anywhere — the loopback rule is about where a device ANSWERS, and one
+that could only notify its own machine could not test a collector elsewhere — so what is bounded is the RATE. A
+refused request is a datagram anything on the machine can send, and uncapped, each spoofed GET would become a
+notification sent to the network: `authenticationFailure` goes out about once a second at most, a device sends 20
+a second (burst 40), and what the cap holds back is counted (`Suppressed`), as is what a full queue drops. One
+goroutine per destination, so an INFORM waiting out its timeout holds up that receiver and no other; stopping closes
+the socket under it, because gosnmp looks at its context between two attempts and not during one.
+
+What each version carries is what an agent's does, and the tests decode it. v2c and v3 put `sysUpTime.0` and
+`snmpTrapOID.0` first — gosnmp otherwise PREPENDS a sysUpTime of its own, which is the Unix time — then the
+notification's objects read from the device's tree at that instant, so linkDown says what a GET would, then for a
+generic notification `snmpTrapEnterprise.0` with the sysObjectID, as net-snmp sends it. v1 is RFC 3584 3.2: the
+generic-trap under the sysObjectID, or enterpriseSpecific with the enterprise cut before the last arc, and before
+the zero ahead of it; a notification carrying a Counter64 has no v1 form and is not sent. A notification to this
+machine leaves from the device's own address (`LocalAddr`); to anywhere else, from the system's choice.
+
+In v3 the direction decides everything. A trap is authoritative at the SENDER, so it goes as the device's own
+engine — the keys the agent localised, its boots, its time — and the test opens it with keys localised to the
+device's engine ID. An INFORM is authoritative at the RECEIVER: it goes with the passphrases, which gosnmp localises
+to the engine ID the destination gives, or to one it discovers when none is given. SnmpLens's own listener cannot be
+discovered — gosnmp's table of users drops a message naming no user before anything could answer it — so
+`snmp.Client.SetTrapEngineID` gives it one, the app keeps it in `trap-engine-id` beside `monitoring.db` (RFC 3411's
+fifth format under enterprise 0, IANA's reserved: SnmpLens has no number of its own and must not borrow a
+vendor's), the Traps panel shows it, and the editor fills it in for "SnmpLens on this machine". gosnmp does not hold
+a sender to it: an INFORM localised to any other valid engine ID is read all the same. `TestSnmpLensHearsTheSimulator`
+drives that whole path, a v2c trap journalled and a v3 INFORM acknowledged.
+
+A destination's community is a secret like the device's, kept by destination ID in the same `DeviceSecrets`, and the
+ID is given in Go as a device's is. Notifications are shown by their MIB names — `linkDown`, `nsNotifyShutdown` —
+which no manager translates; `tests/simulator.test.mjs` requires `en.json` to answer for every problem key and every
+delivery message the renderer builds.
 
 One trap for whoever adds a model: a file named `model_linux.go` is compiled on Linux ONLY — `_linux` is a GOOS
 suffix, and the build on Windows reported the model as undefined — so the Linux model lives in `linuxserver.go`.

--- a/app.go
+++ b/app.go
@@ -65,6 +65,8 @@ type App struct {
 
 	// sim holds and runs the simulated devices (app_simulator.go).
 	sim *simulatorService
+	// trapEngineID is the trap listener's snmpEngineID (app_trapengine.go).
+	trapEngineID []byte
 }
 
 // NewApp creates a new App application struct.
@@ -148,6 +150,11 @@ func (a *App) startup(ctx context.Context) {
 	// The simulated devices are read, not started: a device answers only once
 	// someone starts it in this session.
 	a.sim = newSimulatorService(filepath.Join(configDir, "SnmpLens"))
+
+	// The trap listener's engine ID, before initBackgroundMode can start the
+	// listener: a device sending it SNMPv3 INFORMs is configured with it.
+	a.trapEngineID = loadTrapEngineID(filepath.Join(configDir, "SnmpLens"))
+	a.snmpClient.SetTrapEngineID(a.trapEngineID)
 
 	// 4. Load core MIBs
 	coreMibs := []string{"SNMPv2-SMI", "SNMPv2-TC"}

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -117,7 +117,35 @@ type SimulatedDevice struct {
 	EngineBoots uint32          `json:"engineBoots"`
 	Running     bool            `json:"running"`
 	// Packets is what the device has received since it started.
-	Packets uint32 `json:"packets"`
+	Packets uint32         `json:"packets"`
+	Traps   SimulatedTraps `json:"traps"`
+}
+
+// SimulatedTraps is what a simulated device sends, as the list shows it: the
+// destinations without their communities, each with what it has been sent since
+// the device started.
+type SimulatedTraps struct {
+	Destinations  []SimulatedDestination `json:"destinations"`
+	OnStart       bool                   `json:"onStart"`
+	OnAuthFailure bool                   `json:"onAuthFailure"`
+	Schedules     []simulator.Schedule   `json:"schedules"`
+	// Suppressed counts what the device's cap held back.
+	Suppressed uint32 `json:"suppressed"`
+}
+
+// SimulatedDestination is a destination without its community.
+type SimulatedDestination struct {
+	ID        string `json:"id"`
+	Host      string `json:"host"`
+	Port      int    `json:"port"`
+	Version   string `json:"version"`
+	Inform    bool   `json:"inform"`
+	User      string `json:"user"`
+	EngineID  string `json:"engineId"`
+	Sent      uint32 `json:"sent"`
+	Failed    uint32 `json:"failed"`
+	Dropped   uint32 `json:"dropped"`
+	LastError string `json:"lastError"`
 }
 
 // SimulatedUser is an SNMPv3 user of a simulated device, without passphrases.
@@ -134,11 +162,28 @@ func (s *simulatorService) view(d simulator.Device) SimulatedDevice {
 		users[i] = SimulatedUser{Name: u.Name, SecLevel: u.SecLevel, AuthProto: u.AuthProto, PrivProto: u.PrivProto}
 	}
 	stats, running := s.fleet.Status(d.ID)
+	traps := SimulatedTraps{
+		Destinations:  make([]SimulatedDestination, len(d.Traps.Destinations)),
+		OnStart:       d.Traps.OnStart,
+		OnAuthFailure: d.Traps.OnAuthFailure,
+		Schedules:     append([]simulator.Schedule{}, d.Traps.Schedules...),
+		Suppressed:    stats.Suppressed,
+	}
+	for i, dest := range d.Traps.Destinations {
+		v := SimulatedDestination{ID: dest.ID, Host: dest.Host, Port: dest.Port, Version: dest.Version,
+			Inform: dest.Inform, User: dest.User, EngineID: dest.EngineID}
+		for _, st := range stats.Notifications {
+			if st.ID == dest.ID {
+				v.Sent, v.Failed, v.Dropped, v.LastError = st.Sent, st.Failed, st.Dropped, st.LastError
+			}
+		}
+		traps.Destinations[i] = v
+	}
 	return SimulatedDevice{
 		ID: d.ID, Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
 		Versions: slices.Clone(d.Versions), Users: users,
 		EngineID: d.EngineID, EngineBoots: d.EngineBoots,
-		Running: running, Packets: stats.Packets,
+		Running: running, Packets: stats.Packets, Traps: traps,
 	}
 }
 
@@ -253,6 +298,16 @@ func (a *App) SimulatorSaveDevice(d simulator.Device) (SimulatedDevice, error) {
 	}
 	d.Name = strings.TrimSpace(d.Name)
 	d.Address = strings.TrimSpace(d.Address)
+	// A destination is given its ID here, as a device is: its community is kept
+	// under it.
+	d.Traps.Destinations = slices.Clone(d.Traps.Destinations)
+	for i := range d.Traps.Destinations {
+		dest := &d.Traps.Destinations[i]
+		dest.Host = strings.TrimSpace(dest.Host)
+		if dest.ID == "" {
+			dest.ID = simulator.NewDestinationID()
+		}
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -369,6 +424,21 @@ func (a *App) SimulatorStopDevice(id string) error {
 		a.emitSimulatorChanged()
 	}
 	return nil
+}
+
+// SimulatorSendTrap has a running simulated device send a notification now to
+// each of its destinations, and reports what became of it at each — for an
+// INFORM, once the receiver has answered or not.
+func (a *App) SimulatorSendTrap(id, notification string) ([]simulator.Delivery, error) {
+	s := a.sim
+	if s == nil {
+		return []simulator.Delivery{}, errNoSimulator
+	}
+	out, err := s.fleet.Notify(id, notification)
+	if out == nil {
+		out = []simulator.Delivery{}
+	}
+	return out, err
 }
 
 // SimulatorDeviceCredentials returns a device's community and passphrases: for

--- a/app_simulator_test.go
+++ b/app_simulator_test.go
@@ -31,10 +31,38 @@ func simDevice() simulator.Device {
 		Versions: []string{"v2c", "v3"}, Community: "s3cr3t-community",
 		Users: []simulator.User{{Name: "ops", SecLevel: "AuthPriv",
 			AuthProto: "SHA256", AuthPass: "auth-s3cr3t", PrivProto: "AES", PrivPass: "priv-s3cr3t"}},
+		Traps: simulator.Traps{Destinations: []simulator.Destination{
+			{Host: "127.0.0.1", Port: 1162, Version: "v2c", Community: "trap-s3cr3t"}}},
 	}
 }
 
-var simSecrets = []string{"s3cr3t-community", "auth-s3cr3t", "priv-s3cr3t"}
+var simSecrets = []string{"s3cr3t-community", "auth-s3cr3t", "priv-s3cr3t", "trap-s3cr3t"}
+
+// startSimulated saves d at 127.0.0.1 on a free port and starts it. A port
+// found free can be taken before the device binds it, since `go test ./...`
+// runs every package at once; another is tried.
+func startSimulated(t *testing.T, a *App, d simulator.Device) SimulatedDevice {
+	t.Helper()
+	var saved SimulatedDevice
+	var err error
+	for attempt := 0; attempt < 5; attempt++ {
+		c, lerr := net.ListenPacket("udp", "127.0.0.1:0")
+		if lerr != nil {
+			t.Skipf("no UDP socket: %v", lerr)
+		}
+		d.ID = saved.ID
+		d.Address, d.Port = "127.0.0.1", c.LocalAddr().(*net.UDPAddr).Port
+		c.Close()
+		if saved, err = a.SimulatorSaveDevice(d); err != nil {
+			t.Fatal(err)
+		}
+		if err = a.SimulatorStartDevice(saved.ID); err == nil {
+			return saved
+		}
+	}
+	t.Fatalf("the device would not start: %v", err)
+	return saved
+}
 
 // The device file never holds a secret, and neither does the list the renderer
 // is given; the credential store holds them all, and gives them back only by
@@ -70,6 +98,13 @@ func TestASimulatedDevicesSecretsStayInTheStore(t *testing.T) {
 	creds, err := a.SimulatorDeviceCredentials(saved.ID)
 	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].PrivPass != "priv-s3cr3t" {
 		t.Errorf("credentials: %+v, %v", creds, err)
+	}
+	// A new destination is given its ID, and its community is kept under it.
+	if len(saved.Traps.Destinations) != 1 || saved.Traps.Destinations[0].ID == "" {
+		t.Fatalf("a new destination was not given an ID: %+v", saved.Traps)
+	}
+	if got := creds.Destinations[saved.Traps.Destinations[0].ID]; got != "trap-s3cr3t" {
+		t.Errorf("the destination's community came back as %q", got)
 	}
 
 	again := newSimulatorService(filepath.Dir(a.sim.path))
@@ -151,29 +186,7 @@ func TestDeletingADeviceForgetsItsSecrets(t *testing.T) {
 // with the community the store holds.
 func TestEveryStartRaisesTheBoots(t *testing.T) {
 	a, _ := simApp(t)
-	var saved SimulatedDevice
-	var err error
-	// A port found free can be taken before the device binds it, since
-	// `go test ./...` runs every package at once; try another.
-	for attempt := 0; attempt < 5; attempt++ {
-		c, lerr := net.ListenPacket("udp", "127.0.0.1:0")
-		if lerr != nil {
-			t.Skipf("no UDP socket: %v", lerr)
-		}
-		d := simDevice()
-		d.ID = saved.ID
-		d.Address, d.Port = "127.0.0.1", c.LocalAddr().(*net.UDPAddr).Port
-		c.Close()
-		if saved, err = a.SimulatorSaveDevice(d); err != nil {
-			t.Fatal(err)
-		}
-		if err = a.SimulatorStartDevice(saved.ID); err == nil {
-			break
-		}
-	}
-	if err != nil {
-		t.Fatalf("the device would not start: %v", err)
-	}
+	saved := startSimulated(t, a, simDevice())
 
 	g := &gosnmp.GoSNMP{Target: saved.Address, Port: uint16(saved.Port), Community: "s3cr3t-community",
 		Version: gosnmp.Version2c, Timeout: 2 * time.Second}
@@ -207,6 +220,47 @@ func TestEveryStartRaisesTheBoots(t *testing.T) {
 	}
 	if !a.ListSimulatedDevices()[0].Running {
 		t.Error("a started device is listed as stopped")
+	}
+}
+
+// A running device sends a notification when asked, with the community the
+// credential store holds for its destination, and counts it.
+func TestASimulatedDeviceSendsATrapWhenAsked(t *testing.T) {
+	a, _ := simApp(t)
+	rx, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no UDP socket: %v", err)
+	}
+	defer rx.Close()
+	d := simDevice()
+	d.Traps.Destinations[0].Port = rx.LocalAddr().(*net.UDPAddr).Port
+	saved := startSimulated(t, a, d)
+
+	got, err := a.SimulatorSendTrap(saved.ID, "linkDown")
+	if err != nil || len(got) != 1 || got[0].Error != "" {
+		t.Fatalf("sending: %+v, %v", got, err)
+	}
+	buf := make([]byte, 4096)
+	rx.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, err := rx.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("nothing arrived: %v", err)
+	}
+	p, err := (&gosnmp.GoSNMP{Version: gosnmp.Version2c}).SnmpDecodePacket(buf[:n])
+	if err != nil || p.Community != "trap-s3cr3t" {
+		t.Errorf("received %+v, %v", p, err)
+	}
+	if list := a.ListSimulatedDevices(); list[0].Traps.Destinations[0].Sent != 1 {
+		t.Errorf("counted %+v", list[0].Traps.Destinations)
+	}
+	if _, err := a.SimulatorSendTrap(saved.ID, "linkSideways"); err == nil {
+		t.Error("a notification the model does not have was sent")
+	}
+	if err := a.SimulatorStopDevice(saved.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.SimulatorSendTrap(saved.ID, "linkDown"); !errors.Is(err, simulator.ErrNotRunning) {
+		t.Errorf("a stopped device: %v, want ErrNotRunning", err)
 	}
 }
 

--- a/app_trapengine.go
+++ b/app_trapengine.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// trapEngineFile holds the trap listener's snmpEngineID, in hex, beside
+// monitoring.db. It is no secret: it is what a device sending this machine
+// SNMPv3 INFORMs is configured with.
+const trapEngineFile = "trap-engine-id"
+
+// loadTrapEngineID reads the listener's engine ID from dir, and makes and keeps
+// one the first time. An ID that changed at every start would be one no device
+// could be configured with (snmp.Client.SetTrapEngineID).
+func loadTrapEngineID(dir string) []byte {
+	path := filepath.Join(dir, trapEngineFile)
+	raw, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		if id, err := hex.DecodeString(strings.TrimSpace(string(raw))); err == nil && len(id) >= 5 && len(id) <= 32 {
+			return id
+		}
+		log.Printf("trap listener: %s holds no engine ID; a new one replaces it", path)
+	case !errors.Is(err, os.ErrNotExist):
+		// Present and unreadable is not absent: writing over it could replace an
+		// ID devices are configured with. This session goes without.
+		log.Printf("trap listener: cannot read %s (%v); an engine ID is made for this session only", path, err)
+		return newTrapEngineID()
+	}
+	id := newTrapEngineID()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		log.Printf("trap listener: cannot keep an engine ID in %s: %v", dir, err)
+		return id
+	}
+	if err := os.WriteFile(path, []byte(hex.EncodeToString(id)+"\n"), 0o600); err != nil {
+		log.Printf("trap listener: cannot keep an engine ID in %s: %v", path, err)
+	}
+	return id
+}
+
+// newTrapEngineID is an snmpEngineID in RFC 3411's fifth format — octets an
+// administrator assigns — under enterprise 0. SnmpLens has no enterprise number
+// of its own, and borrowing a vendor's would pass the listener off as one of
+// that vendor's engines; IANA reserves 0, which claims nobody.
+func newTrapEngineID() []byte {
+	id := make([]byte, 13)
+	id[0], id[4] = 0x80, 5
+	rand.Read(id[5:]) // never fails since Go 1.24
+	return id
+}
+
+// TrapListenerEngineID is the trap listener's snmpEngineID, in hex: what a
+// device sending this machine SNMPv3 INFORMs is configured with, and what a
+// simulated device sending to SnmpLens is filled in with.
+func (a *App) TrapListenerEngineID() string {
+	return hex.EncodeToString(a.trapEngineID)
+}

--- a/app_trapengine_test.go
+++ b/app_trapengine_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The trap listener's engine ID is made once and kept: devices are configured
+// with it. A file that does not hold one is replaced, and the replacement kept.
+func TestTheTrapListenersEngineIDIsKept(t *testing.T) {
+	dir := t.TempDir()
+	first := loadTrapEngineID(dir)
+	if len(first) != 13 || !bytes.Equal(first[:5], []byte{0x80, 0, 0, 0, 5}) {
+		t.Fatalf("%x is not RFC 3411's fifth format under enterprise 0", first)
+	}
+	if again := loadTrapEngineID(dir); !bytes.Equal(again, first) {
+		t.Errorf("a second start made a new engine ID: %x, then %x", first, again)
+	}
+	if err := os.WriteFile(filepath.Join(dir, trapEngineFile), []byte("not an engine ID"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	mended := loadTrapEngineID(dir)
+	if len(mended) != 13 || bytes.Equal(mended, first) {
+		t.Errorf("an unreadable file gave %x", mended)
+	}
+	if kept := loadTrapEngineID(dir); !bytes.Equal(kept, mended) {
+		t.Errorf("the replacement was not kept: %x, then %x", mended, kept)
+	}
+}

--- a/frontend/screenshots/bridge/dynamic.js
+++ b/frontend/screenshots/bridge/dynamic.js
@@ -400,6 +400,7 @@ const DEMO_ONLY = {
   SimulatorSaveDevice: 'Saving a simulated device writes it to your configuration directory, and its passwords to the system keychain.',
   SimulatorDeleteDevice: 'Removing a simulated device deletes it from your configuration directory and the system keychain.',
   SimulatorStartDevice: 'Starting a simulated device opens a UDP socket on this machine.',
+  SimulatorSendTrap: 'A simulated device sends its notifications over UDP, from this machine.',
 };
 
 for (const [name, why] of Object.entries(DEMO_ONLY)) {

--- a/frontend/screenshots/scenes.js
+++ b/frontend/screenshots/scenes.js
@@ -335,28 +335,67 @@ const CATALOGUE = [
     tab: TABS.operations,
     height: 900,
     bindings: {
-      ListSimulatorModels: [{ id: 'linux-server', category: 'server' }],
+      ListSimulatorModels: simulatorModels(),
       ListSimulatedDevices: [
         {
           id: 'c0ffee01', name: 'srv-web-01', model: 'linux-server', address: '127.0.0.2', port: 161,
           versions: ['v2c', 'v3'], users: [{ name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', privProto: 'AES' }],
           engineId: '80001f880302a1b2c3d4e5', engineBoots: 3, running: true, packets: 1284,
+          traps: {
+            destinations: [
+              { id: 'd1', host: '127.0.0.1', port: 162, version: 'v2c', inform: false, user: '', engineId: '',
+                sent: 42, failed: 0, dropped: 0, lastError: '' },
+              { id: 'd2', host: '192.0.2.50', port: 162, version: 'v3', inform: true, user: 'ops', engineId: '8000000005a1b2c3d4e5f60718',
+                sent: 17, failed: 1, dropped: 0, lastError: 'the INFORM was not acknowledged' },
+            ],
+            onStart: true, onAuthFailure: true, schedules: [{ notification: 'linkDown', every: 300, irregular: true }], suppressed: 0,
+          },
         },
         {
           id: 'c0ffee02', name: 'srv-db-01', model: 'linux-server', address: '127.0.0.3', port: 161,
           versions: ['v2c'], users: [], engineId: '80001f880302f6e5d4c3b2', engineBoots: 1, running: false, packets: 0,
+          traps: { destinations: [], onStart: false, onAuthFailure: false, schedules: [], suppressed: 0 },
         },
       ],
     },
     act: ['sel:.status-item.simulator|0'],
-    describe: 'The simulator: two simulated Linux servers, one answering, each one click from being a target.',
+    describe: 'The simulator: two simulated Linux servers, one answering and sending traps, each one click from being a target.',
+  },
+  {
+    base: 'simulator-traps',
+    tab: TABS.operations,
+    height: 1600,
+    bindings: {
+      ListSimulatorModels: simulatorModels(),
+      ListSimulatedDevices: [
+        {
+          id: 'c0ffee03', name: 'srv-edge-01', model: 'linux-server', address: '127.0.0.4', port: 161,
+          versions: ['v2c'], users: [], engineId: '80001f880302c3b2a1f6e5', engineBoots: 2, running: false, packets: 0,
+          traps: {
+            destinations: [
+              { id: 'd3', host: '127.0.0.1', port: 162, version: 'v2c', inform: false, user: '', engineId: '',
+                sent: 0, failed: 0, dropped: 0, lastError: '' },
+              { id: 'd4', host: '192.0.2.50', port: 162, version: 'v2c', inform: true, user: '', engineId: '',
+                sent: 0, failed: 0, dropped: 0, lastError: '' },
+            ],
+            onStart: true,
+            onAuthFailure: true,
+            schedules: [{ notification: 'linkDown', every: 300, irregular: true }, { notification: '', every: 60, irregular: false }],
+            suppressed: 0,
+          },
+        },
+      ],
+      SimulatorDeviceCredentials: { community: 'public', users: {}, destinations: { d3: 'public', d4: 'noc-traps' } },
+    },
+    act: ['sel:.status-item.simulator|0', 'sel:.device .icon-btn|0'],
+    describe: 'What a simulated device sends: traps to SnmpLens here and INFORMs to a collector on the network, at boot, on a refused request, and on a schedule.',
   },
   {
     base: 'simulator-editor',
     tab: TABS.operations,
     height: 1400,
     bindings: {
-      ListSimulatorModels: [{ id: 'linux-server', category: 'server' }],
+      ListSimulatorModels: simulatorModels(),
       ListSimulatedDevices: [],
       SimulatorSuggestAddress: { address: '127.0.0.2', port: 161 },
     },
@@ -366,6 +405,24 @@ const CATALOGUE = [
     describe: 'A new simulated device: its model, its loopback address, and who may ask it — two SNMPv3 users here.',
   },
 ];
+
+// The simulator's one model as ListSimulatorModels serves it. A function
+// declaration, so the catalogue above can call it before this line is reached.
+function simulatorModels() {
+  return [{
+    id: 'linux-server',
+    category: 'server',
+    notifications: [
+      { name: 'coldStart', oid: '.1.3.6.1.6.3.1.1.5.1' },
+      { name: 'warmStart', oid: '.1.3.6.1.6.3.1.1.5.2' },
+      { name: 'linkDown', oid: '.1.3.6.1.6.3.1.1.5.3' },
+      { name: 'linkUp', oid: '.1.3.6.1.6.3.1.1.5.4' },
+      { name: 'nsNotifyShutdown', oid: '.1.3.6.1.4.1.8072.4.0.2' },
+      { name: 'nsNotifyRestart', oid: '.1.3.6.1.4.1.8072.4.0.3' },
+      { name: 'authenticationFailure', oid: '.1.3.6.1.6.3.1.1.5.5' },
+    ],
+  }];
+}
 
 export function buildScenes(seeds) {
   const base = baseSeeds(seeds);

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -7,7 +7,8 @@
   import { notificationStore } from './stores/notifications';
   import { anonMode, maskString } from './utils/anonymize';
   import {
-    SIM_VERSIONS, blankDevice, blankV3, editableDevice, deviceProblems, devicePayload, addDeviceAsTarget,
+    SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
+    editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import Icon from './Icon.svelte';
@@ -96,6 +97,48 @@
     editing = { ...editing, users: editing.users.filter((u, i) => i !== index) };
   }
 
+  /** The device's SNMPv3 user names, which a v3 notification is sent as. */
+  function userNames(users) {
+    return users.map((u) => (u.user || '').trim()).filter(Boolean);
+  }
+
+  function setTraps(traps) {
+    editing = { ...editing, traps: { ...editing.traps, ...traps } };
+  }
+
+  function addDestination() {
+    setTraps({ destinations: [...editing.traps.destinations, blankDestination($settingsStore.trapPort)] });
+  }
+
+  function removeDestination(index) {
+    setTraps({ destinations: editing.traps.destinations.filter((d, i) => i !== index) });
+  }
+
+  // v3 is sent as one of the device's users — the first, until another is
+  // chosen — and v1 has no INFORM.
+  function onDestinationVersion(dest) {
+    if (dest.version === 'v3' && !dest.user) dest.user = userNames(editing.users)[0] || '';
+    if (dest.version === 'v1') dest.inform = false;
+    editing = editing;
+  }
+
+  async function useListenerEngine(dest) {
+    try {
+      dest.engineId = await simulatorStore.listenerEngineId();
+      editing = editing;
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    }
+  }
+
+  function addSchedule() {
+    setTraps({ schedules: [...editing.traps.schedules, blankSchedule()] });
+  }
+
+  function removeSchedule(index) {
+    setTraps({ schedules: editing.traps.schedules.filter((s, i) => i !== index) });
+  }
+
   async function save() {
     saving = true;
     saveError = '';
@@ -147,6 +190,29 @@
       );
     } catch (e) {
       notificationStore.add(String(e), 'error');
+    }
+  }
+
+  // The menu is a select that goes back to its prompt once used: a notification
+  // is an action, not a setting.
+  async function sendTrap(device, event) {
+    const name = event.currentTarget.value;
+    event.currentTarget.value = '';
+    if (!name) return;
+    busy = { ...busy, [device.id]: true };
+    try {
+      const deliveries = await simulatorStore.sendTrap(device.id, name);
+      for (const line of deliveryReport(name, deliveries)) {
+        const values = $anonMode && line.values.destination
+          ? { ...line.values, destination: maskString(line.values.destination) }
+          : line.values;
+        notificationStore.add($_(line.key, { values }), line.level);
+      }
+    } catch (e) {
+      notificationStore.add($_('simulator.traps.sendFailed', { values: { name, error: String(e) } }), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+      simulatorStore.refresh().catch(() => {});
     }
   }
 </script>
@@ -235,6 +301,109 @@
             {#if editing.users.length > 1}<span class="users-note">{$_('simulator.firstUserTarget')}</span>{/if}
           </div>
         {/if}
+
+        <h4 class="section-title">{$_('simulator.traps.title')}</h4>
+        <p class="hint"><Icon name="radio" size={14} /> {$_('simulator.traps.hint')}</p>
+        {#each editing.traps.destinations as dest, i (i)}
+          <div class="user-block">
+            <div class="user-head">
+              <span class="user-title">{$_('simulator.traps.destinationN', { values: { n: i + 1 } })}</span>
+              <button class="icon-btn danger" title={$_('simulator.traps.removeDestination')}
+                aria-label={$_('simulator.traps.removeDestination')} on:click={() => removeDestination(i)}>
+                <Icon name="trash-2" size={14} />
+              </button>
+            </div>
+            <div class="dest-grid">
+              <div class="form-group">
+                <label for="sim-dest-{i}-host">{$_('simulator.traps.host')}</label>
+                <input id="sim-dest-{i}-host" type="text" spellcheck="false" bind:value={dest.host} />
+                {#if problems.destinations?.[i]?.host}<span class="problem">{$_(`simulator.problem.${problems.destinations[i].host}`)}</span>{/if}
+              </div>
+              <div class="form-group">
+                <label for="sim-dest-{i}-port">{$_('simulator.traps.port')}</label>
+                <input id="sim-dest-{i}-port" type="number" min="1" max="65535" bind:value={dest.port} />
+                {#if problems.destinations?.[i]?.port}<span class="problem">{$_(`simulator.problem.${problems.destinations[i].port}`)}</span>{/if}
+              </div>
+              <div class="form-group">
+                <label for="sim-dest-{i}-version">{$_('simulator.traps.version')}</label>
+                <select id="sim-dest-{i}-version" bind:value={dest.version} on:change={() => onDestinationVersion(dest)}>
+                  {#each SIM_VERSIONS as version (version)}<option value={version}>{version}</option>{/each}
+                </select>
+              </div>
+              {#if dest.version === 'v3'}
+                <div class="form-group">
+                  <label for="sim-dest-{i}-user">{$_('simulator.traps.user')}</label>
+                  <select id="sim-dest-{i}-user" bind:value={dest.user}>
+                    {#each userNames(editing.users) as userName (userName)}<option value={userName}>{userName}</option>{/each}
+                  </select>
+                  {#if problems.destinations?.[i]?.user}<span class="problem">{$_(`simulator.problem.${problems.destinations[i].user}`)}</span>{/if}
+                </div>
+              {:else}
+                <div class="form-group">
+                  <label for="sim-dest-{i}-community">{$_('simulator.traps.community')}</label>
+                  <input id="sim-dest-{i}-community" type="password" autocomplete="off" bind:value={dest.community} />
+                  {#if problems.destinations?.[i]?.community}<span class="problem">{$_(`simulator.problem.${problems.destinations[i].community}`)}</span>{/if}
+                </div>
+              {/if}
+            </div>
+            <label class="check inform">
+              <input type="checkbox" bind:checked={dest.inform} disabled={dest.version === 'v1'} />
+              {$_('simulator.traps.inform')}
+            </label>
+            {#if dest.version === 'v3' && dest.inform}
+              <div class="form-group engine">
+                <label for="sim-dest-{i}-engine">{$_('simulator.traps.engineId')}</label>
+                <div class="engine-row">
+                  <input id="sim-dest-{i}-engine" type="text" spellcheck="false"
+                    placeholder={$_('simulator.traps.engineIdPlaceholder')} bind:value={dest.engineId} />
+                  <button class="btn tertiary btn-small" on:click={() => useListenerEngine(dest)}>
+                    {$_('simulator.traps.useListener')}
+                  </button>
+                </div>
+                <span class="field-hint">{$_('simulator.traps.engineIdHint')}</span>
+                {#if problems.destinations?.[i]?.engineId}<span class="problem">{$_(`simulator.problem.${problems.destinations[i].engineId}`)}</span>{/if}
+              </div>
+            {/if}
+          </div>
+        {/each}
+        <div class="users-foot">
+          <button class="btn tertiary btn-small" disabled={editing.traps.destinations.length >= MAX_DESTINATIONS}
+            on:click={addDestination}>
+            <Icon name="plus" size={13} /> {$_('simulator.traps.addDestination')}
+          </button>
+          <span class="users-note">{$_('simulator.traps.newDestinationNote')}</span>
+        </div>
+
+        {#if editing.traps.destinations.length}
+          <div class="triggers">
+            <label class="check"><input type="checkbox" bind:checked={editing.traps.onStart} /> {$_('simulator.traps.onStart')}</label>
+            <label class="check"><input type="checkbox" bind:checked={editing.traps.onAuthFailure} /> {$_('simulator.traps.onAuthFailure')}</label>
+          </div>
+          {#each editing.traps.schedules as s, i (i)}
+            <div class="schedule">
+              <select aria-label={$_('simulator.traps.notification')} bind:value={s.notification}>
+                <option value="">{$_('simulator.traps.any')}</option>
+                {#each notificationsOf($simulatorStore.models, editing.model) as n (n.name)}
+                  <option value={n.name}>{n.name}</option>
+                {/each}
+              </select>
+              <span>{$_('simulator.traps.every')}</span>
+              <input type="number" min="1" max={MAX_EVERY} aria-label={$_('simulator.traps.seconds')} bind:value={s.every} />
+              <span>{$_('simulator.traps.seconds')}</span>
+              <label class="check"><input type="checkbox" bind:checked={s.irregular} /> {$_('simulator.traps.irregular')}</label>
+              <button class="icon-btn danger" title={$_('simulator.traps.removeSchedule')}
+                aria-label={$_('simulator.traps.removeSchedule')} on:click={() => removeSchedule(i)}>
+                <Icon name="trash-2" size={14} />
+              </button>
+              {#if problems.schedules?.[i]?.every}<span class="problem">{$_('simulator.problem.every')}</span>{/if}
+            </div>
+          {/each}
+          <div class="users-foot">
+            <button class="btn tertiary btn-small" disabled={editing.traps.schedules.length >= MAX_SCHEDULES} on:click={addSchedule}>
+              <Icon name="plus" size={13} /> {$_('simulator.traps.addSchedule')}
+            </button>
+          </div>
+        {/if}
       </div>
       <footer class="sim-footer">
         {#if saveError}<span class="save-error">{saveError}</span>{/if}
@@ -254,6 +423,7 @@
         {:else}
           <ul class="devices">
             {#each $simulatorStore.devices as d (d.id)}
+              {@const activity = trapActivity(d.traps)}
               <li class="device" class:running={d.running}>
                 <span class="state" title={d.running ? $_('simulator.running') : $_('simulator.stopped')}></span>
                 <div class="identity">
@@ -272,6 +442,15 @@
                     <span class="activity">
                       {d.running ? $_('simulator.packets', { values: { count: d.packets } }) : $_('simulator.stopped')}
                     </span>
+                    {#if d.running && d.traps?.destinations?.length}
+                      <span class="traps-activity" title={activity.lastError}>
+                        <Icon name="radio" size={12} />
+                        {$_('simulator.traps.activity', { values: { sent: activity.sent } })}
+                        {#if activity.failed}
+                          · <span class="failed">{$_('simulator.traps.activityFailed', { values: { failed: activity.failed } })}</span>
+                        {/if}
+                      </span>
+                    {/if}
                   </span>
                 </div>
                 <div class="actions">
@@ -283,6 +462,15 @@
                     <button class="btn btn-small" disabled={busy[d.id]} on:click={() => run(d, 'start')}>
                       <Icon name="play" size={13} /> {$_('common.start')}
                     </button>
+                  {/if}
+                  {#if d.running && d.traps?.destinations?.length}
+                    <select class="send-trap" title={$_('simulator.traps.sendTitle')} aria-label={$_('simulator.traps.sendTitle')}
+                      disabled={busy[d.id]} on:change={(e) => sendTrap(d, e)}>
+                      <option value="">{$_('simulator.traps.send')}</option>
+                      {#each notificationsOf($simulatorStore.models, d.model) as n (n.name)}
+                        <option value={n.name}>{n.name}</option>
+                      {/each}
+                    </select>
                   {/if}
                   <button class="btn tertiary btn-small" title={$_('simulator.addAsTargetTitle')} on:click={() => addAsTarget(d)}>
                     <Icon name="target" size={13} /> {$_('simulator.addAsTarget')}
@@ -662,9 +850,105 @@
     color: var(--error-color);
   }
 
+  .traps-activity {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .traps-activity .failed {
+    color: var(--error-color);
+  }
+
+  .send-trap {
+    height: 28px;
+    padding: 0 6px;
+    background-color: var(--bg-lighter-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+    font-size: 0.85em;
+  }
+
+  .dest-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 2fr;
+    gap: 10px 14px;
+    align-items: start;
+    margin-top: 6px;
+  }
+
+  .inform {
+    margin-top: 10px;
+    font-size: 0.9em;
+  }
+
+  .engine {
+    margin-top: 10px;
+  }
+
+  .engine-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .engine-row input {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .engine-row .btn {
+    white-space: nowrap;
+  }
+
+  .field-hint {
+    margin-top: 4px;
+    font-size: 0.78em;
+    color: var(--text-muted);
+  }
+
+  .triggers {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-top: 14px;
+    font-size: 0.9em;
+  }
+
+  .schedule {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 10px;
+    font-size: 0.9em;
+  }
+
+  .schedule select,
+  .schedule input[type='number'] {
+    padding: 6px 8px;
+    background-color: var(--bg-lighter-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+  }
+
+  .schedule input[type='number'] {
+    width: 90px;
+  }
+
+  .schedule .problem {
+    flex-basis: 100%;
+    margin-top: 0;
+  }
+
   @media (max-width: 640px) {
     .grid {
       grid-template-columns: 1fr;
+    }
+    .dest-grid {
+      grid-template-columns: 1fr 1fr;
     }
     .device {
       flex-wrap: wrap;

--- a/frontend/src/TrapPanel.svelte
+++ b/frontend/src/TrapPanel.svelte
@@ -5,7 +5,7 @@
   import { trapStore } from './stores/trapStore';
   import { settingsStore } from './stores/settingsStore';
   import { notificationStore } from './stores/notifications';
-  import { SendTrap, SendInform } from '../wailsjs/go/main/App';
+  import { SendTrap, SendInform, TrapListenerEngineID } from '../wailsjs/go/main/App';
   import Trap from './Trap.svelte';
   import { escapeCSV, downloadFile } from './utils/csv';
   import { anonMode, anonymizeIp, maskString } from './utils/anonymize';
@@ -88,6 +88,13 @@
   // Inform the store when this panel is visible/hidden
   onMount(() => trapStore.setPanelVisibility(true));
   onDestroy(() => trapStore.setPanelVisibility(false));
+
+  // What a device sending this machine SNMPv3 INFORMs is configured with: the
+  // listener cannot be discovered, so it has to be told.
+  let listenerEngineId = '';
+  onMount(() => {
+    TrapListenerEngineID().then((id) => (listenerEngineId = id || '')).catch(() => {});
+  });
 
   function toggleListener() {
     if ($trapStore.isListening) {
@@ -226,6 +233,12 @@
       <span class="rx-label">SNMPv1/v2c</span>
       <span class="rx-quiet">{$_('traps.reception.anyCommunity')}</span>
     </span>
+    {#if listenerEngineId}
+      <span class="rx-group" title={$_('traps.reception.engineIdTitle')}>
+        <span class="rx-label">{$_('traps.reception.engineId')}</span>
+        <code class="rx-engine">{$anonMode ? maskString(listenerEngineId) : listenerEngineId}</code>
+      </span>
+    {/if}
     <button class="rx-manage" on:click={() => requestSettings('snmp', 'credential-profiles')}>
       <Icon name="key-round" size={13} /> {$_('traps.reception.manage')}
     </button>
@@ -499,6 +512,12 @@
     border-color: var(--warning-color);
     background-color: transparent;
     color: var(--warning-color);
+  }
+
+  .rx-engine {
+    font-size: 0.92em;
+    color: var(--text-muted);
+    user-select: all;
   }
 
   .rx-user {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -412,6 +412,8 @@
       "excludedTitle": "Für Traps nicht akzeptiert: {names}",
       "anyCommunity": "jede Community",
       "anyCommunityTitle": "Die Community eines v1- oder v2c-Traps wird nicht geprüft: Jeder wird empfangen.",
+      "engineId": "Engine-ID",
+      "engineIdTitle": "Damit wird ein Gerät konfiguriert, das SnmpLens SNMPv3-INFORMs sendet. SnmpLens kann nicht erkannt werden, also muss man sie dem Gerät mitteilen.",
       "manage": "Profile verwalten",
       "userTitle": "SNMPv3-Benutzer {user}, {level}",
       "refused": "Vom Listener abgelehnt: {reason}"
@@ -1316,7 +1318,12 @@
       "communityRequired": "v1 und v2c benötigen eine Community.",
       "userRequired": "Der SNMPv3-Benutzer braucht einen Namen.",
       "passphraseShort": "Mindestens 8 Zeichen.",
-      "userDuplicate": "Zwei Benutzer können nicht denselben Namen tragen."
+      "userDuplicate": "Zwei Benutzer können nicht denselben Namen tragen.",
+      "hostRequired": "Wohin? Geben Sie einen Host an.",
+      "trapUser": "Wählen Sie einen der SNMPv3-Benutzer des Geräts.",
+      "trapNeedsV3": "Eine v3-Benachrichtigung wird als SNMPv3-Benutzer des Geräts gesendet: Aktivieren Sie zuerst v3.",
+      "engineId": "5 bis 32 Oktette, hexadezimal.",
+      "every": "Von 1 bis 86400 Sekunden."
     },
     "model": {
       "linux-server": {
@@ -1327,6 +1334,42 @@
     "userN": "Benutzer {n}",
     "addUser": "Benutzer hinzufügen",
     "removeUser": "Diesen Benutzer entfernen",
-    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer."
+    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer.",
+    "traps": {
+      "title": "Benachrichtigungen",
+      "hint": "Wohin das Gerät seine Traps und INFORMs sendet, und wann. Anders als die Adresse, an der es antwortet, darf ein Ziel irgendwo im Netzwerk liegen.",
+      "destinationN": "Ziel {n}",
+      "host": "Host",
+      "port": "Port",
+      "version": "Version",
+      "community": "Community",
+      "user": "Gesendet als",
+      "inform": "INFORM: Der Empfänger bestätigt ihn",
+      "engineId": "Engine-ID des Empfängers",
+      "engineIdPlaceholder": "Wird ermittelt, wenn leer",
+      "engineIdHint": "SnmpLens kann nicht erkannt werden: Um ihm einen INFORM zu senden, geben Sie seine Engine-ID an.",
+      "useListener": "SnmpLens auf diesem Rechner",
+      "addDestination": "Ziel hinzufügen",
+      "removeDestination": "Dieses Ziel entfernen",
+      "newDestinationNote": "Ein neues Ziel ist SnmpLens auf diesem Rechner, an seinem Trap-Port.",
+      "onStart": "coldStart senden, wenn das Gerät startet",
+      "onAuthFailure": "authenticationFailure senden, wenn eine Anfrage abgelehnt wird (höchstens etwa einmal pro Sekunde)",
+      "notification": "Benachrichtigung",
+      "any": "Beliebig, zufällig",
+      "every": "alle",
+      "seconds": "Sekunden",
+      "irregular": "unregelmäßig",
+      "addSchedule": "Zeitplan hinzufügen",
+      "removeSchedule": "Diesen Zeitplan entfernen",
+      "send": "Trap senden…",
+      "sendTitle": "Eine der Benachrichtigungen des Geräts jetzt an seine Ziele senden",
+      "sent": "{name} an {destination} gesendet",
+      "acknowledged": "{name} von {destination} bestätigt",
+      "sentAll": "{name} an {count, plural, one {# Ziel} other {# Ziele}} gesendet",
+      "failed": "{name} an {destination}: {error}",
+      "sendFailed": "{name} wurde nicht gesendet: {error}",
+      "activity": "{sent, plural, one {# Benachrichtigung gesendet} other {# Benachrichtigungen gesendet}}",
+      "activityFailed": "{failed} fehlgeschlagen"
+    }
   }
 }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -412,6 +412,8 @@
       "excludedTitle": "Not accepted for traps: {names}",
       "anyCommunity": "any community",
       "anyCommunityTitle": "The community of a v1 or v2c trap is not checked: every one is received.",
+      "engineId": "Engine ID",
+      "engineIdTitle": "What a device sending SnmpLens SNMPv3 INFORMs is configured with. SnmpLens cannot be discovered, so the device has to be told.",
       "manage": "Manage profiles",
       "userTitle": "SNMPv3 user {user}, {level}",
       "refused": "Refused by the listener: {reason}"
@@ -1316,7 +1318,12 @@
       "communityRequired": "v1 and v2c need a community.",
       "userRequired": "The SNMPv3 user needs a name.",
       "passphraseShort": "At least 8 characters.",
-      "userDuplicate": "Two users cannot share a name."
+      "userDuplicate": "Two users cannot share a name.",
+      "hostRequired": "Where to? Give a host.",
+      "trapUser": "Choose one of the device's SNMPv3 users.",
+      "trapNeedsV3": "A v3 notification is sent as one of the device's SNMPv3 users: answer v3 first.",
+      "engineId": "5 to 32 octets, in hex.",
+      "every": "From 1 to 86400 seconds."
     },
     "model": {
       "linux-server": {
@@ -1327,6 +1334,42 @@
     "userN": "User {n}",
     "addUser": "Add a user",
     "removeUser": "Remove this user",
-    "firstUserTarget": "Add as target uses the first user."
+    "firstUserTarget": "Add as target uses the first user.",
+    "traps": {
+      "title": "Notifications",
+      "hint": "Where the device sends its traps and INFORMs, and when. Unlike where it answers, a destination may be anywhere on the network.",
+      "destinationN": "Destination {n}",
+      "host": "Host",
+      "port": "Port",
+      "version": "Version",
+      "community": "Community",
+      "user": "Sent as",
+      "inform": "INFORM: the receiver acknowledges it",
+      "engineId": "Receiver's engine ID",
+      "engineIdPlaceholder": "Discovered when empty",
+      "engineIdHint": "SnmpLens cannot be discovered: to send it an INFORM, give its engine ID.",
+      "useListener": "SnmpLens on this machine",
+      "addDestination": "Add a destination",
+      "removeDestination": "Remove this destination",
+      "newDestinationNote": "A new destination is SnmpLens on this machine, at its trap port.",
+      "onStart": "Send coldStart when the device starts",
+      "onAuthFailure": "Send authenticationFailure when a request is refused (about once a second at most)",
+      "notification": "Notification",
+      "any": "Any, at random",
+      "every": "every",
+      "seconds": "seconds",
+      "irregular": "irregular",
+      "addSchedule": "Add a schedule",
+      "removeSchedule": "Remove this schedule",
+      "send": "Send a trap…",
+      "sendTitle": "Send one of the device's notifications to its destinations now",
+      "sent": "{name} sent to {destination}",
+      "acknowledged": "{name} acknowledged by {destination}",
+      "sentAll": "{name} sent to {count, plural, one {# destination} other {# destinations}}",
+      "failed": "{name} to {destination}: {error}",
+      "sendFailed": "{name} was not sent: {error}",
+      "activity": "{sent, plural, one {# notification sent} other {# notifications sent}}",
+      "activityFailed": "{failed} failed"
+    }
   }
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -412,6 +412,8 @@
       "excludedTitle": "No aceptados para los Traps: {names}",
       "anyCommunity": "cualquier comunidad",
       "anyCommunityTitle": "La comunidad de un Trap v1 o v2c no se comprueba: se reciben todos.",
+      "engineId": "Engine ID",
+      "engineIdTitle": "Lo que se configura en un dispositivo que envía INFORM SNMPv3 a SnmpLens. SnmpLens no se puede descubrir, así que hay que indicárselo al dispositivo.",
       "manage": "Gestionar perfiles",
       "userTitle": "Usuario SNMPv3 {user}, {level}",
       "refused": "Rechazado por el receptor: {reason}"
@@ -1316,7 +1318,12 @@
       "communityRequired": "v1 y v2c necesitan una comunidad.",
       "userRequired": "El usuario SNMPv3 necesita un nombre.",
       "passphraseShort": "Al menos 8 caracteres.",
-      "userDuplicate": "Dos usuarios no pueden compartir un nombre."
+      "userDuplicate": "Dos usuarios no pueden compartir un nombre.",
+      "hostRequired": "¿Adónde? Indique un host.",
+      "trapUser": "Elija uno de los usuarios SNMPv3 del dispositivo.",
+      "trapNeedsV3": "Una notificación v3 se envía como uno de los usuarios SNMPv3 del dispositivo: active primero la v3.",
+      "engineId": "De 5 a 32 octetos, en hexadecimal.",
+      "every": "De 1 a 86400 segundos."
     },
     "model": {
       "linux-server": {
@@ -1327,6 +1334,42 @@
     "userN": "Usuario {n}",
     "addUser": "Añadir un usuario",
     "removeUser": "Quitar este usuario",
-    "firstUserTarget": "«Añadir como destino» usa el primer usuario."
+    "firstUserTarget": "«Añadir como destino» usa el primer usuario.",
+    "traps": {
+      "title": "Notificaciones",
+      "hint": "Adónde envía el dispositivo sus Traps e INFORM, y cuándo. A diferencia de la dirección en la que responde, un destino puede estar en cualquier lugar de la red.",
+      "destinationN": "Destino {n}",
+      "host": "Host",
+      "port": "Puerto",
+      "version": "Versión",
+      "community": "Comunidad",
+      "user": "Enviado como",
+      "inform": "INFORM: el receptor confirma su recepción",
+      "engineId": "Engine ID del receptor",
+      "engineIdPlaceholder": "Se descubre si está vacío",
+      "engineIdHint": "SnmpLens no se puede descubrir: para enviarle un INFORM, indique su Engine ID.",
+      "useListener": "SnmpLens en este equipo",
+      "addDestination": "Añadir un destino",
+      "removeDestination": "Quitar este destino",
+      "newDestinationNote": "Un destino nuevo es SnmpLens en este equipo, en su puerto de traps.",
+      "onStart": "Enviar coldStart cuando el dispositivo arranca",
+      "onAuthFailure": "Enviar authenticationFailure cuando se rechaza una petición (como mucho una vez por segundo, aproximadamente)",
+      "notification": "Notificación",
+      "any": "Cualquiera, al azar",
+      "every": "cada",
+      "seconds": "segundos",
+      "irregular": "irregular",
+      "addSchedule": "Añadir una programación",
+      "removeSchedule": "Quitar esta programación",
+      "send": "Enviar un Trap…",
+      "sendTitle": "Enviar ahora una de las notificaciones del dispositivo a sus destinos",
+      "sent": "{name} enviado a {destination}",
+      "acknowledged": "{name} confirmado por {destination}",
+      "sentAll": "{name} enviado a {count, plural, one {# destino} other {# destinos}}",
+      "failed": "{name} a {destination}: {error}",
+      "sendFailed": "{name} no se envió: {error}",
+      "activity": "{sent, plural, one {# notificación enviada} other {# notificaciones enviadas}}",
+      "activityFailed": "{failed} fallidas"
+    }
   }
 }

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -412,6 +412,8 @@
       "excludedTitle": "Non acceptés pour les traps : {names}",
       "anyCommunity": "toute communauté",
       "anyCommunityTitle": "La communauté d’un trap v1 ou v2c n’est pas vérifiée : tous sont reçus.",
+      "engineId": "Engine ID",
+      "engineIdTitle": "Ce qu’on configure sur un appareil qui envoie des INFORM SNMPv3 à SnmpLens. SnmpLens ne peut pas être découvert : il faut l’indiquer à l’appareil.",
       "manage": "Gérer les profils",
       "userTitle": "Utilisateur SNMPv3 {user}, {level}",
       "refused": "Refusé par l’écoute : {reason}"
@@ -1316,7 +1318,12 @@
       "communityRequired": "v1 et v2c demandent une communauté.",
       "userRequired": "L'utilisateur SNMPv3 doit avoir un nom.",
       "passphraseShort": "8 caractères au minimum.",
-      "userDuplicate": "Deux utilisateurs ne peuvent pas porter le même nom."
+      "userDuplicate": "Deux utilisateurs ne peuvent pas porter le même nom.",
+      "hostRequired": "Vers où ? Indiquez un hôte.",
+      "trapUser": "Choisissez l’un des utilisateurs SNMPv3 de l’appareil.",
+      "trapNeedsV3": "Une notification v3 part au nom d’un utilisateur SNMPv3 de l’appareil : activez d’abord la v3.",
+      "engineId": "5 à 32 octets, en hexadécimal.",
+      "every": "De 1 à 86400 secondes."
     },
     "model": {
       "linux-server": {
@@ -1327,6 +1334,42 @@
     "userN": "Utilisateur {n}",
     "addUser": "Ajouter un utilisateur",
     "removeUser": "Retirer cet utilisateur",
-    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur."
+    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur.",
+    "traps": {
+      "title": "Notifications",
+      "hint": "Où l’appareil envoie ses traps et ses INFORM, et quand. Contrairement à l’adresse où il répond, une destination peut se trouver n’importe où sur le réseau.",
+      "destinationN": "Destination {n}",
+      "host": "Hôte",
+      "port": "Port",
+      "version": "Version",
+      "community": "Communauté",
+      "user": "Envoyé en tant que",
+      "inform": "INFORM : le destinataire en accuse réception",
+      "engineId": "Engine ID du destinataire",
+      "engineIdPlaceholder": "Découvert s’il est vide",
+      "engineIdHint": "SnmpLens ne peut pas être découvert : pour lui envoyer un INFORM, indiquez son engine ID.",
+      "useListener": "SnmpLens sur cette machine",
+      "addDestination": "Ajouter une destination",
+      "removeDestination": "Retirer cette destination",
+      "newDestinationNote": "Une nouvelle destination est SnmpLens sur cette machine, à son port de traps.",
+      "onStart": "Envoyer coldStart au démarrage de l’appareil",
+      "onAuthFailure": "Envoyer authenticationFailure quand une requête est refusée (environ une par seconde au plus)",
+      "notification": "Notification",
+      "any": "N’importe laquelle, au hasard",
+      "every": "toutes les",
+      "seconds": "secondes",
+      "irregular": "irrégulier",
+      "addSchedule": "Ajouter une planification",
+      "removeSchedule": "Retirer cette planification",
+      "send": "Envoyer un trap…",
+      "sendTitle": "Envoyer maintenant l’une des notifications de l’appareil à ses destinations",
+      "sent": "{name} envoyé à {destination}",
+      "acknowledged": "{name} acquitté par {destination}",
+      "sentAll": "{name} envoyé à {count, plural, one {# destination} other {# destinations}}",
+      "failed": "{name} vers {destination} : {error}",
+      "sendFailed": "{name} n’a pas été envoyé : {error}",
+      "activity": "{sent, plural, one {# notification envoyée} other {# notifications envoyées}}",
+      "activityFailed": "{failed} en échec"
+    }
   }
 }

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -412,6 +412,8 @@
       "excludedTitle": "不接受其 Trap：{names}",
       "anyCommunity": "任意团体名",
       "anyCommunityTitle": "v1 或 v2c Trap 的团体名不会被检查：全部都会接收。",
+      "engineId": "Engine ID",
+      "engineIdTitle": "向 SnmpLens 发送 SNMPv3 INFORM 的设备需要配置此值。SnmpLens 无法被发现，因此必须告知设备。",
       "manage": "管理配置文件",
       "userTitle": "SNMPv3 用户 {user}，{level}",
       "refused": "被监听器拒绝：{reason}"
@@ -1316,7 +1318,12 @@
       "communityRequired": "v1 和 v2c 需要团体名。",
       "userRequired": "SNMPv3 用户需要名称。",
       "passphraseShort": "至少 8 个字符。",
-      "userDuplicate": "两个用户不能同名。"
+      "userDuplicate": "两个用户不能同名。",
+      "hostRequired": "发往何处？请填写主机。",
+      "trapUser": "请选择设备的一个 SNMPv3 用户。",
+      "trapNeedsV3": "v3 通知以设备的某个 SNMPv3 用户身份发送：请先启用 v3。",
+      "engineId": "5 到 32 个八位组，十六进制。",
+      "every": "1 到 86400 秒。"
     },
     "model": {
       "linux-server": {
@@ -1327,6 +1334,42 @@
     "userN": "用户 {n}",
     "addUser": "添加用户",
     "removeUser": "删除此用户",
-    "firstUserTarget": "“添加为目标”使用第一个用户。"
+    "firstUserTarget": "“添加为目标”使用第一个用户。",
+    "traps": {
+      "title": "通知",
+      "hint": "设备向何处、在何时发送 Trap 和 INFORM。与设备应答的地址不同，目标可以位于网络上的任何位置。",
+      "destinationN": "目标 {n}",
+      "host": "主机",
+      "port": "端口",
+      "version": "版本",
+      "community": "团体名",
+      "user": "发送身份",
+      "inform": "INFORM：接收方会确认",
+      "engineId": "接收方的 Engine ID",
+      "engineIdPlaceholder": "留空则自动发现",
+      "engineIdHint": "SnmpLens 无法被发现：要向它发送 INFORM，请填写它的 Engine ID。",
+      "useListener": "本机上的 SnmpLens",
+      "addDestination": "添加目标",
+      "removeDestination": "删除此目标",
+      "newDestinationNote": "新目标默认为本机上的 SnmpLens，使用其 Trap 端口。",
+      "onStart": "设备启动时发送 coldStart",
+      "onAuthFailure": "请求被拒绝时发送 authenticationFailure（最多约每秒一次）",
+      "notification": "通知",
+      "any": "任意，随机",
+      "every": "每",
+      "seconds": "秒",
+      "irregular": "不规则",
+      "addSchedule": "添加计划",
+      "removeSchedule": "删除此计划",
+      "send": "发送 Trap…",
+      "sendTitle": "立即将设备的某个通知发送到其目标",
+      "sent": "{name} 已发送到 {destination}",
+      "acknowledged": "{name} 已被 {destination} 确认",
+      "sentAll": "{name} 已发送到 {count, plural, other {# 个目标}}",
+      "failed": "{name} 发往 {destination}：{error}",
+      "sendFailed": "{name} 未发送：{error}",
+      "activity": "{sent, plural, other {已发送 # 条通知}}",
+      "activityFailed": "{failed} 条失败"
+    }
   }
 }

--- a/frontend/src/stores/simulatorStore.js
+++ b/frontend/src/stores/simulatorStore.js
@@ -8,6 +8,8 @@ import {
   SimulatorStopDevice,
   SimulatorDeviceCredentials,
   SimulatorSuggestAddress,
+  SimulatorSendTrap,
+  TrapListenerEngineID,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
 
@@ -47,8 +49,12 @@ function createSimulatorStore() {
     remove: (id) => SimulatorDeleteDevice(id),
     start: (id) => SimulatorStartDevice(id),
     stop: (id) => SimulatorStopDevice(id),
-    credentials: async (id) => (await SimulatorDeviceCredentials(id)) || { community: '', users: {} },
+    credentials: async (id) => (await SimulatorDeviceCredentials(id)) || { community: '', users: {}, destinations: {} },
     suggestAddress: () => SimulatorSuggestAddress(),
+    /** Sends a notification now; resolves to what became of it at each destination. */
+    sendTrap: async (id, name) => (await SimulatorSendTrap(id, name)) || [],
+    /** The engine ID SnmpLens's own trap listener stands for, in hex. */
+    listenerEngineId: async () => (await TrapListenerEngineID()) || '',
   };
 }
 

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -9,7 +9,8 @@
  *
  * The editor holds each SNMPv3 user in the shape UsmFields edits — `user`,
  * `secLevel`, the protocols and passphrases — and devicePayload turns them into
- * Go's `users` list.
+ * Go's `users` list. What the device sends, `traps`, is Go's shape already, its
+ * destinations' communities filled in from the credential store by ID.
  */
 import { usesAuth, usesPriv } from './snmpSecurity.js';
 
@@ -18,6 +19,40 @@ export const SIM_VERSIONS = ['v1', 'v2c', 'v3'];
 
 /** The shortest passphrase a simulated user may have, as pkg/simulator holds it. */
 export const MIN_PASSPHRASE = 8;
+
+/** The longest a schedule waits between two notifications, as pkg/simulator holds it: a day. */
+export const MAX_EVERY = 86400;
+
+/** How many destinations and schedules one device keeps, as pkg/simulator bounds them. */
+export const MAX_DESTINATIONS = 8;
+export const MAX_SCHEDULES = 8;
+
+/** What a new device sends: nothing, to nowhere. */
+export function blankTraps() {
+  return { destinations: [], onStart: false, onAuthFailure: false, schedules: [] };
+}
+
+/**
+ * A new destination: SnmpLens on this machine, at the port its trap listener
+ * takes, in v2c — the first place a person testing SnmpLens wants traps sent.
+ */
+export function blankDestination(trapPort) {
+  return {
+    id: '',
+    host: '127.0.0.1',
+    port: Number(trapPort) || 162,
+    version: 'v2c',
+    inform: false,
+    community: 'public',
+    user: '',
+    engineId: '',
+  };
+}
+
+/** A new schedule: a notification at random, every minute. */
+export function blankSchedule() {
+  return { notification: '', every: 60, irregular: false };
+}
 
 /** A new SNMPv3 user; `n` numbers the ones after the first. */
 export function blankV3(n = 1) {
@@ -47,6 +82,7 @@ export function blankDevice(model, suggestion) {
     versions: ['v2c'],
     community: 'public',
     users: [blankV3()],
+    traps: blankTraps(),
   };
 }
 
@@ -73,6 +109,21 @@ export function editableDevice(view, creds) {
     versions: [...(view.versions || [])],
     community: creds?.community || '',
     users: users.length ? users : [blankV3()],
+    traps: {
+      destinations: (view.traps?.destinations || []).map((t) => ({
+        id: t.id,
+        host: t.host,
+        port: t.port,
+        version: t.version,
+        inform: !!t.inform,
+        community: creds?.destinations?.[t.id] || '',
+        user: t.user || '',
+        engineId: t.engineId || '',
+      })),
+      onStart: !!view.traps?.onStart,
+      onAuthFailure: !!view.traps?.onAuthFailure,
+      schedules: (view.traps?.schedules || []).map((s) => ({ ...s })),
+    },
   };
 }
 
@@ -112,7 +163,45 @@ export function deviceProblems(d) {
     });
     if (perUser.some((p) => Object.keys(p).length)) problems.users = perUser;
   }
+  const answersV3 = versions.includes('v3');
+  const userNames = answersV3 ? (d.users || []).map((u) => (u.user || '').trim()) : [];
+  const perDestination = (d.traps?.destinations || []).map((t) => destinationProblems(t, userNames, answersV3));
+  if (perDestination.some((p) => Object.keys(p).length)) problems.destinations = perDestination;
+  const perSchedule = (d.traps?.schedules || []).map((s) => {
+    const every = Number(s.every);
+    return Number.isInteger(every) && every >= 1 && every <= MAX_EVERY ? {} : { every: 'every' };
+  });
+  if (perSchedule.some((p) => Object.keys(p).length)) problems.schedules = perSchedule;
   return problems;
+}
+
+/**
+ * What one destination would be refused for. A v3 notification is sent as one
+ * of the device's SNMPv3 users, and a device has users only when it answers v3.
+ */
+function destinationProblems(t, userNames, answersV3) {
+  const p = {};
+  if (!hostOf(t.host)) p.host = 'hostRequired';
+  const port = Number(t.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) p.port = 'port';
+  if (t.version === 'v3') {
+    if (!answersV3) p.user = 'trapNeedsV3';
+    else if (!userNames.includes((t.user || '').trim())) p.user = 'trapUser';
+    if (t.inform && t.engineId && !/^([0-9a-f]{2}){5,32}$/.test(engineIdOf(t.engineId))) p.engineId = 'engineId';
+  } else if (!t.community) {
+    p.community = 'communityRequired';
+  }
+  return p;
+}
+
+/** A host as Go takes it: without the brackets people put round an IPv6 literal. */
+function hostOf(host) {
+  return (host || '').trim().replace(/^\[(.*)\]$/, '$1');
+}
+
+/** An engine ID as Go takes it: hex, without a 0x, colons or spaces. */
+export function engineIdOf(s) {
+  return (s || '').trim().replace(/^0x/i, '').replace(/[\s:]/g, '').toLowerCase();
 }
 
 /**
@@ -142,7 +231,71 @@ export function devicePayload(d) {
       : [],
     engineId: '',
     engineBoots: 0,
+    // Each destination with only what its version uses, as the users are.
+    traps: {
+      destinations: (d.traps?.destinations || []).map((t) => {
+        const v3 = t.version === 'v3';
+        const inform = t.version !== 'v1' && !!t.inform;
+        return {
+          id: t.id || '',
+          host: hostOf(t.host),
+          port: Number(t.port),
+          version: t.version,
+          inform,
+          community: v3 ? '' : t.community,
+          user: v3 ? (t.user || '').trim() : '',
+          engineId: v3 && inform ? engineIdOf(t.engineId) : '',
+        };
+      }),
+      onStart: !!d.traps?.onStart,
+      onAuthFailure: !!d.traps?.onAuthFailure,
+      schedules: (d.traps?.schedules || []).map((s) => ({
+        notification: s.notification || '',
+        every: Number(s.every),
+        irregular: !!s.irregular,
+      })),
+    },
   };
+}
+
+/** What a device of the model can send, as Go lists it. */
+export function notificationsOf(models, modelId) {
+  return (models || []).find((m) => m.id === modelId)?.notifications || [];
+}
+
+/** What a running device has sent, over all its destinations. */
+export function trapActivity(traps) {
+  const out = { sent: 0, failed: 0, dropped: 0, lastError: '' };
+  for (const d of traps?.destinations || []) {
+    out.sent += d.sent || 0;
+    out.failed += d.failed || 0;
+    out.dropped += d.dropped || 0;
+    if (d.lastError) out.lastError = d.lastError;
+  }
+  return out;
+}
+
+/**
+ * What to say about one notification sent on request, as i18n keys: one line
+ * for everywhere it went, and one for each destination it did not reach — an
+ * INFORM nobody acknowledged is one of those.
+ */
+export function deliveryReport(name, deliveries) {
+  const ok = (deliveries || []).filter((d) => !d.error);
+  const out = (deliveries || [])
+    .filter((d) => d.error)
+    .map((d) => ({ key: 'simulator.traps.failed', values: { name, destination: d.destination, error: d.error }, level: 'error' }));
+  if (ok.length === 1) {
+    const d = ok[0];
+    out.unshift({
+      key: d.acknowledged ? 'simulator.traps.acknowledged' : 'simulator.traps.sent',
+      values: { name, destination: d.destination },
+      level: 'success',
+    });
+  } else if (ok.length > 1) {
+    out.unshift({ key: 'simulator.traps.sentAll', values: { name, count: ok.length }, level: 'success' });
+  }
+  return out;
 }
 
 /** The version a target reaches a device in: the most secure one it answers. */

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -48,9 +48,14 @@ if (!globalThis.navigator) {
 const {
   blankDevice,
   blankV3,
+  blankTraps,
+  blankDestination,
+  blankSchedule,
   editableDevice,
   deviceProblems,
   devicePayload,
+  deliveryReport,
+  trapActivity,
   preferredVersion,
   targetOf,
   addDeviceAsTarget,
@@ -99,6 +104,63 @@ check("v3 alone sends no community, and every user under Go's names",
   sent3.community === '' && sent3.users.length === 2 && sent3.users[0].name === 'ops' && sent3.users[1].privPass === 'privpass-1',
   JSON.stringify(sent3.users.map((u) => u.name)));
 
+/* --- what the device sends ------------------------------------------------ */
+
+const withTraps = (traps, extra = {}) => ({ ...fresh, name: 'x', ...extra, traps: { ...blankTraps(), ...traps } });
+const local = blankDestination(1162);
+check('a new destination is SnmpLens on this machine, at its trap port, in v2c',
+  local.host === '127.0.0.1' && local.port === 1162 && local.version === 'v2c' && local.community === 'public');
+check('and asks for nothing more', !deviceProblems(withTraps({ destinations: [local] })).destinations);
+const refused = deviceProblems(withTraps({ destinations: [
+  { ...local, host: ' ' },
+  { ...local, community: '', port: 0 },
+  { ...local, version: 'v3', user: '' },
+] })).destinations || [];
+check('a destination needs a host, a port and, in v1 and v2c, a community',
+  refused[0]?.host === 'hostRequired' && refused[1]?.community === 'communityRequired' && refused[1]?.port === 'port',
+  JSON.stringify(refused));
+check('a v3 destination needs the device to answer v3', refused[2]?.user === 'trapNeedsV3');
+const v3dest = (user, extra = {}) =>
+  withTraps({ destinations: [{ ...local, version: 'v3', user, ...extra }] }, { versions: ['v3'], users: [good('ops')] });
+check("and to be sent as one of the device's users",
+  deviceProblems(v3dest('nobody')).destinations?.[0]?.user === 'trapUser' && !deviceProblems(v3dest('ops')).destinations);
+check("a receiver's engine ID is hex, 5 to 32 octets, with a 0x or colons forgiven",
+  deviceProblems(v3dest('ops', { inform: true, engineId: 'zz' })).destinations?.[0]?.engineId === 'engineId' &&
+  !deviceProblems(v3dest('ops', { inform: true, engineId: '0x80:00:00:00:05:01' })).destinations);
+check('a schedule waits 1 to 86400 seconds',
+  deviceProblems(withTraps({ schedules: [{ ...blankSchedule(), every: 0 }] })).schedules?.[0]?.every === 'every' &&
+  !deviceProblems(withTraps({ schedules: [blankSchedule()] })).schedules);
+
+const sentTraps = devicePayload(withTraps({
+  onStart: true,
+  schedules: [{ notification: 'linkDown', every: '30', irregular: 1 }],
+  destinations: [
+    { ...local, host: ' [::1] ', inform: true, user: 'stale', engineId: 'aa' },
+    { ...local, version: 'v1', inform: true },
+    { ...local, version: 'v3', user: ' ops ', community: 'stale', inform: true, engineId: '0x80:00:00:00:05:01' },
+  ],
+}, { versions: ['v2c', 'v3'], users: [good('ops')] })).traps;
+const [sentV2, sentV1, sentV3] = sentTraps.destinations;
+check('each destination is sent with what its version uses and nothing else',
+  sentV2.host === '::1' && sentV2.inform && sentV2.user === '' && sentV2.engineId === '' &&
+  !sentV1.inform && sentV3.community === '' && sentV3.user === 'ops' && sentV3.engineId === '800000000501',
+  JSON.stringify(sentTraps.destinations));
+check('and the schedules as numbers',
+  sentTraps.onStart === true && sentTraps.schedules[0].every === 30 && sentTraps.schedules[0].irregular === true);
+
+const report = deliveryReport('linkDown', [
+  { id: 'a', destination: '127.0.0.1:162', inform: false, acknowledged: false },
+  { id: 'b', destination: '192.0.2.9:162', inform: true, acknowledged: false, error: 'the INFORM was not acknowledged' },
+]);
+check('a notification sent on request is reported where it went, and where it did not',
+  report.length === 2 && report[0].key === 'simulator.traps.sent' && report[1].key === 'simulator.traps.failed' &&
+  report[1].level === 'error', JSON.stringify(report));
+check('an acknowledged INFORM says so',
+  deliveryReport('linkUp', [{ destination: 'x', inform: true, acknowledged: true }])[0].key === 'simulator.traps.acknowledged');
+check('what a device sent is added up over its destinations',
+  trapActivity({ destinations: [{ sent: 3, failed: 1, lastError: 'refused' }, { sent: 2 }] }).sent === 5 &&
+  trapActivity(undefined).sent === 0);
+
 /* --- editing brings the credentials back --------------------------------- */
 
 const view = {
@@ -108,10 +170,18 @@ const view = {
     { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', privProto: 'AES' },
     { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', privProto: 'AES' },
   ],
+  traps: {
+    destinations: [{ id: 'd1', host: '192.0.2.10', port: 162, version: 'v2c', inform: true, user: '', engineId: '', sent: 3 }],
+    onStart: true,
+    onAuthFailure: false,
+    schedules: [{ notification: 'linkUp', every: 60, irregular: false }],
+    suppressed: 0,
+  },
 };
 const creds = {
   community: 'c0mmunity',
   users: { ops: { authPass: 'authpass-1', privPass: 'privpass-1' }, monitor: { authPass: 'monitor-pass', privPass: '' } },
+  destinations: { d1: 'trap-community' },
 };
 const form = editableDevice(view, creds);
 check('the editor is given the community, and every user with its passphrases',
@@ -122,6 +192,14 @@ check('and editing nothing sends back the same users',
     { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1' },
     { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', authPass: 'monitor-pass', privProto: 'AES', privPass: '' },
   ]));
+check("a destination's community comes back by its ID, and goes back without the counters",
+  form.traps.destinations[0].community === 'trap-community' &&
+  JSON.stringify(devicePayload(form).traps) === JSON.stringify({
+    destinations: [{ id: 'd1', host: '192.0.2.10', port: 162, version: 'v2c', inform: true, community: 'trap-community', user: '', engineId: '' }],
+    onStart: true,
+    onAuthFailure: false,
+    schedules: [{ notification: 'linkUp', every: 60, irregular: false }],
+  }), JSON.stringify(devicePayload(form).traps));
 
 /* --- the port a target names --------------------------------------------- */
 
@@ -198,6 +276,12 @@ for (const file of readdirSync(goDir)) {
   for (const m of readFileSync(new URL(file, goDir), 'utf8').matchAll(/ModelInfo\{ID:\s*"([^"]+)"/g)) ids.add(m[1]);
 }
 check('the models were found in pkg/simulator', ids.size >= 1, [...ids].join(', '));
+for (const key of ['hostRequired', 'trapUser', 'trapNeedsV3', 'engineId', 'every']) {
+  check(`en.json says simulator.problem.${key}`, Boolean(en.simulator?.problem?.[key]));
+}
+for (const key of ['sent', 'acknowledged', 'sentAll', 'failed']) {
+  check(`en.json says simulator.traps.${key}`, Boolean(en.simulator?.traps?.[key]));
+}
 for (const id of ids) {
   check(`en.json names and describes the model ${id}`,
     Boolean(en.simulator?.model?.[id]?.name && en.simulator?.model?.[id]?.description));

--- a/pkg/simulator/agent.go
+++ b/pkg/simulator/agent.go
@@ -45,6 +45,11 @@ type Config struct {
 	EngineBoots uint32
 	// Objects are what the agent answers for.
 	Objects []Object
+	// Notifications are what the agent can send: its model's catalogue, or
+	// without one the generic notifications every agent has.
+	Notifications []Notification
+	// Traps is where the agent sends them, and when.
+	Traps Traps
 }
 
 // Stats counts what an agent did with what it received — most of all what it
@@ -66,6 +71,12 @@ type Stats struct {
 	UnknownContexts       uint32 // snmpUnknownContexts
 	UnknownPDUHandlers    uint32 // snmpUnknownPDUHandlers
 	Faults                uint32 // a message that crashed a decoder, or an answer that would not encode
+
+	// Notifications is what the agent sent, per destination, in the order they
+	// are configured.
+	Notifications []DestinationStats
+	// Suppressed counts the notifications the agent's cap held back.
+	Suppressed uint32
 }
 
 type counters struct {
@@ -88,10 +99,15 @@ type Agent struct {
 	boots       uint32
 	tree        *tree
 	maxSize     int
+	// notify sends the agent's notifications; nil when it has nowhere to.
+	notify *notifier
 
 	mu   sync.Mutex
 	conn *net.UDPConn
 	done chan struct{}
+	// started is when the agent started answering: its sysUpTime and its
+	// snmpEngineTime count from it.
+	started time.Time
 
 	stats counters
 }
@@ -146,6 +162,9 @@ func NewAgent(cfg Config) (*Agent, error) {
 	if a.tree, err = newTree(objects); err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
+	if a.notify, err = newNotifier(a, cfg); err != nil {
+		return nil, fmt.Errorf("simulator: %w", err)
+	}
 	return a, nil
 }
 
@@ -178,11 +197,16 @@ func (a *Agent) Start() error {
 	}
 	a.conn = conn
 	a.done = make(chan struct{})
-	go a.serve(conn, time.Now(), a.done)
+	a.started = time.Now()
+	go a.serve(conn, a.started, a.done)
+	if a.notify != nil {
+		a.notify.start()
+	}
 	return nil
 }
 
-// Stop closes the socket and waits for the message in hand to be answered.
+// Stop closes the socket, waits for the message in hand to be answered, and
+// ends the notifications — one waiting for its acknowledgement included.
 func (a *Agent) Stop() {
 	a.mu.Lock()
 	conn, done := a.conn, a.done
@@ -192,6 +216,9 @@ func (a *Agent) Stop() {
 	}
 	conn.Close()
 	<-done
+	if a.notify != nil {
+		a.notify.stop()
+	}
 }
 
 // Addr is the address the agent answers on, with the port it was given when it
@@ -209,7 +236,7 @@ func (a *Agent) Addr() netip.AddrPort {
 // Stats returns the agent's counters as they stand.
 func (a *Agent) Stats() Stats {
 	s := &a.stats
-	return Stats{
+	st := Stats{
 		Packets:               s.packets.Load(),
 		ParseErrors:           s.parseErrors.Load(),
 		BadVersions:           s.badVersions.Load(),
@@ -226,6 +253,11 @@ func (a *Agent) Stats() Stats {
 		UnknownPDUHandlers:    s.unknownPDUHandlers.Load(),
 		Faults:                s.faults.Load(),
 	}
+	if nt := a.notify; nt != nil {
+		st.Notifications = nt.stats()
+		st.Suppressed = nt.suppressed.Load()
+	}
+	return st
 }
 
 // serve answers datagrams one at a time until the socket closes. One at a time
@@ -292,6 +324,7 @@ func (a *Agent) answerCommunity(ver gosnmp.SnmpVersion, msg []byte, c clock) []b
 	// In constant time: the community is the only secret v1 and v2c have.
 	if subtle.ConstantTimeCompare([]byte(req.Community), a.community) != 1 {
 		a.stats.badCommunities.Add(1)
+		a.authFailed()
 		return nil
 	}
 	switch req.PDUType {

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -38,6 +38,8 @@ type Device struct {
 	// EngineBoots counts the device's starts. Whoever starts it raises the
 	// count and keeps it (Fleet.Start).
 	EngineBoots uint32 `json:"engineBoots"`
+	// Traps is what the device sends, where to and when.
+	Traps Traps `json:"traps"`
 }
 
 // Listen is the address the device answers on, in the form CheckListen reads.
@@ -53,7 +55,8 @@ func (d Device) Validate() error {
 	if name == "" || utf8.RuneCountInString(name) > MaxDeviceName {
 		return fmt.Errorf("a device's name is 1 to %d characters", MaxDeviceName)
 	}
-	if _, ok := findModel(d.Model); !ok {
+	m, ok := findModel(d.Model)
+	if !ok {
 		return fmt.Errorf("%q is not a device model", d.Model)
 	}
 	if d.Port < 1 || d.Port > 65535 {
@@ -96,6 +99,15 @@ func (d Device) Validate() error {
 			seen[u.Name] = true
 		}
 	}
+	// A device's users exist only when it answers v3, so a v3 destination
+	// needs that as well.
+	var users []User
+	if v3 {
+		users = d.Users
+	}
+	if err := d.Traps.check(users, m.catalogue()); err != nil {
+		return err
+	}
 	if id, err := hex.DecodeString(d.EngineID); err != nil || len(id) < 5 || len(id) > 32 {
 		return errors.New("a device's engine ID is 5 to 32 octets, in hex")
 	}
@@ -105,11 +117,13 @@ func (d Device) Validate() error {
 	return nil
 }
 
-// DeviceSecrets is what a Device holds that no file may: the community, and
-// each user's passphrases by user name.
+// DeviceSecrets is what a Device holds that no file may: the community, each
+// user's passphrases by user name, and each destination's community by
+// destination ID.
 type DeviceSecrets struct {
-	Community string                 `json:"community"`
-	Users     map[string]UserSecrets `json:"users"`
+	Community    string                 `json:"community"`
+	Users        map[string]UserSecrets `json:"users"`
+	Destinations map[string]string      `json:"destinations"`
 }
 
 // UserSecrets are one user's passphrases.
@@ -120,9 +134,16 @@ type UserSecrets struct {
 
 // Secrets is d's secrets and nothing else.
 func (d Device) Secrets() DeviceSecrets {
-	s := DeviceSecrets{Community: d.Community, Users: make(map[string]UserSecrets, len(d.Users))}
+	s := DeviceSecrets{
+		Community:    d.Community,
+		Users:        make(map[string]UserSecrets, len(d.Users)),
+		Destinations: make(map[string]string, len(d.Traps.Destinations)),
+	}
 	for _, u := range d.Users {
 		s.Users[u.Name] = UserSecrets{AuthPass: u.AuthPass, PrivPass: u.PrivPass}
+	}
+	for _, dest := range d.Traps.Destinations {
+		s.Destinations[dest.ID] = dest.Community
 	}
 	return s
 }
@@ -134,6 +155,10 @@ func (d Device) WithoutSecrets() Device {
 	d.Users = slices.Clone(d.Users)
 	for i := range d.Users {
 		d.Users[i].AuthPass, d.Users[i].PrivPass = "", ""
+	}
+	d.Traps = d.Traps.clone()
+	for i := range d.Traps.Destinations {
+		d.Traps.Destinations[i].Community = ""
 	}
 	return d
 }
@@ -147,6 +172,10 @@ func (d Device) WithSecrets(s DeviceSecrets) Device {
 		p := s.Users[d.Users[i].Name]
 		d.Users[i].AuthPass, d.Users[i].PrivPass = p.AuthPass, p.PrivPass
 	}
+	d.Traps = d.Traps.clone()
+	for i := range d.Traps.Destinations {
+		d.Traps.Destinations[i].Community = s.Destinations[d.Traps.Destinations[i].ID]
+	}
 	return d
 }
 
@@ -157,6 +186,9 @@ func NewDeviceID() string {
 	rand.Read(b) // never fails since Go 1.24
 	return hex.EncodeToString(b)
 }
+
+// NewDestinationID is a new destination's ID, random as a device's is.
+func NewDestinationID() string { return NewDeviceID() }
 
 // NewEngineID is the engine ID a new device of a model is created with: the MAC
 // format of EngineID, carrying the model's vendor and a MAC drawn from the
@@ -191,12 +223,14 @@ func (d Device) config() (Config, error) {
 		return Config{}, fmt.Errorf("engine ID: %w", err)
 	}
 	return Config{
-		Listen:      d.Listen(),
-		Versions:    d.Versions,
-		Community:   d.Community,
-		Users:       d.Users,
-		EngineID:    engineID,
-		EngineBoots: d.EngineBoots,
-		Objects:     m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID)}),
+		Listen:        d.Listen(),
+		Versions:      d.Versions,
+		Community:     d.Community,
+		Users:         d.Users,
+		EngineID:      engineID,
+		EngineBoots:   d.EngineBoots,
+		Objects:       m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID)}),
+		Notifications: m.catalogue(),
+		Traps:         d.Traps.clone(),
 	}, nil
 }

--- a/pkg/simulator/device_test.go
+++ b/pkg/simulator/device_test.go
@@ -65,18 +65,19 @@ func TestADeviceIsHeldToTheRules(t *testing.T) {
 
 func TestTheSecretsComeApartAndGoBack(t *testing.T) {
 	d := validDevice(t)
+	d.Traps.Destinations = []Destination{{ID: "nms", Host: "192.0.2.10", Port: 162, Version: "v2c", Community: "trap-community"}}
 	bare := d.WithoutSecrets()
 	raw, err := json.Marshal(bare)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, secret := range []string{"public", "authpass-1", "privpass-1"} {
+	for _, secret := range []string{"public", "authpass-1", "privpass-1", "trap-community"} {
 		if strings.Contains(string(raw), secret) {
 			t.Errorf("%q survived WithoutSecrets: %s", secret, raw)
 		}
 	}
-	if d.Users[0].AuthPass != "authpass-1" {
-		t.Error("WithoutSecrets blanked the original's passphrase too: the two share a slice")
+	if d.Users[0].AuthPass != "authpass-1" || d.Traps.Destinations[0].Community != "trap-community" {
+		t.Error("WithoutSecrets blanked the original's secrets too: the two share a slice")
 	}
 	if back := bare.WithSecrets(d.Secrets()); !reflect.DeepEqual(back, d) {
 		t.Errorf("the round trip changed the device:\n%+v\n%+v", back, d)

--- a/pkg/simulator/fleet.go
+++ b/pkg/simulator/fleet.go
@@ -76,6 +76,18 @@ func (f *Fleet) StopAll() {
 	}
 }
 
+// Notify has a running device send the notification named name now; see
+// Agent.Notify.
+func (f *Fleet) Notify(id, name string) ([]Delivery, error) {
+	f.mu.Lock()
+	a := f.agents[id]
+	f.mu.Unlock()
+	if a == nil {
+		return nil, ErrNotRunning
+	}
+	return a.Notify(name)
+}
+
 // Status reports whether a device is running, and its counters if it is.
 func (f *Fleet) Status(id string) (Stats, bool) {
 	f.mu.Lock()

--- a/pkg/simulator/linuxserver.go
+++ b/pkg/simulator/linuxserver.go
@@ -20,6 +20,14 @@ var linuxServer = model{
 	ModelInfo:  ModelInfo{ID: "linux-server", Category: "server"},
 	enterprise: 8072, // net-snmp
 	build:      buildLinuxServer,
+	notifications: []Notification{
+		linkNotification(false, 3), // eth1, cabled and down
+		linkNotification(true, 2),  // eth0, the uplink
+		// NET-SNMP-AGENT-MIB: what snmpd sends as it stops, and when it
+		// restarts on a SIGHUP.
+		{Name: "nsNotifyShutdown", OID: ".1.3.6.1.4.1.8072.4.0.2"},
+		{Name: "nsNotifyRestart", OID: ".1.3.6.1.4.1.8072.4.0.3"},
+	},
 }
 
 type linuxInterface struct {

--- a/pkg/simulator/model.go
+++ b/pkg/simulator/model.go
@@ -1,14 +1,21 @@
 package simulator
 
-import "github.com/gosnmp/gosnmp"
+import (
+	"slices"
+
+	"github.com/gosnmp/gosnmp"
+)
 
 // ModelInfo is a device model as the interface lists it. It carries no prose:
 // the interface names and describes a model from its ID, in five languages
 // (simulator.model.<id>), the way preset.WidgetKinds serves i18n key suffixes
-// rather than sentences.
+// rather than sentences. A notification is shown by its MIB name, which no
+// manager translates.
 type ModelInfo struct {
 	ID       string `json:"id"`
 	Category string `json:"category"`
+	// Notifications are what a device of the model can send.
+	Notifications []NotificationInfo `json:"notifications"`
 }
 
 // Identity is what makes one device differ from another of the same model.
@@ -25,6 +32,9 @@ type model struct {
 	// enterprise is the vendor's number, which the engine ID carries.
 	enterprise uint32
 	build      func(Identity) []Object
+	// notifications are the model's own, beside the generic ones every device
+	// sends.
+	notifications []Notification
 }
 
 var models = []model{linuxServer}
@@ -33,9 +43,19 @@ var models = []model{linuxServer}
 func Models() []ModelInfo {
 	out := make([]ModelInfo, len(models))
 	for i, m := range models {
-		out[i] = m.ModelInfo
+		info := m.ModelInfo
+		for _, n := range m.catalogue() {
+			info.Notifications = append(info.Notifications, NotificationInfo{Name: n.Name, OID: n.OID})
+		}
+		out[i] = info
 	}
 	return out
+}
+
+// catalogue is every notification a device of m can send: the generic ones
+// every agent has, and m's own.
+func (m model) catalogue() []Notification {
+	return slices.Concat([]Notification{coldStart, warmStart}, m.notifications, []Notification{authenticationFailure})
 }
 
 func findModel(id string) (model, bool) {

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -1,0 +1,798 @@
+package simulator
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"net"
+	"net/netip"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Bounds on what a device file may ask of a device.
+const (
+	// MaxDestinations is how many places one device sends its notifications to.
+	MaxDestinations = 8
+	// MaxSchedules is how many schedules one device keeps.
+	MaxSchedules = 8
+	// MaxEvery is the longest a schedule waits between two notifications: a day.
+	MaxEvery = 86400
+)
+
+// What one device may send, whatever it is configured to. The cap is the
+// device's rather than a schedule's because authenticationFailure is not
+// scheduled: every refused request asks for one, a request is a datagram
+// anything on this machine can send, and a destination may be on the network.
+// Uncapped, a simulated device would turn each spoofed datagram into a
+// notification sent elsewhere, as many times a second as anyone liked.
+const (
+	notifyRate       = 20 // notifications a second, on average
+	notifyBurst      = 40
+	authFailureRate  = 1
+	authFailureBurst = 3
+	// informTimeout and informRetries are how long an INFORM waits to be
+	// acknowledged, and how many more times it is sent.
+	informTimeout = 2 * time.Second
+	informRetries = 1
+	// queueDepth is how many notifications wait for one destination. One that
+	// makes every INFORM wait out its timeout fills it, and what does not fit is
+	// counted rather than waited for.
+	queueDepth = 32
+)
+
+const (
+	oidSysObjectID        = ".1.3.6.1.2.1.1.2.0"
+	oidSysUpTime          = ".1.3.6.1.2.1.1.3.0"
+	oidSnmpTrapOID        = ".1.3.6.1.6.3.1.1.4.1.0"
+	oidSnmpTrapEnterprise = ".1.3.6.1.6.3.1.1.4.3.0"
+	// oidSnmpTraps is where RFC 3418 puts the generic notifications, which
+	// SNMPv1 numbers by generic-trap rather than by OID.
+	oidSnmpTraps = ".1.3.6.1.6.3.1.1.5"
+)
+
+var (
+	// ErrNotRunning is returned for a device that is not running.
+	ErrNotRunning = errors.New("simulator: the device is not running")
+	// ErrNoDestination is returned for a notification from a device that has
+	// nowhere to send one.
+	ErrNoDestination = errors.New("simulator: the device has nowhere to send notifications")
+	// ErrTooFast is returned for a notification over the device's cap.
+	ErrTooFast = errors.New("simulator: the device is already sending notifications as fast as it may")
+
+	errQueueFull = errors.New("too many notifications are waiting for this destination")
+)
+
+// Notification is one a device can send: its name in the MIB that defines it —
+// which is also how the interface shows it, since it is the name every manager
+// shows — the snmpTrapOID it carries, and the objects it carries after that.
+type Notification struct {
+	Name string
+	OID  string
+	// Objects are read from the device's own tree as it is sent, so what
+	// linkDown says about an interface is what a GET says about it at that
+	// moment.
+	Objects []string
+}
+
+// NotificationInfo is a notification as the interface lists it.
+type NotificationInfo struct {
+	Name string `json:"name"`
+	OID  string `json:"oid"`
+}
+
+// The generic notifications of RFC 3418 that every device sends.
+var (
+	coldStart             = Notification{Name: "coldStart", OID: oidSnmpTraps + ".1"}
+	warmStart             = Notification{Name: "warmStart", OID: oidSnmpTraps + ".2"}
+	authenticationFailure = Notification{Name: "authenticationFailure", OID: oidSnmpTraps + ".5"}
+)
+
+// linkNotification is RFC 2863's linkDown or linkUp about the interface at
+// index, with the three objects that RFC has it carry.
+func linkNotification(up bool, index int) Notification {
+	n := Notification{Name: "linkDown", OID: oidSnmpTraps + ".3"}
+	if up {
+		n = Notification{Name: "linkUp", OID: oidSnmpTraps + ".4"}
+	}
+	for _, column := range []int{1, 7, 8} { // ifIndex, ifAdminStatus, ifOperStatus
+		n.Objects = append(n.Objects, fmt.Sprintf(".1.3.6.1.2.1.2.2.1.%d.%d", column, index))
+	}
+	return n
+}
+
+// Destination is where a device sends its notifications: a manager, SnmpLens on
+// this machine or on another one. Unlike where a device ANSWERS, it may be any
+// address — a simulated device that could only notify its own machine would be
+// no use for testing a trap receiver elsewhere.
+type Destination struct {
+	// ID keys the destination's community in the credential store. It is given
+	// when the destination is first saved, as a device's is.
+	ID string `json:"id"`
+	// Host is an IP address or a host name.
+	Host string `json:"host"`
+	Port int    `json:"port"`
+	// Version is v1, v2c or v3.
+	Version string `json:"version"`
+	// Inform sends an InformRequest, which the receiver acknowledges, instead
+	// of a trap. v2c and v3 only.
+	Inform bool `json:"inform"`
+	// Community is what a v1 or v2c notification carries. A secret.
+	Community string `json:"community"`
+	// User is the device's SNMPv3 user a v3 notification is sent as.
+	User string `json:"user"`
+	// EngineID is the receiver's snmpEngineID in hex, for a v3 INFORM: the
+	// receiver is the authoritative engine for one, and a device given none
+	// discovers it (RFC 3414 4). A v3 trap is sent as the device's own engine
+	// and ignores it.
+	EngineID string `json:"engineId"`
+}
+
+// Schedule sends a notification over and over.
+type Schedule struct {
+	// Notification is a name from the device's catalogue, or empty for one at
+	// random each time.
+	Notification string `json:"notification"`
+	// Every is the seconds between two, 1 to MaxEvery.
+	Every int `json:"every"`
+	// Irregular draws each wait at random, from half of Every to half as much
+	// again: the same rate on average, without the regularity no real event has.
+	Irregular bool `json:"irregular"`
+}
+
+// Traps is what a device sends, where to and when.
+type Traps struct {
+	Destinations []Destination `json:"destinations"`
+	// OnStart sends coldStart once the device answers, as an agent does when it
+	// starts.
+	OnStart bool `json:"onStart"`
+	// OnAuthFailure sends authenticationFailure for a request refused for its
+	// community, an unknown user or a wrong digest: snmpEnableAuthenTraps.
+	OnAuthFailure bool       `json:"onAuthFailure"`
+	Schedules     []Schedule `json:"schedules"`
+}
+
+// clone is t sharing nothing with it.
+func (t Traps) clone() Traps {
+	t.Destinations = slices.Clone(t.Destinations)
+	t.Schedules = slices.Clone(t.Schedules)
+	return t
+}
+
+// check reports the first thing wrong with t, for a device whose SNMPv3 users
+// are users and which can send what catalogue lists.
+func (t Traps) check(users []User, catalogue []Notification) error {
+	if len(t.Destinations) > MaxDestinations {
+		return fmt.Errorf("a device sends to at most %d destinations", MaxDestinations)
+	}
+	if len(t.Schedules) > MaxSchedules {
+		return fmt.Errorf("a device keeps at most %d schedules", MaxSchedules)
+	}
+	ids := make(map[string]bool, len(t.Destinations))
+	for _, d := range t.Destinations {
+		if d.ID == "" || ids[d.ID] {
+			return errors.New("every destination needs an ID of its own")
+		}
+		ids[d.ID] = true
+		if err := d.check(users); err != nil {
+			return fmt.Errorf("destination %s: %w", net.JoinHostPort(d.Host, strconv.Itoa(d.Port)), err)
+		}
+	}
+	for _, s := range t.Schedules {
+		if s.Every < 1 || s.Every > MaxEvery {
+			return fmt.Errorf("a schedule waits 1 to %d seconds, not %d", MaxEvery, s.Every)
+		}
+		if s.Notification != "" && !slices.ContainsFunc(catalogue, func(n Notification) bool { return n.Name == s.Notification }) {
+			return fmt.Errorf("%q is not a notification this device sends", s.Notification)
+		}
+	}
+	return nil
+}
+
+func (d Destination) check(users []User) error {
+	if err := checkNotifyHost(d.Host); err != nil {
+		return err
+	}
+	if d.Port < 1 || d.Port > 65535 {
+		return fmt.Errorf("%d is not a port", d.Port)
+	}
+	switch d.Version {
+	case "v1", "v2c":
+		if d.Inform && d.Version == "v1" {
+			return errors.New("SNMPv1 has no InformRequest (RFC 1157)")
+		}
+		if d.Community == "" || len(d.Community) > maxCommunity {
+			return fmt.Errorf("v1 and v2c need a community of 1 to %d octets", maxCommunity)
+		}
+	case "v3":
+		if !slices.ContainsFunc(users, func(u User) bool { return u.Name == d.User }) {
+			return fmt.Errorf("a v3 notification is sent as one of the device's SNMPv3 users, and %q is not one", d.User)
+		}
+	default:
+		return fmt.Errorf("%q is not an SNMP version (v1, v2c or v3)", d.Version)
+	}
+	if d.EngineID != "" {
+		if id, err := hex.DecodeString(d.EngineID); err != nil || len(id) < 5 || len(id) > 32 {
+			return errors.New("a receiver's engine ID is 5 to 32 octets, in hex")
+		}
+	}
+	return nil
+}
+
+var broadcast = netip.AddrFrom4([4]byte{255, 255, 255, 255})
+
+// checkNotifyHost accepts an IP address or a host name, and refuses what a
+// notification cannot be sent to: no address at all (0.0.0.0, ::) and a group.
+func checkNotifyHost(host string) error {
+	if ip, err := netip.ParseAddr(host); err == nil {
+		ip = ip.Unmap()
+		if ip.IsUnspecified() || ip.IsMulticast() || ip == broadcast {
+			return fmt.Errorf("%s is not an address a notification can be sent to", host)
+		}
+		return nil
+	}
+	if !validHostName(host) {
+		return fmt.Errorf("%q is neither an IP address nor a host name", host)
+	}
+	return nil
+}
+
+// validHostName is RFC 1123: dot-separated labels of letters, digits and
+// hyphens, none starting or ending with a hyphen.
+func validHostName(s string) bool {
+	s = strings.TrimSuffix(s, ".")
+	if s == "" || len(s) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(s, ".") {
+		if label == "" || len(label) > 63 || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, r := range label {
+			if !(r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '-') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Delivery is what became of one notification at one destination.
+type Delivery struct {
+	// ID is the destination's.
+	ID string `json:"id"`
+	// Destination is where it went, as host:port.
+	Destination string `json:"destination"`
+	Inform      bool   `json:"inform"`
+	// Acknowledged is an INFORM the receiver answered.
+	Acknowledged bool   `json:"acknowledged"`
+	Error        string `json:"error,omitempty"`
+}
+
+// DestinationStats is what a device has sent one destination since it started.
+type DestinationStats struct {
+	ID string `json:"id"`
+	// Sent counts the notifications that left: a trap written to the socket, or
+	// an INFORM the receiver acknowledged.
+	Sent uint32 `json:"sent"`
+	// Failed counts the ones that did not, an INFORM nobody acknowledged
+	// included.
+	Failed uint32 `json:"failed"`
+	// Dropped counts the ones never tried, the destination's queue being full.
+	Dropped   uint32 `json:"dropped"`
+	LastError string `json:"lastError"`
+}
+
+// notifier sends a running agent's notifications, and lives exactly as long as
+// the agent runs.
+type notifier struct {
+	a             *Agent
+	catalogue     []Notification
+	schedules     []Schedule
+	onStart       bool
+	onAuthFailure bool
+	// passphrases are the users', by name. An INFORM is localised to the
+	// receiver's engine, and the agent holds keys for its own engine only.
+	passphrases map[string]User
+	out         []*outbound
+	limit       *bucket
+	authLimit   *bucket
+	suppressed  atomic.Uint32
+	ctx         context.Context
+	cancel      context.CancelFunc
+	running     atomic.Bool
+	wg          sync.WaitGroup
+}
+
+// outbound is one destination and the one goroutine that sends to it, so an
+// INFORM waiting on a receiver that never answers holds up that receiver and no
+// other.
+type outbound struct {
+	Destination
+	// dial is the host as dialled: "localhost" is made the loopback address of
+	// the device's own family, without asking a resolver.
+	dial string
+	// local is where the notification leaves from. For a destination on this
+	// machine that is the device's own address, so a receiver sees it come from
+	// the device as it would from real equipment. For any other it is the
+	// system's choice, since a loopback source cannot reach the network.
+	local string
+	// receiver is an INFORM receiver's engine ID, or empty to discover it.
+	receiver string
+	queue    chan job
+
+	sent, failed, dropped atomic.Uint32
+	mu                    sync.Mutex
+	lastError             string
+}
+
+type job struct {
+	n    Notification
+	done chan<- Delivery // nil unless somebody waits for the outcome
+}
+
+// newNotifier prepares what cfg has the agent send, or returns nil when there
+// is nowhere to send anything.
+func newNotifier(a *Agent, cfg Config) (*notifier, error) {
+	catalogue := cfg.Notifications
+	if catalogue == nil {
+		catalogue = []Notification{coldStart, warmStart, authenticationFailure}
+	}
+	var users []User
+	if a.v3 {
+		users = cfg.Users
+	}
+	if err := cfg.Traps.check(users, catalogue); err != nil {
+		return nil, err
+	}
+	if len(cfg.Traps.Destinations) == 0 {
+		return nil, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	nt := &notifier{
+		a:             a,
+		catalogue:     slices.Clone(catalogue),
+		schedules:     slices.Clone(cfg.Traps.Schedules),
+		onStart:       cfg.Traps.OnStart,
+		onAuthFailure: cfg.Traps.OnAuthFailure,
+		passphrases:   make(map[string]User, len(users)),
+		limit:         newBucket(notifyRate, notifyBurst),
+		authLimit:     newBucket(authFailureRate, authFailureBurst),
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+	for _, u := range users {
+		nt.passphrases[u.Name] = u
+	}
+	self := a.listen.Addr()
+	for _, d := range cfg.Traps.Destinations {
+		o := &outbound{Destination: d, dial: d.Host, queue: make(chan job, queueDepth)}
+		dest, err := netip.ParseAddr(d.Host)
+		if strings.EqualFold(d.Host, "localhost") {
+			dest, err = netip.IPv6Loopback(), nil
+			if self.Is4() {
+				dest = netip.AddrFrom4([4]byte{127, 0, 0, 1})
+			}
+		}
+		if dest = dest.Unmap(); err == nil && dest.IsLoopback() {
+			o.dial = dest.String()
+			if dest.Is4() == self.Is4() {
+				o.local = netip.AddrPortFrom(self, 0).String()
+			}
+		}
+		if d.EngineID != "" {
+			id, _ := hex.DecodeString(d.EngineID) // check has read it
+			o.receiver = string(id)
+		}
+		nt.out = append(nt.out, o)
+	}
+	return nt, nil
+}
+
+func (nt *notifier) start() {
+	nt.running.Store(true)
+	for _, o := range nt.out {
+		nt.wg.Add(1)
+		go nt.run(o)
+	}
+	for _, s := range nt.schedules {
+		nt.wg.Add(1)
+		go nt.every(s)
+	}
+	if nt.onStart {
+		nt.fire(coldStart)
+	}
+}
+
+// stop ends the schedules and the sends — an INFORM waiting for its
+// acknowledgement included — and waits for them.
+func (nt *notifier) stop() {
+	nt.cancel()
+	nt.wg.Wait()
+}
+
+// fire sends n to every destination if the device's cap allows it. It never
+// blocks: the agent's receive loop is among its callers.
+func (nt *notifier) fire(n Notification) {
+	if !nt.limit.allow(time.Now()) {
+		nt.suppressed.Add(1)
+		return
+	}
+	nt.enqueue(n, nil)
+}
+
+// enqueue hands n to every destination's goroutine without waiting. What a full
+// queue cannot take is counted, and told to whoever waits for the outcome.
+func (nt *notifier) enqueue(n Notification, done chan<- Delivery) {
+	for _, o := range nt.out {
+		select {
+		case o.queue <- job{n: n, done: done}:
+		default:
+			o.dropped.Add(1)
+			if done != nil {
+				done <- o.delivery(errQueueFull)
+			}
+		}
+	}
+}
+
+func (nt *notifier) run(o *outbound) {
+	defer nt.wg.Done()
+	for {
+		select {
+		case <-nt.ctx.Done():
+			return
+		case j := <-o.queue:
+			err := nt.deliver(o, j.n)
+			if nt.ctx.Err() != nil {
+				// Stopped in the middle of it, which is not an outcome.
+				return
+			}
+			o.record(err)
+			if j.done != nil {
+				j.done <- o.delivery(err)
+			}
+		}
+	}
+}
+
+// every runs one schedule until the agent stops.
+func (nt *notifier) every(s Schedule) {
+	defer nt.wg.Done()
+	period := time.Duration(s.Every) * time.Second
+	for {
+		wait := period
+		if s.Irregular {
+			wait = time.Duration((0.5 + rand.Float64()) * float64(period))
+		}
+		t := time.NewTimer(wait)
+		select {
+		case <-nt.ctx.Done():
+			t.Stop()
+			return
+		case <-t.C:
+		}
+		if n, ok := nt.pick(s.Notification); ok {
+			nt.fire(n)
+		}
+	}
+}
+
+// find returns the notification named name.
+func (nt *notifier) find(name string) (Notification, bool) {
+	i := slices.IndexFunc(nt.catalogue, func(n Notification) bool { return n.Name == name })
+	if i < 0 {
+		return Notification{}, false
+	}
+	return nt.catalogue[i], true
+}
+
+// pick is the notification a schedule names, or one at random when it names
+// none.
+func (nt *notifier) pick(name string) (Notification, bool) {
+	if name != "" {
+		return nt.find(name)
+	}
+	if len(nt.catalogue) == 0 {
+		return Notification{}, false
+	}
+	return nt.catalogue[rand.IntN(len(nt.catalogue))], true
+}
+
+// deliver sends n to o now and, for an INFORM, waits for the acknowledgement.
+func (nt *notifier) deliver(o *outbound, n Notification) error {
+	a := nt.a
+	c := clock{started: a.started, now: time.Now()}
+	g := &gosnmp.GoSNMP{
+		Target:    o.dial,
+		Port:      uint16(o.Port),
+		Transport: "udp",
+		LocalAddr: o.local,
+		Timeout:   informTimeout,
+		Retries:   informRetries,
+		Context:   nt.ctx,
+	}
+	var trap gosnmp.SnmpTrap
+	switch o.Version {
+	case "v1":
+		g.Version, g.Community = gosnmp.Version1, o.Community
+		t, err := a.v1Trap(n, c)
+		if err != nil {
+			return err
+		}
+		trap = t
+	case "v2c":
+		g.Version, g.Community = gosnmp.Version2c, o.Community
+		trap.Variables = a.varbinds(n, c)
+	case "v3":
+		u := a.users[o.User]
+		g.Version, g.SecurityModel, g.MsgFlags = gosnmp.Version3, gosnmp.UserSecurityModel, u.level
+		// The originator's context, as RFC 3413 3.2 has it.
+		g.ContextEngineID = string(a.engineID)
+		g.SecurityParameters = nt.security(o, u, c)
+		trap.Variables = a.varbinds(n, c)
+	}
+	trap.IsInform = o.Inform
+	if err := g.Connect(); err != nil {
+		return err
+	}
+	// gosnmp looks at its context between two attempts and not during one, so a
+	// device stopping while an INFORM waits for its acknowledgement closes the
+	// socket under it. Otherwise Stop would wait the timeout out.
+	release := context.AfterFunc(nt.ctx, func() { g.Conn.Close() })
+	defer func() {
+		release()
+		g.Conn.Close()
+	}()
+	res, err := g.SendTrap(trap)
+	switch {
+	case err != nil:
+		return err
+	case !o.Inform:
+		return nil
+	case res == nil:
+		return errors.New("the INFORM was not acknowledged")
+	case res.Error != gosnmp.NoError:
+		return fmt.Errorf("the receiver refused the INFORM: %v", res.Error)
+	}
+	return nil
+}
+
+// security is how a v3 notification to o is signed and sealed.
+//
+// A trap is sent as the device's own engine, which is the authoritative one for
+// it (RFC 3414 1.5.1): with the keys the agent localised to its engine ID, its
+// boots and its time. An INFORM is authoritative at the RECEIVER, so it goes with
+// the passphrases, which gosnmp localises to the engine ID given — or to the one
+// it discovers first, when none was.
+func (nt *notifier) security(o *outbound, u *user, c clock) *gosnmp.UsmSecurityParameters {
+	if !o.Inform {
+		sp := u.params(nt.a.engineID, u.level)
+		sp.AuthoritativeEngineBoots = nt.a.boots
+		sp.AuthoritativeEngineTime = nt.a.engineTime(c)
+		return sp
+	}
+	p := nt.passphrases[u.name]
+	sp := &gosnmp.UsmSecurityParameters{
+		UserName:               u.name,
+		AuthoritativeEngineID:  o.receiver,
+		AuthenticationProtocol: gosnmp.NoAuth,
+		PrivacyProtocol:        gosnmp.NoPriv,
+	}
+	if u.level&gosnmp.AuthNoPriv != 0 {
+		sp.AuthenticationProtocol, sp.AuthenticationPassphrase = u.auth, p.AuthPass
+	}
+	if u.level == gosnmp.AuthPriv {
+		sp.PrivacyProtocol, sp.PrivacyPassphrase = u.priv, p.PrivPass
+	}
+	return sp
+}
+
+// varbinds is what a v2c or v3 notification carries (RFC 3416 4.2.6):
+// sysUpTime.0 and snmpTrapOID.0, then the notification's objects as the device
+// answers them at this instant, then — for a generic one — snmpTrapEnterprise.0
+// with the device's sysObjectID, which is where RFC 3584 3.2 finds an SNMPv1
+// enterprise for it and what net-snmp sends.
+func (a *Agent) varbinds(n Notification, c clock) []gosnmp.SnmpPDU {
+	vars := []gosnmp.SnmpPDU{
+		{Name: oidSysUpTime, Type: gosnmp.TimeTicks, Value: c.uptime()},
+		{Name: oidSnmpTrapOID, Type: gosnmp.ObjectIdentifier, Value: n.OID},
+	}
+	vars = append(vars, a.objectsOf(n, c)...)
+	if _, generic := genericTrap(n.OID); generic {
+		if id, ok := a.sysObjectID(c); ok {
+			vars = append(vars, gosnmp.SnmpPDU{Name: oidSnmpTrapEnterprise, Type: gosnmp.ObjectIdentifier, Value: id})
+		}
+	}
+	return vars
+}
+
+// objectsOf reads n's objects from the tree; one the device does not have is
+// left out.
+func (a *Agent) objectsOf(n Notification, c clock) []gosnmp.SnmpPDU {
+	var out []gosnmp.SnmpPDU
+	for _, name := range n.Objects {
+		id, err := parseOID(name)
+		if err != nil {
+			continue
+		}
+		if e := a.tree.get(id); e != nil {
+			out = append(out, e.varbind(c))
+		}
+	}
+	return out
+}
+
+func (a *Agent) sysObjectID(c clock) (string, bool) {
+	id, _ := parseOID(oidSysObjectID)
+	e := a.tree.get(id)
+	if e == nil || e.typ != gosnmp.ObjectIdentifier {
+		return "", false
+	}
+	s, ok := e.val.read(c).(string)
+	return s, ok
+}
+
+// genericTrap is the SNMPv1 generic-trap of a notification RFC 3418 defines —
+// snmpTraps.1 to .6 are coldStart(0) to egpNeighborLoss(5) — and false for any
+// other.
+func genericTrap(oid string) (int, bool) {
+	rest, ok := strings.CutPrefix(oid, oidSnmpTraps+".")
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 1 || n > 6 {
+		return 0, false
+	}
+	return n - 1, true
+}
+
+// v1Trap is n as an SNMPv1 Trap-PDU, by RFC 3584 3.2. A generic notification is
+// its generic-trap under the device's sysObjectID. Any other is
+// enterpriseSpecific(6), with its last arc as the specific-trap and the rest as
+// the enterprise — less the zero before the last arc too, which is how SMIv2
+// writes a notification an SNMPv1 trap once was.
+func (a *Agent) v1Trap(n Notification, c clock) (gosnmp.SnmpTrap, error) {
+	// agent-addr is an IPv4 address (RFC 1157). For a device on ::1 the
+	// wildcard, which says to look at where the datagram came from.
+	t := gosnmp.SnmpTrap{AgentAddress: "0.0.0.0", Timestamp: uint(c.uptime())}
+	if ip := a.listen.Addr(); ip.Is4() {
+		t.AgentAddress = ip.String()
+	}
+	if generic, ok := genericTrap(n.OID); ok {
+		t.GenericTrap, t.Enterprise = generic, oidSnmpTraps
+		if id, ok := a.sysObjectID(c); ok {
+			t.Enterprise = id
+		}
+	} else {
+		id, err := parseOID(n.OID)
+		if err != nil {
+			return t, err
+		}
+		cut := len(id) - 1
+		if cut > 2 && id[cut-1] == 0 {
+			cut--
+		}
+		t.GenericTrap, t.SpecificTrap, t.Enterprise = 6, int(id[len(id)-1]), id[:cut].String()
+	}
+	for _, v := range a.objectsOf(n, c) {
+		if v.Type == gosnmp.Counter64 {
+			return t, errors.New("SNMPv1 cannot carry a Counter64, and RFC 3584 3.2 then sends nothing")
+		}
+		t.Variables = append(t.Variables, v)
+	}
+	return t, nil
+}
+
+func (o *outbound) record(err error) {
+	if err == nil {
+		o.sent.Add(1)
+		return
+	}
+	o.failed.Add(1)
+	o.mu.Lock()
+	o.lastError = err.Error()
+	o.mu.Unlock()
+}
+
+func (o *outbound) delivery(err error) Delivery {
+	d := Delivery{ID: o.ID, Destination: net.JoinHostPort(o.Host, strconv.Itoa(o.Port)), Inform: o.Inform}
+	if err != nil {
+		d.Error = err.Error()
+	} else {
+		d.Acknowledged = o.Inform
+	}
+	return d
+}
+
+func (nt *notifier) stats() []DestinationStats {
+	out := make([]DestinationStats, len(nt.out))
+	for i, o := range nt.out {
+		o.mu.Lock()
+		last := o.lastError
+		o.mu.Unlock()
+		out[i] = DestinationStats{ID: o.ID, Sent: o.sent.Load(), Failed: o.failed.Load(),
+			Dropped: o.dropped.Load(), LastError: last}
+	}
+	return out
+}
+
+// Notify has the agent send the notification named name to each of its
+// destinations now, and reports what became of it at each, in the order they
+// are configured. An INFORM's acknowledgement is waited for.
+func (a *Agent) Notify(name string) ([]Delivery, error) {
+	nt := a.notify
+	if nt == nil {
+		return nil, ErrNoDestination
+	}
+	if !nt.running.Load() || nt.ctx.Err() != nil {
+		return nil, ErrNotRunning
+	}
+	n, ok := nt.find(name)
+	if !ok {
+		return nil, fmt.Errorf("simulator: %q is not a notification this device sends", name)
+	}
+	if !nt.limit.allow(time.Now()) {
+		nt.suppressed.Add(1)
+		return nil, ErrTooFast
+	}
+	done := make(chan Delivery, len(nt.out))
+	nt.enqueue(n, done)
+	got := make(map[string]Delivery, len(nt.out))
+	for range nt.out {
+		select {
+		case d := <-done:
+			got[d.ID] = d
+		case <-nt.ctx.Done():
+			return nil, ErrNotRunning
+		}
+	}
+	out := make([]Delivery, len(nt.out))
+	for i, o := range nt.out {
+		out[i] = got[o.ID]
+	}
+	return out, nil
+}
+
+// authFailed is told of a request refused as not authentic — a community this
+// device does not have, a user it does not know, a wrong digest — and sends
+// authenticationFailure when the device is configured to, about once a second
+// at most whatever the rate of refusals.
+func (a *Agent) authFailed() {
+	if nt := a.notify; nt != nil && nt.onAuthFailure && nt.authLimit.allow(time.Now()) {
+		nt.fire(authenticationFailure)
+	}
+}
+
+// bucket lets rate events a second through on average, and burst at once.
+type bucket struct {
+	mu          sync.Mutex
+	rate, burst float64
+	tokens      float64
+	last        time.Time
+}
+
+func newBucket(rate, burst float64) *bucket { return &bucket{rate: rate, burst: burst, tokens: burst} }
+
+func (b *bucket) allow(now time.Time) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.last.IsZero() {
+		b.tokens = min(b.burst, b.tokens+now.Sub(b.last).Seconds()*b.rate)
+	}
+	b.last = now
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math"
 	"math/rand/v2"
 	"net"
 	"net/netip"
@@ -678,11 +679,17 @@ func (a *Agent) v1Trap(n Notification, c clock) (gosnmp.SnmpTrap, error) {
 		if err != nil {
 			return t, err
 		}
+		// specific-trap is an INTEGER (RFC 1157) and an arc goes to 2^32 - 1,
+		// past what an Integer32 holds — and what an int holds on a 32-bit build.
+		specific := id[len(id)-1]
+		if specific > math.MaxInt32 {
+			return t, fmt.Errorf("SNMPv1 cannot carry a specific-trap of %d", specific)
+		}
 		cut := len(id) - 1
 		if cut > 2 && id[cut-1] == 0 {
 			cut--
 		}
-		t.GenericTrap, t.SpecificTrap, t.Enterprise = 6, int(id[len(id)-1]), id[:cut].String()
+		t.GenericTrap, t.SpecificTrap, t.Enterprise = 6, int(specific), id[:cut].String()
 	}
 	for _, v := range a.objectsOf(n, c) {
 		if v.Type == gosnmp.Counter64 {

--- a/pkg/simulator/notify_test.go
+++ b/pkg/simulator/notify_test.go
@@ -235,6 +235,11 @@ func TestANotificationTranslatesToSNMPv1(t *testing.T) {
 	if _, err := a.v1Trap(wide, c); err == nil {
 		t.Error("a notification carrying a Counter64 was translated to SNMPv1")
 	}
+	// Nor has it a specific-trap past Integer32, which an arc can be.
+	huge := Notification{Name: "huge", OID: ".1.3.6.1.4.1.9.0.4294967295"}
+	if _, err := a.v1Trap(huge, c); err == nil {
+		t.Error("a specific-trap past Integer32 was translated to SNMPv1")
+	}
 }
 
 // Every notification a model lists can be sent: its OID parses, the device has

--- a/pkg/simulator/notify_test.go
+++ b/pkg/simulator/notify_test.go
@@ -1,0 +1,522 @@
+package simulator
+
+import (
+	"encoding/hex"
+	"errors"
+	"net"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/events"
+	"SnmpLens/pkg/snmp"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+const sysNameOID = ".1.3.6.1.2.1.1.5.0"
+
+var notifyUser = User{Name: "ops", SecLevel: "AuthPriv",
+	AuthProto: "SHA256", AuthPass: "authpass-1", PrivProto: "AES", PrivPass: "privpass-1"}
+
+// notifyingAgent starts an agent built as the Linux server, whose
+// notifications carry objects, sending what traps says.
+func notifyingAgent(t *testing.T, listen string, traps Traps) *Agent {
+	t.Helper()
+	return startAgent(t, Config{
+		Listen:        listen,
+		Versions:      []string{"v1", "v2c", "v3"},
+		Community:     "public",
+		Users:         []User{notifyUser},
+		Objects:       linuxServer.build(Identity{Name: "srv-01", Seed: 1}),
+		Notifications: linuxServer.catalogue(),
+		Traps:         traps,
+	})
+}
+
+// trapReceiver is a UDP socket a test reads notifications from, as a manager
+// would.
+type trapReceiver struct{ conn *net.UDPConn }
+
+func listenForTraps(t *testing.T) *trapReceiver {
+	t.Helper()
+	conn, err := net.ListenUDP("udp", net.UDPAddrFromAddrPort(netip.MustParseAddrPort("127.0.0.1:0")))
+	if err != nil {
+		t.Skipf("no UDP socket: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return &trapReceiver{conn: conn}
+}
+
+func (r *trapReceiver) port() int { return r.conn.LocalAddr().(*net.UDPAddr).Port }
+
+// next is the next datagram and where it came from; the test fails if none
+// comes within two seconds.
+func (r *trapReceiver) next(t *testing.T) ([]byte, netip.Addr) {
+	t.Helper()
+	buf := make([]byte, 65535)
+	r.conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, from, err := r.conn.ReadFromUDPAddrPort(buf)
+	if err != nil {
+		t.Fatalf("no notification arrived: %v", err)
+	}
+	return buf[:n], from.Addr().Unmap()
+}
+
+// count is how many datagrams arrive within d.
+func (r *trapReceiver) count(d time.Duration) int {
+	buf := make([]byte, 65535)
+	r.conn.SetReadDeadline(time.Now().Add(d))
+	n := 0
+	for {
+		if _, _, err := r.conn.ReadFromUDPAddrPort(buf); err != nil {
+			return n
+		}
+		n++
+	}
+}
+
+func decodeTrap(t *testing.T, raw []byte, ver gosnmp.SnmpVersion) *gosnmp.SnmpPacket {
+	t.Helper()
+	p, err := (&gosnmp.GoSNMP{Version: ver}).SnmpDecodePacket(raw)
+	if err != nil {
+		t.Fatalf("an undecodable notification: %v", err)
+	}
+	return p
+}
+
+// trapOIDOf is a v2c or v3 notification's snmpTrapOID.0, which RFC 3416 puts
+// second.
+func trapOIDOf(t *testing.T, p *gosnmp.SnmpPacket) string {
+	t.Helper()
+	if len(p.Variables) < 2 || p.Variables[1].Name != oidSnmpTrapOID {
+		t.Fatalf("no snmpTrapOID.0 in second place: %v", names(p.Variables))
+	}
+	oid, _ := p.Variables[1].Value.(string)
+	return oid
+}
+
+func usmOf(u User) *gosnmp.UsmSecurityParameters {
+	return &gosnmp.UsmSecurityParameters{UserName: u.Name,
+		AuthenticationProtocol: gosnmp.SHA256, AuthenticationPassphrase: u.AuthPass,
+		PrivacyProtocol: gosnmp.AES, PrivacyPassphrase: u.PrivPass}
+}
+
+// ownAddress is a loopback address other than 127.0.0.1 where this machine
+// answers on one — Windows and Linux do, macOS without aliases does not — so a
+// notification's source can be told from the receiver's own address.
+func ownAddress() string {
+	c, err := net.ListenPacket("udp", "127.0.0.2:0")
+	if err != nil {
+		return "127.0.0.1"
+	}
+	c.Close()
+	return "127.0.0.2"
+}
+
+// A device sends one notification in each version as that version has it:
+// SNMPv1's generic-trap under the device's sysObjectID, SNMPv2's varbinds in
+// RFC 3416's order, SNMPv3 signed and sealed as the device's own engine — and
+// all three from the device's own address, as real equipment would send them.
+func TestADeviceSendsANotificationInEachVersion(t *testing.T) {
+	host := ownAddress()
+	v1, v2c, v3 := listenForTraps(t), listenForTraps(t), listenForTraps(t)
+	a := notifyingAgent(t, host+":0", Traps{Destinations: []Destination{
+		{ID: "v1", Host: "127.0.0.1", Port: v1.port(), Version: "v1", Community: "v1-community"},
+		{ID: "v2c", Host: "127.0.0.1", Port: v2c.port(), Version: "v2c", Community: "v2c-community"},
+		{ID: "v3", Host: "localhost", Port: v3.port(), Version: "v3", User: "ops"},
+	}})
+	got, err := a.Notify("linkDown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range got {
+		if d.Error != "" || d.Acknowledged {
+			t.Errorf("%s: %+v", d.ID, d)
+		}
+	}
+
+	const sysObjectID = ".1.3.6.1.4.1.8072.3.2.10"
+	link := []string{".1.3.6.1.2.1.2.2.1.1.3", ".1.3.6.1.2.1.2.2.1.7.3", ".1.3.6.1.2.1.2.2.1.8.3"}
+	v2Order := slices.Concat([]string{oidSysUpTime, oidSnmpTrapOID}, link, []string{oidSnmpTrapEnterprise})
+	source := func(t *testing.T, from netip.Addr) {
+		t.Helper()
+		if from.String() != host {
+			t.Errorf("sent from %s rather than from the device's own %s", from, host)
+		}
+	}
+
+	t.Run("v1", func(t *testing.T) {
+		raw, from := v1.next(t)
+		p := decodeTrap(t, raw, gosnmp.Version1)
+		if p.PDUType != gosnmp.Trap || p.Community != "v1-community" {
+			t.Fatalf("%v with community %q", p.PDUType, p.Community)
+		}
+		if p.GenericTrap != 2 || p.SpecificTrap != 0 || p.Enterprise != sysObjectID || p.AgentAddress != host {
+			t.Errorf("generic %d, specific %d, enterprise %s, agent %s", p.GenericTrap, p.SpecificTrap, p.Enterprise, p.AgentAddress)
+		}
+		if !slices.Equal(names(p.Variables), link) {
+			t.Errorf("varbinds %v, want %v", names(p.Variables), link)
+		}
+		source(t, from)
+	})
+	t.Run("v2c", func(t *testing.T) {
+		raw, from := v2c.next(t)
+		p := decodeTrap(t, raw, gosnmp.Version2c)
+		if p.PDUType != gosnmp.SNMPv2Trap || p.Community != "v2c-community" {
+			t.Fatalf("%v with community %q", p.PDUType, p.Community)
+		}
+		if !slices.Equal(names(p.Variables), v2Order) {
+			t.Fatalf("varbinds %v, want %v", names(p.Variables), v2Order)
+		}
+		if oid := trapOIDOf(t, p); oid != oidSnmpTraps+".3" {
+			t.Errorf("snmpTrapOID.0 = %s", oid)
+		}
+		// What the notification says of eth1 is what a GET says: it is down.
+		if oper := p.Variables[4].Value; oper != 2 {
+			t.Errorf("ifOperStatus.3 = %v, want 2", oper)
+		}
+		source(t, from)
+	})
+	t.Run("v3", func(t *testing.T) {
+		raw, from := v3.next(t)
+		// Read with the user's keys for the DEVICE's engine: a v3 trap is sent
+		// as the engine that is authoritative for it.
+		sp := usmOf(notifyUser)
+		sp.AuthoritativeEngineID = string(a.engineID)
+		g := &gosnmp.GoSNMP{Version: gosnmp.Version3, SecurityModel: gosnmp.UserSecurityModel,
+			MsgFlags: gosnmp.AuthPriv, SecurityParameters: sp}
+		p, err := g.UnmarshalTrap(raw, false)
+		if err != nil {
+			t.Fatalf("the v3 trap does not open with the device's keys: %v", err)
+		}
+		got := p.SecurityParameters.(*gosnmp.UsmSecurityParameters)
+		if got.AuthoritativeEngineID != string(a.engineID) || got.AuthoritativeEngineBoots != a.boots || got.UserName != "ops" {
+			t.Errorf("sent as engine %x, boots %d, user %q", got.AuthoritativeEngineID, got.AuthoritativeEngineBoots, got.UserName)
+		}
+		if p.MsgFlags&gosnmp.AuthPriv != gosnmp.AuthPriv || p.MsgFlags&gosnmp.Reportable != 0 {
+			t.Errorf("flags %v: a trap is authPriv here, and never reportable (RFC 3412 6.4)", p.MsgFlags)
+		}
+		if !slices.Equal(names(p.Variables), v2Order) {
+			t.Errorf("varbinds %v, want %v", names(p.Variables), v2Order)
+		}
+		source(t, from)
+	})
+}
+
+// RFC 3584 3.2, for the notifications that are not generic: enterpriseSpecific,
+// the last arc as the specific-trap, and the enterprise without it — and without
+// the zero before it, where there is one.
+func TestANotificationTranslatesToSNMPv1(t *testing.T) {
+	a := newAgent(t, Config{Versions: []string{"v1"}, Community: "public",
+		Objects: linuxServer.build(Identity{Name: "srv-01", Seed: 1})})
+	c := clock{started: time.Now(), now: time.Now()}
+	for _, tc := range []struct {
+		n                 Notification
+		generic, specific int
+		enterprise        string
+	}{
+		{coldStart, 0, 0, ".1.3.6.1.4.1.8072.3.2.10"},
+		{authenticationFailure, 4, 0, ".1.3.6.1.4.1.8072.3.2.10"},
+		{Notification{Name: "nsNotifyShutdown", OID: ".1.3.6.1.4.1.8072.4.0.2"}, 6, 2, ".1.3.6.1.4.1.8072.4"},
+		{Notification{Name: "vendor", OID: ".1.3.6.1.4.1.9.9.41.2.1"}, 6, 1, ".1.3.6.1.4.1.9.9.41.2"},
+	} {
+		trap, err := a.v1Trap(tc.n, c)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.n.Name, err)
+		}
+		if trap.GenericTrap != tc.generic || trap.SpecificTrap != tc.specific || trap.Enterprise != tc.enterprise {
+			t.Errorf("%s: generic %d, specific %d, enterprise %s", tc.n.Name, trap.GenericTrap, trap.SpecificTrap, trap.Enterprise)
+		}
+	}
+	// SNMPv1 has no Counter64, and a notification carrying one is not sent in it.
+	wide := Notification{Name: "wide", OID: ".1.3.6.1.4.1.9.0.1", Objects: []string{".1.3.6.1.2.1.31.1.1.1.6.2"}}
+	if _, err := a.v1Trap(wide, c); err == nil {
+		t.Error("a notification carrying a Counter64 was translated to SNMPv1")
+	}
+}
+
+// Every notification a model lists can be sent: its OID parses, the device has
+// every object it carries, and it has an SNMPv1 form.
+func TestEveryNotificationOfAModelIsWhole(t *testing.T) {
+	for _, m := range models {
+		a := newAgent(t, Config{Versions: []string{"v1"}, Community: "public", Objects: m.build(Identity{Name: "x", Seed: 1})})
+		c := clock{started: time.Now(), now: time.Now()}
+		seen := map[string]bool{}
+		for _, n := range m.catalogue() {
+			if seen[n.Name] {
+				t.Errorf("%s: %s is listed twice", m.ID, n.Name)
+			}
+			seen[n.Name] = true
+			if _, err := parseOID(n.OID); err != nil {
+				t.Errorf("%s: %s: %v", m.ID, n.Name, err)
+			}
+			if got := len(a.objectsOf(n, c)); got != len(n.Objects) {
+				t.Errorf("%s: %s carries %d of its %d objects", m.ID, n.Name, got, len(n.Objects))
+			}
+			if _, err := a.v1Trap(n, c); err != nil {
+				t.Errorf("%s: %s has no SNMPv1 form: %v", m.ID, n.Name, err)
+			}
+		}
+	}
+}
+
+// answerInforms acknowledges every v2c INFORM that reaches conn, as a trap
+// receiver does, until conn closes.
+func answerInforms(conn *net.UDPConn) {
+	buf := make([]byte, 65535)
+	for {
+		n, from, err := conn.ReadFromUDPAddrPort(buf)
+		if err != nil {
+			return
+		}
+		p, err := (&gosnmp.GoSNMP{Version: gosnmp.Version2c}).SnmpDecodePacket(buf[:n])
+		if err != nil || p.PDUType != gosnmp.InformRequest {
+			continue
+		}
+		p.PDUType = gosnmp.GetResponse
+		if out, err := p.MarshalMsg(); err == nil {
+			_, _ = conn.WriteToUDPAddrPort(out, from)
+		}
+	}
+}
+
+// An INFORM is reported acknowledged only when the receiver answers it — and a
+// device stopping while one waits for an answer does not wait out the timeout.
+func TestAnInformWaitsForItsAcknowledgement(t *testing.T) {
+	answering := listenForTraps(t)
+	go answerInforms(answering.conn)
+	a := notifyingAgent(t, "127.0.0.1:0", Traps{Destinations: []Destination{
+		{ID: "nms", Host: "127.0.0.1", Port: answering.port(), Version: "v2c", Community: "public", Inform: true}}})
+	got, err := a.Notify("linkUp")
+	if err != nil || len(got) != 1 || !got[0].Acknowledged || got[0].Error != "" {
+		t.Fatalf("an answered INFORM: %+v, %v", got, err)
+	}
+	if st := a.Stats().Notifications; len(st) != 1 || st[0].Sent != 1 || st[0].Failed != 0 {
+		t.Errorf("counted %+v", st)
+	}
+
+	unanswering := listenForTraps(t)
+	b := notifyingAgent(t, "127.0.0.1:0", Traps{Destinations: []Destination{
+		{ID: "void", Host: "127.0.0.1", Port: unanswering.port(), Version: "v2c", Community: "public", Inform: true}}})
+	result := make(chan error, 1)
+	go func() {
+		_, err := b.Notify("linkUp")
+		result <- err
+	}()
+	unanswering.next(t) // the INFORM is out, and waits
+	start := time.Now()
+	b.Stop()
+	if took := time.Since(start); took > time.Second {
+		t.Errorf("stopping took %v with an INFORM waiting", took)
+	}
+	if err := <-result; !errors.Is(err, ErrNotRunning) {
+		t.Errorf("the waiting Notify returned %v, want ErrNotRunning", err)
+	}
+}
+
+// managerOf is a gosnmp manager aimed at a, waiting timeout for an answer.
+func managerOf(t *testing.T, a *Agent, g *gosnmp.GoSNMP, timeout time.Duration) *gosnmp.GoSNMP {
+	t.Helper()
+	ap := a.Addr()
+	g.Target, g.Port, g.Timeout, g.Retries = ap.Addr().String(), ap.Port(), timeout, 0
+	if g.Version == gosnmp.Version3 {
+		g.SecurityModel, g.MsgFlags = gosnmp.UserSecurityModel, gosnmp.AuthPriv
+	}
+	return connect(t, g)
+}
+
+// A request refused as not authentic is notified — a wrong community, an
+// unknown user, a wrong digest — and discovery and an authentic request are
+// not. A burst of refusals is capped: each is a datagram anyone on the machine
+// can send, and the notification may go to the network.
+func TestARefusedRequestSendsAuthenticationFailure(t *testing.T) {
+	r := listenForTraps(t)
+	traps := func(port int) Traps {
+		return Traps{OnAuthFailure: true, Destinations: []Destination{
+			{ID: "nms", Host: "127.0.0.1", Port: port, Version: "v2c", Community: "public"}}}
+	}
+	a := notifyingAgent(t, "127.0.0.1:0", traps(r.port()))
+
+	good := managerOf(t, a, &gosnmp.GoSNMP{Version: gosnmp.Version3, SecurityParameters: usmOf(notifyUser)}, 2*time.Second)
+	if _, err := good.Get([]string{sysNameOID}); err != nil {
+		t.Fatal(err)
+	}
+	if n := r.count(silent); n != 0 {
+		t.Fatalf("discovery and an authentic request sent %d notifications", n)
+	}
+
+	bad := managerOf(t, a, &gosnmp.GoSNMP{Version: gosnmp.Version2c, Community: "wrong"}, 20*time.Millisecond)
+	for range 10 {
+		_, _ = bad.Get([]string{sysNameOID})
+	}
+	raw, _ := r.next(t)
+	if oid := trapOIDOf(t, decodeTrap(t, raw, gosnmp.Version2c)); oid != authenticationFailure.OID {
+		t.Errorf("a wrong community sent %s", oid)
+	}
+	if n := 1 + r.count(silent); n > authFailureBurst+1 {
+		t.Errorf("ten refused requests sent %d notifications", n)
+	}
+
+	stranger := notifyUser
+	stranger.Name = "nobody"
+	forger := notifyUser
+	forger.AuthPass = "not-the-passphrase"
+	for name, u := range map[string]User{"an unknown user": stranger, "a wrong digest": forger} {
+		t.Run(name, func(t *testing.T) {
+			r := listenForTraps(t)
+			a := notifyingAgent(t, "127.0.0.1:0", traps(r.port()))
+			g := managerOf(t, a, &gosnmp.GoSNMP{Version: gosnmp.Version3, SecurityParameters: usmOf(u)}, 500*time.Millisecond)
+			if _, err := g.Get([]string{sysNameOID}); err == nil {
+				t.Fatal("the request was answered")
+			}
+			raw, _ := r.next(t)
+			if oid := trapOIDOf(t, decodeTrap(t, raw, gosnmp.Version2c)); oid != authenticationFailure.OID {
+				t.Errorf("sent %s", oid)
+			}
+		})
+	}
+}
+
+// A device configured to says it started, then keeps its schedule.
+func TestADeviceNotifiesItsStartThenKeepsItsSchedule(t *testing.T) {
+	r := listenForTraps(t)
+	notifyingAgent(t, "127.0.0.1:0", Traps{OnStart: true, Schedules: []Schedule{{Notification: "linkUp", Every: 1}},
+		Destinations: []Destination{{ID: "nms", Host: "127.0.0.1", Port: r.port(), Version: "v2c", Community: "public"}}})
+	for _, want := range []Notification{coldStart, linkNotification(true, 2)} {
+		raw, _ := r.next(t)
+		if got := trapOIDOf(t, decodeTrap(t, raw, gosnmp.Version2c)); got != want.OID {
+			t.Errorf("got %s, want %s (%s)", got, want.OID, want.Name)
+		}
+	}
+}
+
+// SnmpLens hears a simulated device: its trap listener journals the device's
+// v2c trap, and acknowledges its SNMPv3 INFORM sent to the engine ID the
+// listener stands for.
+func TestSnmpLensHearsTheSimulator(t *testing.T) {
+	engineID, _ := hex.DecodeString("8000000005a1b2c3d4e5f60718")
+	traps, informs := make(chan events.Event, 1), make(chan events.Event, 1)
+	// No context is a headless client: it journals what it hears and emits
+	// nothing to a window, where the Wails runtime would end the process.
+	//lint:ignore SA1012 a nil context is how pkg/snmp tells a headless client
+	client := snmp.NewClient(nil)
+	client.SetRecorder(events.RecorderFunc(func(e events.Event, _ string) error {
+		ch := traps
+		if e.Kind == events.KindTrapInform {
+			ch = informs
+		}
+		select {
+		case ch <- e:
+		default:
+		}
+		return nil
+	}))
+	client.SetTrapEngineID(engineID)
+	c, err := net.ListenPacket("udp", ":0")
+	if err != nil {
+		t.Skipf("no UDP socket: %v", err)
+	}
+	port := c.LocalAddr().(*net.UDPAddr).Port
+	c.Close()
+	info, err := client.StartTrapListener(port, []snmp.V3Params{{User: notifyUser.Name, SecLevel: notifyUser.SecLevel,
+		AuthProto: notifyUser.AuthProto, AuthPass: notifyUser.AuthPass, PrivProto: notifyUser.PrivProto, PrivPass: notifyUser.PrivPass}})
+	if err != nil {
+		t.Skipf("cannot bind a trap listener: %v", err)
+	}
+	t.Cleanup(client.StopTrapListener)
+	if info.Users != 1 {
+		t.Fatalf("the listener took %d users: %+v", info.Users, info.Refused)
+	}
+
+	// The listener binds on a goroutine of its own, so the device sends until
+	// it is heard.
+	trapper := notifyingAgent(t, "127.0.0.1:0", Traps{Destinations: []Destination{
+		{ID: "trap", Host: "127.0.0.1", Port: port, Version: "v2c", Community: "public"}}})
+	deadline := time.After(5 * time.Second)
+	for heard := false; !heard; {
+		if _, err := trapper.Notify("linkUp"); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case e := <-traps:
+			if e.OID != oidSnmpTraps+".4" {
+				t.Errorf("journalled the trap as %q", e.OID)
+			}
+			heard = true
+		case <-time.After(50 * time.Millisecond):
+		case <-deadline:
+			t.Fatal("SnmpLens never heard the simulated device's trap")
+		}
+	}
+
+	informer := notifyingAgent(t, "127.0.0.1:0", Traps{Destinations: []Destination{
+		{ID: "inform", Host: "127.0.0.1", Port: port, Version: "v3", User: "ops", Inform: true,
+			EngineID: hex.EncodeToString(engineID)}}})
+	got, err := informer.Notify("linkDown")
+	if err != nil || len(got) != 1 || !got[0].Acknowledged {
+		t.Fatalf("the SNMPv3 INFORM: %+v, %v", got, err)
+	}
+	// Acknowledged means journalled first: the insert is what the
+	// acknowledgement waits for.
+	select {
+	case e := <-informs:
+		if e.OID != oidSnmpTraps+".3" {
+			t.Errorf("journalled the INFORM as %q", e.OID)
+		}
+	default:
+		t.Error("an acknowledged INFORM was not journalled")
+	}
+}
+
+// Where a device may send, and what, is checked when it is saved.
+func TestTrapsAreHeldToTheRules(t *testing.T) {
+	valid := func() Device {
+		d := validDevice(t)
+		d.Traps = Traps{
+			Destinations: []Destination{
+				{ID: "a", Host: "192.0.2.10", Port: 162, Version: "v2c", Community: "public"},
+				{ID: "b", Host: "nms.example.com", Port: 10162, Version: "v3", User: "ops", Inform: true, EngineID: "8000000005aabbccdd"},
+			},
+			Schedules: []Schedule{{Notification: "linkDown", Every: 60}, {Every: 5, Irregular: true}},
+		}
+		return d
+	}
+	if err := valid().Validate(); err != nil {
+		t.Fatalf("valid traps: %v", err)
+	}
+	for missing, change := range map[string]func(*Traps){
+		"a host":                         func(tr *Traps) { tr.Destinations[0].Host = "" },
+		"a host name that is one":        func(tr *Traps) { tr.Destinations[0].Host = "-nms.example.com" },
+		"an address to send to":          func(tr *Traps) { tr.Destinations[0].Host = "0.0.0.0" },
+		"one receiver, not a group":      func(tr *Traps) { tr.Destinations[0].Host = "224.0.0.1" },
+		"a port":                         func(tr *Traps) { tr.Destinations[0].Port = 0 },
+		"a known version":                func(tr *Traps) { tr.Destinations[0].Version = "v2" },
+		"an INFORM SNMPv1 has":           func(tr *Traps) { tr.Destinations[0].Version, tr.Destinations[0].Inform = "v1", true },
+		"a community":                    func(tr *Traps) { tr.Destinations[0].Community = "" },
+		"a user the device has":          func(tr *Traps) { tr.Destinations[1].User = "nobody" },
+		"an engine ID in hex":            func(tr *Traps) { tr.Destinations[1].EngineID = "zz" },
+		"an engine ID of 5 octets":       func(tr *Traps) { tr.Destinations[1].EngineID = "80000000" },
+		"an ID":                          func(tr *Traps) { tr.Destinations[0].ID = "" },
+		"an ID of its own":               func(tr *Traps) { tr.Destinations[1].ID = "a" },
+		"a notification the device has":  func(tr *Traps) { tr.Schedules[0].Notification = "linkSideways" },
+		"an interval":                    func(tr *Traps) { tr.Schedules[0].Every = 0 },
+		"an interval of a day at most":   func(tr *Traps) { tr.Schedules[0].Every = MaxEvery + 1 },
+		"a bounded list of destinations": func(tr *Traps) { tr.Destinations = make([]Destination, MaxDestinations+1) },
+		"a bounded list of schedules":    func(tr *Traps) { tr.Schedules = make([]Schedule, MaxSchedules+1) },
+	} {
+		d := valid()
+		change(&d.Traps)
+		if err := d.Validate(); err == nil {
+			t.Errorf("traps without %s were accepted", missing)
+		}
+	}
+	// A device's users are its SNMPv3 users: one that does not answer v3 has
+	// none to send a v3 notification as.
+	d := valid()
+	d.Versions = []string{"v2c"}
+	if err := d.Validate(); err == nil {
+		t.Error("a device that does not answer v3 was given a v3 destination")
+	}
+}

--- a/pkg/simulator/usm.go
+++ b/pkg/simulator/usm.go
@@ -228,6 +228,7 @@ func (a *Agent) answerV3(msg []byte, c clock) []byte {
 	}
 	u := a.users[h.user]
 	if u == nil {
+		a.authFailed()
 		return a.report(h, nil, gosnmp.NoAuthNoPriv, h.requestID, oidUnknownUserNames, &a.stats.unknownUserNames, c)
 	}
 	if level > u.level {
@@ -322,6 +323,7 @@ func (a *Agent) refuse(h *v3Header, u *user, level gosnmp.SnmpV3MsgFlags, msg []
 		return nil
 	}
 	if _, err := a.decoder(u, level).SnmpDecodePacket(bytes.Clone(msg)); err == nil {
+		a.authFailed()
 		return a.report(h, nil, gosnmp.NoAuthNoPriv, h.requestID, oidWrongDigests, &a.stats.wrongDigests, c)
 	}
 	if level == gosnmp.AuthPriv {

--- a/pkg/snmp/client.go
+++ b/pkg/snmp/client.go
@@ -89,6 +89,9 @@ type Client struct {
 	// the users differ.
 	trapPort  int
 	trapUsers []V3Params
+	// trapEngineID is the snmpEngineID the listener stands for
+	// (SetTrapEngineID), under trapMu.
+	trapEngineID string
 	// trapLife serialises the listener's LIFECYCLE — start, stop, and a change
 	// of users, which is a stop and a start back to back; another start or
 	// stop landing between the two would be undone by the second. Separate

--- a/pkg/snmp/trap.go
+++ b/pkg/snmp/trap.go
@@ -81,6 +81,8 @@ func (c *Client) startTrapListener(port int, users []V3Params) (TrapListenerInfo
 		params.Version = gosnmp.Version3
 		params.SecurityModel = gosnmp.UserSecurityModel
 		params.MsgFlags = sec.flags
+		// The engine a message is compared with; see SetTrapEngineID.
+		sec.first.AuthoritativeEngineID = c.trapEngineID
 		// Both, never the table alone: see trapSecurity.first.
 		params.SecurityParameters = sec.first
 		params.TrapSecurityParametersTable = sec.table
@@ -150,6 +152,26 @@ func (c *Client) startTrapListener(port int, users []V3Params) (TrapListenerInfo
 	c.trapPort = port
 	c.trapUsers = sec.info.accepted
 	return sec.info, nil
+}
+
+// SetTrapEngineID gives the trap listener the snmpEngineID it stands for, from
+// its next start.
+//
+// The receiver of an SNMPv3 INFORM is the authoritative engine for it (RFC 3414
+// 1.5.1), and gosnmp's listener never answers the discovery a sender would learn
+// the ID from: a message naming no engine names no user either, and the table
+// of users drops it before anything could report. So a sender has to be TOLD
+// the ID, and one that changed at every start is one nobody could configure —
+// which is why the application keeps this one and shows it.
+//
+// gosnmp does not hold a sender to it. An INFORM localised to any other valid
+// engine ID is read all the same, its listener taking RFC 3414 3.2.3a's
+// "continue processing" literally; a sender configured before this existed
+// keeps working.
+func (c *Client) SetTrapEngineID(id []byte) {
+	c.trapMu.Lock()
+	defer c.trapMu.Unlock()
+	c.trapEngineID = string(id)
 }
 
 // StopTrapListener stops the active trap listener.


### PR DESCRIPTION
## Summary

Step 4 of the simulator: a simulated device sends traps and INFORMs.

> **Stacked on #65.** This branch starts from it, so until #65 is merged the diff includes it; this PR's own changes are the last commit.

### What a device sends, and when

- Up to eight destinations, each in v1, v2c or v3, as traps or as INFORMs (v2c and v3).
- Triggers:
  - coldStart when the device starts;
  - authenticationFailure when a request is refused (wrong community, unknown user, wrong digest);
  - schedules: a named notification or one at random, every 1 to 86400 seconds, optionally irregular;
  - **Send a trap…** in the device list.
- A destination may be anywhere on the network. What is bounded is the rate:
  - authenticationFailure about once a second at most;
  - 20 notifications a second per device, burst 40;
  - held-back and dropped notifications are counted.
- One goroutine per destination. Stopping a device interrupts an INFORM that is waiting for its acknowledgement.

### What a notification carries

- **v2c/v3:** sysUpTime.0 and snmpTrapOID.0 first, then the notification's objects read from the device's tree at that instant, then snmpTrapEnterprise.0 (the sysObjectID) for a generic notification.
- **v1:** RFC 3584 3.2, either the generic-trap under the sysObjectID or enterpriseSpecific. A notification carrying a Counter64 has no v1 form.
- **v3 trap:** signed and sealed as the device's own engine.
- **v3 INFORM:** localised to the receiver's engine ID, given or discovered.
- A notification sent to this machine leaves from the device's own address.

### SnmpLens's listener engine ID

- gosnmp's trap listener cannot be discovered, so SnmpLens now keeps an engine ID of its own: `trap-engine-id` beside `monitoring.db`, RFC 3411 format 5 under enterprise 0.
- The Traps panel shows it, and the **SnmpLens on this machine** button fills it in for a v3 INFORM.

### Secrets and interface

- Destination communities go to the credential store with the device's other secrets, by destination ID.
- Neither the device file nor the list the renderer receives holds one; `app_simulator_test.go` searches both.
- The editor has a Notifications section. The list shows what a running device has sent, with a menu to send a notification now.
- All five locales.

## Verification

- `pkg/simulator`:
  - one notification decoded in each version: varbind order, v1 fields, v3 opened with keys localised to the device's engine, source address;
  - the RFC 3584 translation;
  - every notification of every model has all its objects and a v1 form;
  - an answered INFORM is acknowledged, and stopping a device with an INFORM pending returns within a second;
  - authenticationFailure is sent for each kind of refusal and capped, and discovery or an authentic request sends none;
  - coldStart, then a schedule;
  - the validation rules.
- `TestSnmpLensHearsTheSimulator`: SnmpLens's own listener journals a simulated v2c trap and acknowledges a v3 INFORM sent to its engine ID.
- App tests:
  - a destination gets its ID at save;
  - communities stay in the store only;
  - sending a trap works end to end;
  - the engine ID is made once and kept.
- Clean: `go vet`, `go test -race` (root, `pkg/snmp`, `pkg/simulator`) and staticcheck 0.8.1. Passing: `npm test`, `svelte-check --fail-on-warnings` and the Vite build.
- The `simulator` and `simulator-editor` scenes, and the new `simulator-traps`, were checked in both themes.
