### PR TITLE
Give the simulator a catalogue: nine models the presets poll

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -605,12 +605,25 @@ what keeps a previous run's messages out of the time window. Every start raises 
 the device answers. A running device that is edited restarts; nothing starts by itself at launch. The header's
 status and the modal read `simulatorStore`, which Go refreshes with `simulator:changed`.
 
-**A model is a vocabulary, not prose.** `simulator.Models()` serves an ID and a category; the name and the
-description are `simulator.model.<id>` in the five locales, and `tests/simulator.test.mjs` requires `en.json` to
-answer for every ID in `pkg/simulator`. The Linux model answers everything the "Interfaces (IF-MIB)" and "Server
-(HOST-RESOURCES-MIB)" presets poll — `TestTheLinuxModelFeedsItsPresets` expands their widgets against it — and its
-values are pure functions of time (`values.go`): counters that only go up and wrap at 32 bits as a real
+**A model is a vocabulary, not prose.** `simulator.Models()` serves an ID, a category and the notifications; the
+name and the description are `simulator.model.<id>`, and the category `simulator.category.<category>`, in the five
+locales, and `tests/simulator.test.mjs` requires `en.json` to answer for every ID and category in `pkg/simulator`.
+Values are pure functions of time (`values.go`): counters that only go up and wrap at 32 bits as a real
 interface's do, gauges that swing, nothing ticking in the background.
+
+**The catalogue is what the presets poll.** Nine models: a Linux server, a Windows server, a Catalyst 2960 with 24
+and with 48 ports, an ISR 4331 with two eBGP sessions, a Synology NAS, a three-phase APC Smart-UPS, an HP LaserJet
+and an ENTITY-SENSOR-MIB probe. Each says which bundled presets it feeds (`modelPresets`), and
+`TestEveryModelFeedsItsPresets` expands those presets' widgets against it, discovery walks included — a model
+cannot be added without saying what it answers, nor a preset grow a widget its models leave empty. Three choices
+look odd without that. The Catalyst numbers its ports from 1, because "Switch drawing (24 ports)" polls
+`ifOperStatus.1` to `.26`, where a real 2960 numbers them from 10001. The UPS is the three-phase model, because
+"UPS (RFC 1628)" charts three output lines. And interfaces, host resources and the system group are shared
+builders (`ifaces.go`, `hostres.go`, `addSystem`), so what a preset reads means the same on every model.
+`TestTheCiscoPresetClaimsTheSimulatedCiscos` holds the identification: the "Cisco (IF-MIB)" preset claims the
+Catalysts and the ISR by their CISCO-PRODUCTS-MIB OIDs, and nothing else. The NAS and the probe report net-snmp's
+Linux sysObjectID because DSM's agent is net-snmp, as most embedded probes' is; their own tables tell them apart.
+The vendor OIDs were read from the MIBs, not remembered.
 
 **A device becomes a target in the renderer** (`addDeviceAsTarget` in `utils/simulator.js`): the target in the
 list, and an override with its identifiers in the most secure version it answers — its FIRST user for v3, since a

--- a/frontend/screenshots/scenes.js
+++ b/frontend/screenshots/scenes.js
@@ -352,14 +352,19 @@ const CATALOGUE = [
           },
         },
         {
-          id: 'c0ffee02', name: 'srv-db-01', model: 'linux-server', address: '127.0.0.3', port: 161,
-          versions: ['v2c'], users: [], engineId: '80001f880302f6e5d4c3b2', engineBoots: 1, running: false, packets: 0,
+          id: 'c0ffee02', name: 'sw-floor-2', model: 'cisco-catalyst-48', address: '127.0.0.3', port: 161,
+          versions: ['v2c'], users: [], engineId: '800000090302f6e5d4c3b2', engineBoots: 7, running: true, packets: 5310,
+          traps: { destinations: [], onStart: false, onAuthFailure: false, schedules: [], suppressed: 0 },
+        },
+        {
+          id: 'c0ffee04', name: 'ups-01', model: 'apc-smart-ups', address: '127.0.0.5', port: 161,
+          versions: ['v1', 'v2c'], users: [], engineId: '8000013e0302b7a6c5d4e3', engineBoots: 1, running: false, packets: 0,
           traps: { destinations: [], onStart: false, onAuthFailure: false, schedules: [], suppressed: 0 },
         },
       ],
     },
     act: ['sel:.status-item.simulator|0'],
-    describe: 'The simulator: two simulated Linux servers, one answering and sending traps, each one click from being a target.',
+    describe: 'The simulator: a Linux server sending traps, a Catalyst switch and a UPS, each one click from being a target.',
   },
   {
     base: 'simulator-traps',
@@ -406,22 +411,35 @@ const CATALOGUE = [
   },
 ];
 
-// The simulator's one model as ListSimulatorModels serves it. A function
+// The simulator's catalogue as ListSimulatorModels serves it. A function
 // declaration, so the catalogue above can call it before this line is reached.
 function simulatorModels() {
-  return [{
-    id: 'linux-server',
-    category: 'server',
-    notifications: [
-      { name: 'coldStart', oid: '.1.3.6.1.6.3.1.1.5.1' },
-      { name: 'warmStart', oid: '.1.3.6.1.6.3.1.1.5.2' },
-      { name: 'linkDown', oid: '.1.3.6.1.6.3.1.1.5.3' },
-      { name: 'linkUp', oid: '.1.3.6.1.6.3.1.1.5.4' },
+  const generic = (own = []) => [
+    { name: 'coldStart', oid: '.1.3.6.1.6.3.1.1.5.1' },
+    { name: 'warmStart', oid: '.1.3.6.1.6.3.1.1.5.2' },
+    ...own,
+    { name: 'authenticationFailure', oid: '.1.3.6.1.6.3.1.1.5.5' },
+  ];
+  const link = [
+    { name: 'linkDown', oid: '.1.3.6.1.6.3.1.1.5.3' },
+    { name: 'linkUp', oid: '.1.3.6.1.6.3.1.1.5.4' },
+  ];
+  const config = { name: 'ciscoConfigManEvent', oid: '.1.3.6.1.4.1.9.9.43.2.0.1' };
+  return [
+    { id: 'linux-server', category: 'server', notifications: generic([...link,
       { name: 'nsNotifyShutdown', oid: '.1.3.6.1.4.1.8072.4.0.2' },
-      { name: 'nsNotifyRestart', oid: '.1.3.6.1.4.1.8072.4.0.3' },
-      { name: 'authenticationFailure', oid: '.1.3.6.1.6.3.1.1.5.5' },
-    ],
-  }];
+      { name: 'nsNotifyRestart', oid: '.1.3.6.1.4.1.8072.4.0.3' }]) },
+    { id: 'windows-server', category: 'server', notifications: generic(link) },
+    { id: 'cisco-catalyst-24', category: 'network', notifications: generic([...link, config]) },
+    { id: 'cisco-catalyst-48', category: 'network', notifications: generic([...link, config]) },
+    { id: 'cisco-isr-4331', category: 'network', notifications: generic([...link,
+      { name: 'bgpEstablishedNotification', oid: '.1.3.6.1.2.1.15.0.1' },
+      { name: 'bgpBackwardTransNotification', oid: '.1.3.6.1.2.1.15.0.2' }, config]) },
+    { id: 'synology-nas', category: 'storage', notifications: generic(link) },
+    { id: 'apc-smart-ups', category: 'power', notifications: generic([{ name: 'upsTrapOnBattery', oid: '.1.3.6.1.2.1.33.2.1' }]) },
+    { id: 'hp-laserjet', category: 'printing', notifications: generic([{ name: 'printerV2Alert', oid: '.1.3.6.1.2.1.43.18.2.0.1' }]) },
+    { id: 'environment-probe', category: 'environment', notifications: generic() },
+  ];
 }
 
 export function buildScenes(seeds) {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -9,6 +9,7 @@
   import {
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
+    modelGroups,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import Icon from './Icon.svelte';
@@ -65,12 +66,29 @@
     close();
   }
 
+  /** The name a new device was given, which follows its model until someone types another. */
+  let defaultName = '';
+
   async function newDevice(models, devices) {
     const model = models[0]?.id || 'linux-server';
     const suggestion = await simulatorStore.suggestAddress().catch(() => null);
     editing = blankDevice(model, suggestion);
-    editing.name = `${$_(`simulator.model.${model}.name`)} ${devices.length + 1}`;
+    defaultName = `${$_(`simulator.model.${model}.name`)} ${devices.length + 1}`;
+    editing.name = defaultName;
     saveError = '';
+  }
+
+  // A schedule naming a notification the new model does not send falls back
+  // to one at random, rather than being refused at save.
+  function onModel() {
+    if (editing.name === defaultName) {
+      defaultName = `${$_(`simulator.model.${editing.model}.name`)} ${$simulatorStore.devices.length + 1}`;
+      editing.name = defaultName;
+    }
+    const names = notificationsOf($simulatorStore.models, editing.model).map((n) => n.name);
+    editing.traps.schedules = editing.traps.schedules.map((s) =>
+      (s.notification && !names.includes(s.notification) ? { ...s, notification: '' } : s));
+    editing = editing;
   }
 
   async function edit(device) {
@@ -237,9 +255,13 @@
           </div>
           <div class="form-group">
             <label for="sim-model">{$_('simulator.field.model')}</label>
-            <select id="sim-model" bind:value={editing.model} disabled={!!editing.id}>
-              {#each $simulatorStore.models as m (m.id)}
-                <option value={m.id}>{$_(`simulator.model.${m.id}.name`)}</option>
+            <select id="sim-model" bind:value={editing.model} disabled={!!editing.id} on:change={onModel}>
+              {#each modelGroups($simulatorStore.models) as group (group.category)}
+                <optgroup label={$_(`simulator.category.${group.category}`)}>
+                  {#each group.models as m (m.id)}
+                    <option value={m.id}>{$_(`simulator.model.${m.id}.name`)}</option>
+                  {/each}
+                </optgroup>
               {/each}
             </select>
           </div>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1325,7 +1325,47 @@
       "engineId": "5 bis 32 Oktette, hexadezimal.",
       "every": "Von 1 bis 86400 Sekunden."
     },
+    "category": {
+      "server": "Server",
+      "network": "Netzwerk",
+      "storage": "Speicher",
+      "power": "Stromversorgung",
+      "printing": "Druck",
+      "environment": "Umgebung"
+    },
     "model": {
+      "windows-server": {
+        "name": "Windows-Server",
+        "description": "Ein Windows-Server-2022-Host mit seinem SNMP-Dienst: System, zwei Netzwerkadapter, Host-Ressourcen nach Laufwerksbuchstaben. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
+      },
+      "cisco-catalyst-24": {
+        "name": "Cisco Catalyst 2960, 24 Ports",
+        "description": "Ein Access-Switch: 24 Fast-Ethernet-Ports, zwei Gigabit-Uplinks und VLAN 1, mit CPU-Last und Konfigurationsänderungen von Cisco. Als Cisco erkannt, daher steht das Preset „Cisco (IF-MIB)“ an erster Stelle; passt auch zu „Switch ports“ und „Switch drawing (24 ports)“."
+      },
+      "cisco-catalyst-48": {
+        "name": "Cisco Catalyst 2960, 48 Ports",
+        "description": "Derselbe Access-Switch mit 48 Ports. Als Cisco erkannt, daher steht das Preset „Cisco (IF-MIB)“ an erster Stelle; passt auch zu „Switch ports“."
+      },
+      "cisco-isr-4331": {
+        "name": "Cisco-Router ISR 4331",
+        "description": "Ein Filialrouter: WAN-, LAN- und Management-Ports, zwei eBGP-Sitzungen — eine aufgebaut, eine nicht — und die CPU-Last von Cisco. Sendet die BGP-Benachrichtigungen und Konfigurationsänderungen."
+      },
+      "synology-nas": {
+        "name": "Synology-NAS",
+        "description": "Eine DS920+ mit DSM: Synologys System-, Festplatten- und RAID-Tabellen neben Schnittstellen und Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
+      },
+      "apc-smart-ups": {
+        "name": "APC Smart-UPS, dreiphasig",
+        "description": "Eine 10-kVA-USV an ihrer Netzwerkkarte, die die Standard-UPS-MIB beantwortet: Batterie, Eingang und Ausgang je Phase. Passt zum Preset „UPS (RFC 1628)“ und sendet upsTrapOnBattery."
+      },
+      "hp-laserjet": {
+        "name": "HP-LaserJet-Drucker",
+        "description": "Ein Netzwerk-Laserdrucker, der die Printer-MIB beantwortet: Seitenzähler, eine fast leere schwarze Kartusche und ihr Alarm. Sendet printerV2Alert."
+      },
+      "environment-probe": {
+        "name": "Umgebungssensor",
+        "description": "Ein Temperatur- und Feuchtesensor, der die Standard-ENTITY-SENSOR-MIB beantwortet, wie im Kaltgang eines Serverraums."
+      },
       "linux-server": {
         "name": "Linux-Server",
         "description": "Ein Ubuntu-Host mit net-snmp: System, drei Schnittstellen, Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1325,7 +1325,47 @@
       "engineId": "5 to 32 octets, in hex.",
       "every": "From 1 to 86400 seconds."
     },
+    "category": {
+      "server": "Servers",
+      "network": "Network",
+      "storage": "Storage",
+      "power": "Power",
+      "printing": "Printing",
+      "environment": "Environment"
+    },
     "model": {
+      "windows-server": {
+        "name": "Windows server",
+        "description": "A Windows Server 2022 host with its SNMP service: system, two network adapters, host resources by drive letter. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
+      },
+      "cisco-catalyst-24": {
+        "name": "Cisco Catalyst 2960, 24 ports",
+        "description": "An access switch: 24 Fast Ethernet ports, two gigabit uplinks and VLAN 1, with Cisco's CPU load and configuration changes. Recognised as a Cisco, so the “Cisco (IF-MIB)” preset comes first; also fits “Switch ports” and “Switch drawing (24 ports)”."
+      },
+      "cisco-catalyst-48": {
+        "name": "Cisco Catalyst 2960, 48 ports",
+        "description": "The same access switch with 48 ports. Recognised as a Cisco, so the “Cisco (IF-MIB)” preset comes first; also fits “Switch ports”."
+      },
+      "cisco-isr-4331": {
+        "name": "Cisco ISR 4331 router",
+        "description": "A branch router: WAN, LAN and management ports, two eBGP sessions — one established, one not — and Cisco's CPU load. Sends the BGP notifications and configuration changes."
+      },
+      "synology-nas": {
+        "name": "Synology NAS",
+        "description": "A DS920+ on DSM: Synology's system, disk and RAID tables beside interfaces and host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
+      },
+      "apc-smart-ups": {
+        "name": "APC Smart-UPS, three-phase",
+        "description": "A 10 kVA UPS on its network card, answering the standard UPS-MIB: battery, input and output per phase. Fits the “UPS (RFC 1628)” preset and sends upsTrapOnBattery."
+      },
+      "hp-laserjet": {
+        "name": "HP LaserJet printer",
+        "description": "A network laser printer answering the Printer MIB: page count, a black cartridge running low and its alert. Sends printerV2Alert."
+      },
+      "environment-probe": {
+        "name": "Environment probe",
+        "description": "A temperature and humidity probe answering the standard ENTITY-SENSOR-MIB, as a server room's cold aisle reads."
+      },
       "linux-server": {
         "name": "Linux server",
         "description": "An Ubuntu host running net-snmp: system, three interfaces, host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1325,7 +1325,47 @@
       "engineId": "De 5 a 32 octetos, en hexadecimal.",
       "every": "De 1 a 86400 segundos."
     },
+    "category": {
+      "server": "Servidores",
+      "network": "Red",
+      "storage": "Almacenamiento",
+      "power": "Energía",
+      "printing": "Impresión",
+      "environment": "Entorno"
+    },
     "model": {
+      "windows-server": {
+        "name": "Servidor Windows",
+        "description": "Un host Windows Server 2022 con su servicio SNMP: sistema, dos adaptadores de red, recursos del host por letra de unidad. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
+      },
+      "cisco-catalyst-24": {
+        "name": "Cisco Catalyst 2960, 24 puertos",
+        "description": "Un switch de acceso: 24 puertos Fast Ethernet, dos enlaces ascendentes gigabit y la VLAN 1, con la carga de CPU y los cambios de configuración de Cisco. Se reconoce como Cisco, así que el preset «Cisco (IF-MIB)» aparece primero; también encaja con «Switch ports» y «Switch drawing (24 ports)»."
+      },
+      "cisco-catalyst-48": {
+        "name": "Cisco Catalyst 2960, 48 puertos",
+        "description": "El mismo switch de acceso con 48 puertos. Se reconoce como Cisco, así que el preset «Cisco (IF-MIB)» aparece primero; también encaja con «Switch ports»."
+      },
+      "cisco-isr-4331": {
+        "name": "Router Cisco ISR 4331",
+        "description": "Un router de sucursal: puertos WAN, LAN y de gestión, dos sesiones eBGP —una establecida y otra no— y la carga de CPU de Cisco. Envía las notificaciones BGP y los cambios de configuración."
+      },
+      "synology-nas": {
+        "name": "NAS Synology",
+        "description": "Un DS920+ con DSM: las tablas de sistema, discos y RAID de Synology junto a las interfaces y los recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
+      },
+      "apc-smart-ups": {
+        "name": "SAI APC Smart-UPS, trifásico",
+        "description": "Un SAI de 10 kVA en su tarjeta de red, que responde a la UPS-MIB estándar: batería, entrada y salida por fase. Encaja con el preset «UPS (RFC 1628)» y envía upsTrapOnBattery."
+      },
+      "hp-laserjet": {
+        "name": "Impresora HP LaserJet",
+        "description": "Una impresora láser de red que responde a la Printer MIB: contador de páginas, un cartucho negro casi vacío y su alerta. Envía printerV2Alert."
+      },
+      "environment-probe": {
+        "name": "Sonda ambiental",
+        "description": "Una sonda de temperatura y humedad que responde a la ENTITY-SENSOR-MIB estándar, como en el pasillo frío de una sala de servidores."
+      },
       "linux-server": {
         "name": "Servidor Linux",
         "description": "Un host Ubuntu con net-snmp: sistema, tres interfaces, recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1325,7 +1325,47 @@
       "engineId": "5 à 32 octets, en hexadécimal.",
       "every": "De 1 à 86400 secondes."
     },
+    "category": {
+      "server": "Serveurs",
+      "network": "Réseau",
+      "storage": "Stockage",
+      "power": "Énergie",
+      "printing": "Impression",
+      "environment": "Environnement"
+    },
     "model": {
+      "windows-server": {
+        "name": "Serveur Windows",
+        "description": "Un hôte Windows Server 2022 avec son service SNMP : système, deux cartes réseau, ressources de l’hôte par lettre de lecteur. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
+      },
+      "cisco-catalyst-24": {
+        "name": "Cisco Catalyst 2960, 24 ports",
+        "description": "Un commutateur d’accès : 24 ports Fast Ethernet, deux liens montants gigabit et le VLAN 1, avec la charge CPU et les changements de configuration de Cisco. Reconnu comme un Cisco : le preset « Cisco (IF-MIB) » vient en premier ; convient aussi à « Switch ports » et « Switch drawing (24 ports) »."
+      },
+      "cisco-catalyst-48": {
+        "name": "Cisco Catalyst 2960, 48 ports",
+        "description": "Le même commutateur d’accès, avec 48 ports. Reconnu comme un Cisco : le preset « Cisco (IF-MIB) » vient en premier ; convient aussi à « Switch ports »."
+      },
+      "cisco-isr-4331": {
+        "name": "Routeur Cisco ISR 4331",
+        "description": "Un routeur d’agence : ports WAN, LAN et d’administration, deux sessions eBGP — l’une établie, l’autre non — et la charge CPU de Cisco. Envoie les notifications BGP et les changements de configuration."
+      },
+      "synology-nas": {
+        "name": "NAS Synology",
+        "description": "Un DS920+ sous DSM : les tables système, disques et RAID de Synology, à côté des interfaces et des ressources de l’hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
+      },
+      "apc-smart-ups": {
+        "name": "Onduleur APC Smart-UPS, triphasé",
+        "description": "Un onduleur de 10 kVA sur sa carte réseau, qui répond à l’UPS-MIB standard : batterie, entrée et sortie par phase. Convient au preset « UPS (RFC 1628) » et envoie upsTrapOnBattery."
+      },
+      "hp-laserjet": {
+        "name": "Imprimante HP LaserJet",
+        "description": "Une imprimante laser réseau qui répond à la Printer MIB : compteur de pages, une cartouche noire presque vide et son alerte. Envoie printerV2Alert."
+      },
+      "environment-probe": {
+        "name": "Sonde d’environnement",
+        "description": "Une sonde de température et d’humidité qui répond à l’ENTITY-SENSOR-MIB standard, comme dans l’allée froide d’une salle serveurs."
+      },
       "linux-server": {
         "name": "Serveur Linux",
         "description": "Un hôte Ubuntu avec net-snmp : système, trois interfaces, ressources de l'hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1325,7 +1325,47 @@
       "engineId": "5 到 32 个八位组，十六进制。",
       "every": "1 到 86400 秒。"
     },
+    "category": {
+      "server": "服务器",
+      "network": "网络",
+      "storage": "存储",
+      "power": "电源",
+      "printing": "打印",
+      "environment": "环境"
+    },
     "model": {
+      "windows-server": {
+        "name": "Windows 服务器",
+        "description": "带 SNMP 服务的 Windows Server 2022 主机：系统、两块网卡、按盘符列出的主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
+      },
+      "cisco-catalyst-24": {
+        "name": "Cisco Catalyst 2960，24 端口",
+        "description": "一台接入交换机：24 个快速以太网端口、两个千兆上联口和 VLAN 1，带有 Cisco 的 CPU 负载和配置变更。被识别为 Cisco 设备，因此“Cisco (IF-MIB)”预设排在最前；也适用于“Switch ports”和“Switch drawing (24 ports)”。"
+      },
+      "cisco-catalyst-48": {
+        "name": "Cisco Catalyst 2960，48 端口",
+        "description": "同一款接入交换机，48 个端口。被识别为 Cisco 设备，因此“Cisco (IF-MIB)”预设排在最前；也适用于“Switch ports”。"
+      },
+      "cisco-isr-4331": {
+        "name": "Cisco ISR 4331 路由器",
+        "description": "一台分支路由器：WAN、LAN 和管理端口，两个 eBGP 会话（一个已建立，一个未建立），以及 Cisco 的 CPU 负载。发送 BGP 通知和配置变更。"
+      },
+      "synology-nas": {
+        "name": "Synology NAS",
+        "description": "运行 DSM 的 DS920+：Synology 的系统、磁盘和 RAID 表，外加接口和主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
+      },
+      "apc-smart-ups": {
+        "name": "APC Smart-UPS 三相 UPS",
+        "description": "一台通过网卡管理的 10 kVA UPS，响应标准 UPS-MIB：电池、各相输入和输出。适用于“UPS (RFC 1628)”预设，并发送 upsTrapOnBattery。"
+      },
+      "hp-laserjet": {
+        "name": "HP LaserJet 打印机",
+        "description": "一台响应 Printer MIB 的网络激光打印机：页数计数、即将耗尽的黑色硒鼓及其告警。发送 printerV2Alert。"
+      },
+      "environment-probe": {
+        "name": "环境探头",
+        "description": "一个响应标准 ENTITY-SENSOR-MIB 的温湿度探头，读数如同服务器机房的冷通道。"
+      },
       "linux-server": {
         "name": "Linux 服务器",
         "description": "运行 net-snmp 的 Ubuntu 主机：系统、三个接口、主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -258,6 +258,23 @@ export function devicePayload(d) {
   };
 }
 
+/**
+ * The models grouped by category, in the order Go lists them: a category comes
+ * where its first model does.
+ */
+export function modelGroups(models) {
+  const groups = [];
+  for (const m of models || []) {
+    let group = groups.find((g) => g.category === m.category);
+    if (!group) {
+      group = { category: m.category, models: [] };
+      groups.push(group);
+    }
+    group.models.push(m);
+  }
+  return groups;
+}
+
 /** What a device of the model can send, as Go lists it. */
 export function notificationsOf(models, modelId) {
   return (models || []).find((m) => m.id === modelId)?.notifications || [];

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -56,6 +56,7 @@ const {
   devicePayload,
   deliveryReport,
   trapActivity,
+  modelGroups,
   preferredVersion,
   targetOf,
   addDeviceAsTarget,
@@ -271,11 +272,23 @@ check('and over the default, with no override at all', getEffectiveSettings(sett
 const en = JSON.parse(readFileSync(new URL('../src/i18n/en.json', import.meta.url), 'utf8'));
 const goDir = new URL('../../pkg/simulator/', import.meta.url);
 const ids = new Set();
+const categories = new Set();
 for (const file of readdirSync(goDir)) {
   if (!file.endsWith('.go') || file.endsWith('_test.go')) continue;
-  for (const m of readFileSync(new URL(file, goDir), 'utf8').matchAll(/ModelInfo\{ID:\s*"([^"]+)"/g)) ids.add(m[1]);
+  for (const m of readFileSync(new URL(file, goDir), 'utf8').matchAll(/ModelInfo\{ID:\s*"([^"]+)",\s*Category:\s*"([^"]+)"/g)) {
+    ids.add(m[1]);
+    categories.add(m[2]);
+  }
 }
-check('the models were found in pkg/simulator', ids.size >= 1, [...ids].join(', '));
+check('the models were found in pkg/simulator', ids.size >= 9, [...ids].join(', '));
+for (const category of categories) {
+  check(`en.json names the category ${category}`, Boolean(en.simulator?.category?.[category]));
+}
+const groups = modelGroups([
+  { id: 'a', category: 'server' }, { id: 'b', category: 'network' }, { id: 'c', category: 'server' },
+]);
+check("the models are grouped by category, in the order of each category's first model",
+  groups.map((g) => `${g.category}:${g.models.map((m) => m.id).join('+')}`).join(' ') === 'server:a+c network:b');
 for (const key of ['hostRequired', 'trapUser', 'trapNeedsV3', 'engineId', 'every']) {
   check(`en.json says simulator.problem.${key}`, Boolean(en.simulator?.problem?.[key]));
 }

--- a/pkg/simulator/cisco.go
+++ b/pkg/simulator/cisco.go
@@ -1,0 +1,245 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// The Catalyst 2960, Cisco's access switch of the last fifteen years: Fast
+// Ethernet ports, two gigabit uplinks and VLAN 1 — what the "Switch ports"
+// preset draws and, with 24 ports, "Switch drawing (24 ports)". Its
+// sysObjectID is Cisco's, so the "Cisco (IF-MIB)" preset is offered first for
+// it, as it is for a real one.
+//
+// The ports are numbered from 1, as the drawing preset polls them, where a
+// real 2960 numbers them from 10001; the names are a 2960's.
+var (
+	catalyst24 = model{
+		ModelInfo:  ModelInfo{ID: "cisco-catalyst-24", Category: "network"},
+		enterprise: 9, // Cisco
+		build: func(id Identity) []Object {
+			return buildCatalyst(id, 24, ".1.3.6.1.4.1.9.1.716") // catalyst296024TT
+		},
+		notifications: catalystNotifications(24),
+	}
+	catalyst48 = model{
+		ModelInfo:  ModelInfo{ID: "cisco-catalyst-48", Category: "network"},
+		enterprise: 9,
+		build: func(id Identity) []Object {
+			return buildCatalyst(id, 48, ".1.3.6.1.4.1.9.1.717") // catalyst296048TT
+		},
+		notifications: catalystNotifications(48),
+	}
+)
+
+const catalystDescr = "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), Version 15.0(2)SE11, RELEASE SOFTWARE (fc3)\r\n" +
+	"Technical Support: http://www.cisco.com/techsupport\r\n" +
+	"Copyright (c) 1986-2017 by Cisco Systems, Inc.\r\n" +
+	"Compiled Sat 19-Aug-17 09:34 by prod_rel_team"
+
+func buildCatalyst(id Identity, ports int, sysObjectID string) []Object {
+	var o objects
+	addSystem(&o, id, catalystDescr, sysObjectID, "noc@example.com", "Wiring closet, floor 2", 2) // layer 2
+	ifs := make([]iface, 0, ports+3)
+	for p := 1; p <= ports; p++ {
+		f := iface{index: p, descr: fmt.Sprintf("FastEthernet0/%d", p), name: fmt.Sprintf("Fa0/%d", p),
+			ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000, mac: deviceMAC(id.Seed, uint64(p))}
+		// Most of an access switch's ports are in use and some are not, which is
+		// also why no bundled preset watches ifOperStatus. The first is always up:
+		// it is where the presets look for traffic.
+		switch r := unit(id.Seed + 7000 + uint64(p)); {
+		case p == 1:
+			f.up, f.alias, f.inRate, f.outRate = true, "srv-01", 900_000, 2_400_000
+		case r < 0.06:
+			f.adminDown = true
+		case r < 0.64:
+			f.up, f.alias = true, fmt.Sprintf("desk 2-%02d", p)
+			f.inRate = 4_000 + 120_000*unit(id.Seed+7100+uint64(p))
+			f.outRate = 8_000 + 300_000*unit(id.Seed+7200+uint64(p))
+			f.errorRate = 0.0005
+		}
+		ifs = append(ifs, f)
+	}
+	ifs = append(ifs,
+		iface{index: ports + 1, descr: "GigabitEthernet0/1", name: "Gi0/1", alias: "uplink core-sw-01",
+			ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(ports+1)),
+			up: true, inRate: 6_500_000, outRate: 2_800_000, errorRate: 0.001},
+		iface{index: ports + 2, descr: "GigabitEthernet0/2", name: "Gi0/2", alias: "spare uplink",
+			ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(ports+2))},
+		// VLAN 1 carries the switch's own address, and its base MAC — the one
+		// its engine ID carries too.
+		iface{index: ports + 3, descr: "Vlan1", name: "Vl1", ifType: ifTypePropVirtual, mtu: 1500,
+			speed: 1_000_000_000, mac: deviceMAC(id.Seed, 0), up: true, inRate: 2_000, outRate: 1_500},
+	)
+	addInterfaces(&o, id.Seed, ifs)
+	addCiscoCPU(&o, id.Seed, 3, 24)
+	addCiscoConfigHistory(&o)
+	return o
+}
+
+// catalystNotifications are a Catalyst's: linkDown about its spare uplink,
+// which is down, linkUp about the one in use, and a configuration change.
+func catalystNotifications(ports int) []Notification {
+	return []Notification{linkNotification(false, ports+2), linkNotification(true, ports+1), ciscoConfigManEvent}
+}
+
+// isr4331 is a branch router: a WAN port, a LAN port, a backup WAN port that is
+// down, the management port, and two eBGP sessions, one established and one
+// not.
+var isr4331 = model{
+	ModelInfo:  ModelInfo{ID: "cisco-isr-4331", Category: "network"},
+	enterprise: 9,
+	build:      buildISR4331,
+	notifications: []Notification{
+		linkNotification(false, 3), // the backup WAN, down
+		linkNotification(true, 1),  // the WAN
+		bgpNotification("bgpEstablishedNotification", 1, bgpPeers[0].remote),
+		bgpNotification("bgpBackwardTransNotification", 2, bgpPeers[1].remote),
+		ciscoConfigManEvent,
+	},
+}
+
+const isrDescr = "Cisco IOS XE Software, Version 17.09.04a\r\n" +
+	"Cisco IOS Software [Cupertino], ISR Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 17.9.4a, RELEASE SOFTWARE (fc3)\r\n" +
+	"Technical Support: http://www.cisco.com/techsupport\r\n" +
+	"Copyright (c) 1986-2023 by Cisco Systems, Inc.\r\n" +
+	"Compiled Fri 20-Oct-23 10:44 by mcpre"
+
+func buildISR4331(id Identity) []Object {
+	var o objects
+	addSystem(&o, id, isrDescr, ".1.3.6.1.4.1.9.1.2068", // ciscoISR4331
+		"noc@example.com", "Branch office, network room", 78)
+	gig := func(index int, descr, name, alias string) iface {
+		return iface{index: index, descr: descr, name: name, alias: alias, ifType: ifTypeEthernet, mtu: 1500,
+			speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(index))}
+	}
+	wan := gig(1, "GigabitEthernet0/0/0", "Gi0/0/0", "WAN transit 203.0.113.0/30")
+	wan.up, wan.inRate, wan.outRate, wan.errorRate = true, 3_200_000, 900_000, 0.002
+	lan := gig(2, "GigabitEthernet0/0/1", "Gi0/0/1", "LAN")
+	lan.up, lan.inRate, lan.outRate = true, 850_000, 3_000_000
+	mgmt := gig(4, "GigabitEthernet0", "Gi0", "management")
+	mgmt.up, mgmt.inRate, mgmt.outRate = true, 3_000, 5_000
+	addInterfaces(&o, id.Seed, []iface{
+		wan,
+		lan,
+		gig(3, "GigabitEthernet0/0/2", "Gi0/0/2", "backup WAN"),
+		mgmt,
+		{index: 5, descr: "Null0", name: "Nu0", ifType: ifTypeOther, mtu: 1500, speed: 10_000_000_000, up: true},
+		{index: 6, descr: "Loopback0", name: "Lo0", ifType: ifTypeSoftwareLoopback, mtu: 1514,
+			speed: 8_000_000_000, up: true},
+	})
+	addCiscoCPU(&o, id.Seed, 2, 14)
+	addBGP(&o, id.Seed)
+	addCiscoConfigHistory(&o)
+	return o
+}
+
+// addCiscoCPU adds CISCO-PROCESS-MIB's cpmCPUTotalTable for one processor: its
+// load over five seconds, a minute and five minutes, the longer averages
+// steadier than the shorter.
+func addCiscoCPU(o *objects, seed uint64, lo, hi float64) {
+	col := func(n int) string { return fmt.Sprintf("1.3.6.1.4.1.9.9.109.1.1.1.1.%d.1", n) }
+	span := hi - lo
+	o.add(col(6), gosnmp.Gauge32, Gauge(lo, hi, Swing{Period: 2 * time.Minute, Seed: seed + 9000}))
+	o.add(col(7), gosnmp.Gauge32, Gauge(lo+span*0.2, hi-span*0.3, Swing{Period: 10 * time.Minute, Seed: seed + 9001}))
+	o.add(col(8), gosnmp.Gauge32, Gauge(lo+span*0.3, hi-span*0.5, Swing{Period: 30 * time.Minute, Seed: seed + 9002}))
+}
+
+// ciscoConfigManEvent is CISCO-CONFIG-MAN-MIB's notice of a configuration
+// change, carrying the history row that records it.
+var ciscoConfigManEvent = Notification{
+	Name: "ciscoConfigManEvent",
+	OID:  ".1.3.6.1.4.1.9.9.43.2.0.1",
+	// ccmHistoryEventCommandSource, …ConfigSource, …ConfigDestination
+	Objects: []string{
+		".1.3.6.1.4.1.9.9.43.1.1.6.1.3.1",
+		".1.3.6.1.4.1.9.9.43.1.1.6.1.4.1",
+		".1.3.6.1.4.1.9.9.43.1.1.6.1.5.1",
+	},
+}
+
+// addCiscoConfigHistory adds the one history row ciscoConfigManEvent carries: a
+// change typed at the command line into the running configuration.
+func addCiscoConfigHistory(o *objects) {
+	col := func(n int) string { return fmt.Sprintf("1.3.6.1.4.1.9.9.43.1.1.6.1.%d.1", n) }
+	o.add(col(3), gosnmp.Integer, Const(1)) // command source: commandLine
+	o.add(col(4), gosnmp.Integer, Const(2)) // configuration source: commandSource
+	o.add(col(5), gosnmp.Integer, Const(3)) // configuration destination: running
+}
+
+// The router's two eBGP sessions: to its transit provider, established since the
+// router started, and to a second provider that is not — which is what
+// bgpBackwardTransNotification is about.
+var bgpPeers = []struct {
+	remote, local, identifier string
+	as                        int
+	established               bool
+}{
+	{remote: "203.0.113.1", local: "203.0.113.2", identifier: "203.0.113.1", as: 64500, established: true},
+	{remote: "198.51.100.9", local: "0.0.0.0", identifier: "0.0.0.0", as: 64501},
+}
+
+// bgpNotification is one of BGP4-MIB's two (RFC 4273) about a peer: its
+// address, its last error and its state.
+func bgpNotification(name string, n int, peer string) Notification {
+	col := func(c int) string { return fmt.Sprintf(".1.3.6.1.2.1.15.3.1.%d.%s", c, peer) }
+	return Notification{Name: name, OID: fmt.Sprintf(".1.3.6.1.2.1.15.0.%d", n), Objects: []string{col(7), col(14), col(2)}}
+}
+
+// addBGP adds BGP4-MIB's scalars and its peer table, indexed by the peer's
+// address.
+func addBGP(o *objects, seed uint64) {
+	o.add("1.3.6.1.2.1.15.1.0", gosnmp.OctetString, Const([]byte{0x10})) // bgpVersion: 4
+	o.add("1.3.6.1.2.1.15.2.0", gosnmp.Integer, Const(65010))            // bgpLocalAs
+	o.add("1.3.6.1.2.1.15.4.0", gosnmp.IPAddress, Const("10.255.0.1"))   // bgpIdentifier
+	for i, p := range bgpPeers {
+		col := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.15.3.1.%d.%s", c, p.remote) }
+		n := uint64(i) * 8
+		swing := Swing{Depth: 0.3, Period: 20 * time.Minute, Seed: seed + 60000 + n}
+		start := func(k uint64) uint64 { return uint64(1e4 + 5e4*unit(seed+60100+n+k)) }
+		o.add(col(1), gosnmp.IPAddress, Const(p.identifier))
+		o.add(col(3), gosnmp.Integer, Const(2)) // admin status: start
+		o.add(col(5), gosnmp.IPAddress, Const(p.local))
+		o.add(col(7), gosnmp.IPAddress, Const(p.remote))
+		o.add(col(9), gosnmp.Integer, Const(p.as))
+		// In the established state, or out of it, since the router started.
+		o.add(col(16), gosnmp.Gauge32, SecondsUp())
+		o.add(col(17), gosnmp.Integer, Const(120)) // connect retry interval
+		o.add(col(20), gosnmp.Integer, Const(180)) // hold time configured
+		o.add(col(21), gosnmp.Integer, Const(60))  // keepalive configured
+		o.add(col(22), gosnmp.Integer, Const(15))  // minimum AS origination interval
+		o.add(col(23), gosnmp.Integer, Const(30))  // minimum route advertisement interval
+		if p.established {
+			o.add(col(2), gosnmp.Integer, Const(6)) // established
+			o.add(col(4), gosnmp.Integer, Const(4))
+			o.add(col(6), gosnmp.Integer, Const(36011))
+			o.add(col(8), gosnmp.Integer, Const(179))
+			o.add(col(10), gosnmp.Counter32, Counter(0.02, start(0), swing))
+			o.add(col(11), gosnmp.Counter32, Counter(0.005, start(1), swing))
+			// A keepalive a minute, and the updates.
+			o.add(col(12), gosnmp.Counter32, Counter(1.0/60+0.02, start(2), swing))
+			o.add(col(13), gosnmp.Counter32, Counter(1.0/60+0.005, start(3), swing))
+			o.add(col(14), gosnmp.OctetString, Const([]byte{0, 0}))
+			o.add(col(15), gosnmp.Counter32, Const(uint32(1)))
+			o.add(col(18), gosnmp.Integer, Const(180))
+			o.add(col(19), gosnmp.Integer, Const(60))
+			o.add(col(24), gosnmp.Gauge32, Gauge(5, 240, swing))
+		} else {
+			o.add(col(2), gosnmp.Integer, Const(3)) // active: trying, and not getting through
+			o.add(col(4), gosnmp.Integer, Const(0))
+			o.add(col(6), gosnmp.Integer, Const(0))
+			o.add(col(8), gosnmp.Integer, Const(0))
+			o.add(col(10), gosnmp.Counter32, Const(uint32(1482)))
+			o.add(col(11), gosnmp.Counter32, Const(uint32(37)))
+			o.add(col(12), gosnmp.Counter32, Const(uint32(9163)))
+			o.add(col(13), gosnmp.Counter32, Const(uint32(7702)))
+			o.add(col(14), gosnmp.OctetString, Const([]byte{4, 0})) // hold timer expired
+			o.add(col(15), gosnmp.Counter32, Const(uint32(3)))
+			o.add(col(18), gosnmp.Integer, Const(0))
+			o.add(col(19), gosnmp.Integer, Const(0))
+			o.add(col(24), gosnmp.Gauge32, Const(uint32(0)))
+		}
+	}
+}

--- a/pkg/simulator/hostres.go
+++ b/pkg/simulator/hostres.go
@@ -1,0 +1,65 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// The hrStorageTypes of HOST-RESOURCES-TYPES the models use.
+const (
+	hrStorageRam           = ".1.3.6.1.2.1.25.2.1.2"
+	hrStorageVirtualMemory = ".1.3.6.1.2.1.25.2.1.3"
+	hrStorageFixedDisk     = ".1.3.6.1.2.1.25.2.1.4"
+)
+
+// hostResources is what HOST-RESOURCES-MIB (RFC 2790) says of a machine.
+type hostResources struct {
+	memoryKiB int
+	// users and processes are the ranges hrSystemNumUsers and
+	// hrSystemProcesses swing in.
+	users, processes [2]float64
+	storage          []storageArea
+	// processors are the hrDeviceIndex of each processor, which an agent
+	// chooses: net-snmp numbers them from 196608, Windows after its disks.
+	processors   []int
+	cpuLo, cpuHi float64
+}
+
+type storageArea struct {
+	index       int
+	kind, descr string
+	unit, size  int     // the allocation unit in bytes, and the size in units
+	lo, hi      float64 // the share of the size in use
+	period      time.Duration
+}
+
+// addHostResources adds the system scalars, the storage table and the
+// processor table: everything the "Server (HOST-RESOURCES-MIB)" preset polls.
+func addHostResources(o *objects, seed uint64, hr hostResources) {
+	swing := func(n uint64, period time.Duration) Swing {
+		return Swing{Period: period, Seed: seed + 1<<16 + n}
+	}
+	o.add("1.3.6.1.2.1.25.1.1.0", gosnmp.TimeTicks, Uptime())
+	o.add("1.3.6.1.2.1.25.1.5.0", gosnmp.Gauge32, Gauge(hr.users[0], hr.users[1], swing(0, 20*time.Minute)))
+	o.add("1.3.6.1.2.1.25.1.6.0", gosnmp.Gauge32, Gauge(hr.processes[0], hr.processes[1], swing(1, 7*time.Minute)))
+	o.add("1.3.6.1.2.1.25.2.2.0", gosnmp.Integer, Const(hr.memoryKiB))
+
+	for i, st := range hr.storage {
+		col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.25.2.3.1.%d.%d", n, st.index) }
+		o.add(col(1), gosnmp.Integer, Const(st.index))
+		o.add(col(2), gosnmp.ObjectIdentifier, Const(st.kind))
+		o.add(col(3), gosnmp.OctetString, Const(st.descr))
+		o.add(col(4), gosnmp.Integer, Const(st.unit))
+		o.add(col(5), gosnmp.Integer, Const(st.size))
+		o.add(col(6), gosnmp.Integer, IntegerGauge(st.lo*float64(st.size), st.hi*float64(st.size),
+			swing(100+uint64(i), st.period)))
+	}
+
+	for i, index := range hr.processors {
+		o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.3.1.1.%d", index), gosnmp.ObjectIdentifier, Const(".0.0"))
+		o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.3.1.2.%d", index), gosnmp.Integer,
+			IntegerGauge(hr.cpuLo, hr.cpuHi, swing(200+uint64(i), 90*time.Second)))
+	}
+}

--- a/pkg/simulator/ifaces.go
+++ b/pkg/simulator/ifaces.go
@@ -1,0 +1,101 @@
+package simulator
+
+import (
+	"fmt"
+	"math"
+	"net"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// The IANAifType values the models use.
+const (
+	ifTypeOther            = 1
+	ifTypeEthernet         = 6
+	ifTypeSoftwareLoopback = 24
+	ifTypePropVirtual      = 53
+)
+
+// iface is one interface of a model: what IF-MIB says of it, and how busy it is.
+type iface struct {
+	index int
+	// descr is ifDescr and name ifName: the long and the short form a Cisco
+	// gives, "FastEthernet0/1" and "Fa0/1". A name not given is the descr.
+	descr, name, alias string
+	ifType, mtu        int
+	speed              uint64 // bits per second
+	mac                net.HardwareAddr
+	adminDown, up      bool
+	inRate, outRate    float64 // octets per second, while up
+	errorRate          float64 // input errors per second, while up
+}
+
+// addInterfaces adds IF-MIB's ifNumber, ifTable and ifXTable. An interface that
+// is down keeps the counts it made while it was up, and adds nothing to them.
+func addInterfaces(o *objects, seed uint64, ifs []iface) {
+	swing := func(n uint64, depth float64, period time.Duration) Swing {
+		return Swing{Depth: depth, Period: period, Seed: seed + n}
+	}
+	// A starting count drawn from the seed, so two devices' counters differ
+	// and a busy 32-bit one wraps within minutes of the device starting.
+	start := func(n uint64, base, spread float64) uint64 {
+		return uint64(base + spread*unit(seed+1000+n))
+	}
+	o.add("1.3.6.1.2.1.2.1.0", gosnmp.Integer, Const(len(ifs)))
+	for _, f := range ifs {
+		col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.2.2.1.%d.%d", n, f.index) }
+		ext := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.31.1.1.1.%d.%d", n, f.index) }
+		n := uint64(f.index) * 16
+		admin, oper := 1, 2
+		if f.adminDown {
+			admin = 2
+		}
+		in, out, errs := 0.0, 0.0, 0.0
+		if f.up && !f.adminDown {
+			oper, in, out, errs = 1, f.inRate, f.outRate, f.errorRate
+		}
+		name := f.name
+		if name == "" {
+			name = f.descr
+		}
+		inOctets := func() (float64, uint64, Swing) {
+			return in, start(n, 3.0e9, 1.0e9), swing(n, 0.6, 5*time.Minute)
+		}
+		outOctets := func() (float64, uint64, Swing) {
+			return out, start(n+1, 1.0e9, 2.0e9), swing(n+1, 0.5, 7*time.Minute)
+		}
+
+		o.add(col(1), gosnmp.Integer, Const(f.index))
+		o.add(col(2), gosnmp.OctetString, Const(f.descr))
+		o.add(col(3), gosnmp.Integer, Const(f.ifType))
+		o.add(col(4), gosnmp.Integer, Const(f.mtu))
+		// ifSpeed stops at 2^32 - 1, which is why ifHighSpeed exists.
+		o.add(col(5), gosnmp.Gauge32, Const(uint32(min(f.speed, math.MaxUint32))))
+		o.add(col(6), gosnmp.OctetString, Const([]byte(f.mac)))
+		o.add(col(7), gosnmp.Integer, Const(admin))
+		o.add(col(8), gosnmp.Integer, Const(oper))
+		o.add(col(9), gosnmp.TimeTicks, Const(uint32(0)))
+		o.add(col(10), gosnmp.Counter32, Counter(inOctets()))
+		o.add(col(11), gosnmp.Counter32, Counter(in/900, start(n+2, 1e6, 1e7), swing(n, 0.6, 5*time.Minute)))
+		o.add(col(13), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(14), gosnmp.Counter32, Counter(errs, start(n+3, 0, 40), swing(n+3, 0.9, 11*time.Minute)))
+		o.add(col(16), gosnmp.Counter32, Counter(outOctets()))
+		o.add(col(17), gosnmp.Counter32, Counter(out/700, start(n+4, 1e6, 1e7), swing(n+1, 0.5, 7*time.Minute)))
+		o.add(col(19), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(20), gosnmp.Counter32, Const(uint32(0)))
+
+		o.add(ext(1), gosnmp.OctetString, Const(name))
+		o.add(ext(6), gosnmp.Counter64, Counter64(inOctets()))
+		o.add(ext(10), gosnmp.Counter64, Counter64(outOctets()))
+		o.add(ext(15), gosnmp.Gauge32, Const(uint32(min(f.speed/1_000_000, math.MaxUint32))))
+		o.add(ext(18), gosnmp.OctetString, Const(f.alias))
+	}
+}
+
+// deviceMAC is a MAC address for a device's n-th port, drawn from its seed:
+// locally administered and unicast (02:…), so it can never be a vendor's.
+func deviceMAC(seed uint64, n uint64) net.HardwareAddr {
+	h := mix(seed ^ (n * 0x100000001B3))
+	return net.HardwareAddr{0x02, byte(h >> 32), byte(h >> 24), byte(h >> 16), byte(h >> 8), byte(h)}
+}

--- a/pkg/simulator/linuxserver.go
+++ b/pkg/simulator/linuxserver.go
@@ -2,10 +2,7 @@ package simulator
 
 import (
 	"fmt"
-	"net"
 	"time"
-
-	"github.com/gosnmp/gosnmp"
 )
 
 // linuxServer is an Ubuntu host running net-snmp: the system group, three
@@ -13,7 +10,7 @@ import (
 // interface wall looks like on a real server — and the host resources.
 //
 // It answers everything the bundled "Interfaces" and "Host resources" presets
-// poll, and TestTheLinuxModelFeedsItsPresets holds it to that: binding a preset
+// poll, and TestEveryModelFeedsItsPresets holds it to that: binding a preset
 // to a simulated server and getting empty widgets would be a demonstration of
 // the wrong thing.
 var linuxServer = model{
@@ -30,126 +27,32 @@ var linuxServer = model{
 	},
 }
 
-type linuxInterface struct {
-	index           int
-	name, alias     string
-	ifType, mtu     int
-	speed           uint32 // bits per second
-	mac             net.HardwareAddr
-	up              bool
-	inRate, outRate float64 // octets per second
-	errorRate       float64 // input errors per second
-}
-
 func buildLinuxServer(id Identity) []Object {
 	var o objects
-	swing := func(n uint64, depth float64, period time.Duration) Swing {
-		return Swing{Depth: depth, Period: period, Seed: id.Seed + n}
-	}
-	// A starting count drawn from the seed, so two servers' counters differ
-	// and a 32-bit one wraps within minutes of the device starting.
-	start := func(n uint64, base, spread float64) uint64 {
-		return uint64(base + spread*unit(id.Seed+1000+n))
-	}
-
-	// system (RFC 3418)
-	o.add("1.3.6.1.2.1.1.1.0", gosnmp.OctetString,
-		Const(fmt.Sprintf("Linux %s 6.8.0-45-generic #45-Ubuntu SMP PREEMPT_DYNAMIC x86_64", id.Name)))
-	o.add("1.3.6.1.2.1.1.2.0", gosnmp.ObjectIdentifier, Const(".1.3.6.1.4.1.8072.3.2.10"))
-	o.add("1.3.6.1.2.1.1.3.0", gosnmp.TimeTicks, Uptime())
-	o.add("1.3.6.1.2.1.1.4.0", gosnmp.OctetString, Const("root@"+id.Name))
-	o.add("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, Const(id.Name))
-	o.add("1.3.6.1.2.1.1.6.0", gosnmp.OctetString, Const("Server room, rack A1"))
-	o.add("1.3.6.1.2.1.1.7.0", gosnmp.Integer, Const(72))
-
-	// interfaces (RFC 2863): ifTable, then ifXTable
-	ifs := []linuxInterface{
-		{1, "lo", "", 24, 65536, 10_000_000, nil, true, 20_000, 20_000, 0},
-		{2, "eth0", "uplink", 6, 1500, 1_000_000_000, deviceMAC(id.Seed, 1), true, 1_250_000, 310_000, 0.004},
-		{3, "eth1", "spare", 6, 1500, 1_000_000_000, deviceMAC(id.Seed, 2), false, 0, 0, 0},
-	}
-	o.add("1.3.6.1.2.1.2.1.0", gosnmp.Integer, Const(len(ifs)))
-	for _, f := range ifs {
-		col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.2.2.1.%d.%d", n, f.index) }
-		ext := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.31.1.1.1.%d.%d", n, f.index) }
-		n := uint64(f.index) * 16
-		oper := 2 // down
-		if f.up {
-			oper = 1
-		}
-		inOctets := func() (float64, uint64, Swing) {
-			return f.inRate, start(n, 3.0e9, 1.0e9), swing(n, 0.6, 5*time.Minute)
-		}
-		outOctets := func() (float64, uint64, Swing) {
-			return f.outRate, start(n+1, 1.0e9, 2.0e9), swing(n+1, 0.5, 7*time.Minute)
-		}
-
-		o.add(col(1), gosnmp.Integer, Const(f.index))
-		o.add(col(2), gosnmp.OctetString, Const(f.name))
-		o.add(col(3), gosnmp.Integer, Const(f.ifType))
-		o.add(col(4), gosnmp.Integer, Const(f.mtu))
-		o.add(col(5), gosnmp.Gauge32, Const(f.speed))
-		o.add(col(6), gosnmp.OctetString, Const([]byte(f.mac)))
-		o.add(col(7), gosnmp.Integer, Const(1)) // administratively up
-		o.add(col(8), gosnmp.Integer, Const(oper))
-		o.add(col(9), gosnmp.TimeTicks, Const(uint32(0)))
-		o.add(col(10), gosnmp.Counter32, Counter(inOctets()))
-		o.add(col(11), gosnmp.Counter32, Counter(f.inRate/900, start(n+2, 1e6, 1e7), swing(n, 0.6, 5*time.Minute)))
-		o.add(col(13), gosnmp.Counter32, Const(uint32(0)))
-		o.add(col(14), gosnmp.Counter32, Counter(f.errorRate, start(n+3, 0, 40), swing(n+3, 0.9, 11*time.Minute)))
-		o.add(col(16), gosnmp.Counter32, Counter(outOctets()))
-		o.add(col(17), gosnmp.Counter32, Counter(f.outRate/700, start(n+4, 1e6, 1e7), swing(n+1, 0.5, 7*time.Minute)))
-		o.add(col(19), gosnmp.Counter32, Const(uint32(0)))
-		o.add(col(20), gosnmp.Counter32, Const(uint32(0)))
-
-		o.add(ext(1), gosnmp.OctetString, Const(f.name))
-		o.add(ext(6), gosnmp.Counter64, Counter64(inOctets()))
-		o.add(ext(10), gosnmp.Counter64, Counter64(outOctets()))
-		o.add(ext(15), gosnmp.Gauge32, Const(f.speed/1_000_000))
-		o.add(ext(18), gosnmp.OctetString, Const(f.alias))
-	}
-
-	// host resources (RFC 2790)
-	o.add("1.3.6.1.2.1.25.1.1.0", gosnmp.TimeTicks, Uptime())
-	o.add("1.3.6.1.2.1.25.1.5.0", gosnmp.Gauge32, Gauge(1, 3, swing(200, 0, 20*time.Minute)))
-	o.add("1.3.6.1.2.1.25.1.6.0", gosnmp.Gauge32, Gauge(180, 260, swing(201, 0, 7*time.Minute)))
-	o.add("1.3.6.1.2.1.25.2.2.0", gosnmp.Integer, Const(8388608)) // KiB: 8 GiB
-
-	storage := []struct {
-		index       int
-		kind, descr string
-		unit, size  int
-		lo, hi      float64 // share of size in use
-		period      time.Duration
-	}{
-		{1, ".1.3.6.1.2.1.25.2.1.2", "Physical memory", 1024, 8388608, 0.55, 0.75, 4 * time.Minute},
-		{3, ".1.3.6.1.2.1.25.2.1.3", "Virtual memory", 1024, 10485760, 0.48, 0.62, 5 * time.Minute},
-		{31, ".1.3.6.1.2.1.25.2.1.4", "/", 4096, 25600000, 0.41, 0.43, 6 * time.Hour},
-		{36, ".1.3.6.1.2.1.25.2.1.4", "/home", 4096, 51200000, 0.63, 0.64, 9 * time.Hour},
-	}
-	for i, st := range storage {
-		col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.25.2.3.1.%d.%d", n, st.index) }
-		o.add(col(1), gosnmp.Integer, Const(st.index))
-		o.add(col(2), gosnmp.ObjectIdentifier, Const(st.kind))
-		o.add(col(3), gosnmp.OctetString, Const(st.descr))
-		o.add(col(4), gosnmp.Integer, Const(st.unit))
-		o.add(col(5), gosnmp.Integer, Const(st.size))
-		o.add(col(6), gosnmp.Integer, IntegerGauge(st.lo*float64(st.size), st.hi*float64(st.size),
-			swing(300+uint64(i), 0, st.period)))
-	}
-
-	// One row per CPU, indexed as net-snmp indexes hrDeviceTable.
-	for i, index := range []int{196608, 196609} {
-		o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.3.1.1.%d", index), gosnmp.ObjectIdentifier, Const(".0.0"))
-		o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.3.1.2.%d", index), gosnmp.Integer,
-			IntegerGauge(4, 55, swing(400+uint64(i), 0, 90*time.Second)))
-	}
+	addSystem(&o, id, fmt.Sprintf("Linux %s 6.8.0-45-generic #45-Ubuntu SMP PREEMPT_DYNAMIC x86_64", id.Name),
+		".1.3.6.1.4.1.8072.3.2.10", "root@"+id.Name, "Server room, rack A1", 72)
+	addInterfaces(&o, id.Seed, []iface{
+		{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
+			up: true, inRate: 20_000, outRate: 20_000},
+		{index: 2, descr: "eth0", alias: "uplink", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+			mac: deviceMAC(id.Seed, 1), up: true, inRate: 1_250_000, outRate: 310_000, errorRate: 0.004},
+		{index: 3, descr: "eth1", alias: "spare", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+			mac: deviceMAC(id.Seed, 2)},
+	})
+	addHostResources(&o, id.Seed, hostResources{
+		memoryKiB: 8388608, // 8 GiB
+		users:     [2]float64{1, 3},
+		processes: [2]float64{180, 260},
+		storage: []storageArea{
+			{1, hrStorageRam, "Physical memory", 1024, 8388608, 0.55, 0.75, 4 * time.Minute},
+			{3, hrStorageVirtualMemory, "Virtual memory", 1024, 10485760, 0.48, 0.62, 5 * time.Minute},
+			{31, hrStorageFixedDisk, "/", 4096, 25600000, 0.41, 0.43, 6 * time.Hour},
+			{36, hrStorageFixedDisk, "/home", 4096, 51200000, 0.63, 0.64, 9 * time.Hour},
+		},
+		// One row per CPU, indexed as net-snmp indexes hrDeviceTable.
+		processors: []int{196608, 196609},
+		cpuLo:      4,
+		cpuHi:      55,
+	})
 	return o
-}
-
-// deviceMAC is a MAC address for a device's n-th port, drawn from its seed:
-// locally administered and unicast (02:…), so it can never be a vendor's.
-func deviceMAC(seed uint64, n uint64) net.HardwareAddr {
-	h := mix(seed ^ (n * 0x100000001B3))
-	return net.HardwareAddr{0x02, byte(h >> 32), byte(h >> 24), byte(h >> 16), byte(h >> 8), byte(h)}
 }

--- a/pkg/simulator/model.go
+++ b/pkg/simulator/model.go
@@ -37,7 +37,17 @@ type model struct {
 	notifications []Notification
 }
 
-var models = []model{linuxServer}
+// models is the catalogue, in the order the interface offers it; a new device
+// is made from the first. Each says which bundled presets it feeds
+// (TestEveryModelFeedsItsPresets).
+var models = []model{
+	linuxServer, windowsServer,
+	catalyst24, catalyst48, isr4331,
+	synologyNAS,
+	apcSmartUPS,
+	hpLaserJet,
+	environmentProbe,
+}
 
 // Models lists the models a device can be made from.
 func Models() []ModelInfo {
@@ -72,4 +82,17 @@ type objects []Object
 
 func (o *objects) add(oid string, t gosnmp.Asn1BER, r Reading) {
 	*o = append(*o, Object{OID: oid, Type: t, Value: r})
+}
+
+// addSystem adds the system group (RFC 3418) as a model's agent answers it.
+// sysServices adds up the layers the device serves: 2 a bridge, 4 a router,
+// 8 end to end, 64 applications.
+func addSystem(o *objects, id Identity, descr, sysObjectID, contact, location string, services int) {
+	o.add("1.3.6.1.2.1.1.1.0", gosnmp.OctetString, Const(descr))
+	o.add("1.3.6.1.2.1.1.2.0", gosnmp.ObjectIdentifier, Const(sysObjectID))
+	o.add("1.3.6.1.2.1.1.3.0", gosnmp.TimeTicks, Uptime())
+	o.add("1.3.6.1.2.1.1.4.0", gosnmp.OctetString, Const(contact))
+	o.add("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, Const(id.Name))
+	o.add("1.3.6.1.2.1.1.6.0", gosnmp.OctetString, Const(location))
+	o.add("1.3.6.1.2.1.1.7.0", gosnmp.Integer, Const(services))
 }

--- a/pkg/simulator/model_test.go
+++ b/pkg/simulator/model_test.go
@@ -7,63 +7,103 @@ import (
 	"strings"
 	"testing"
 
+	"SnmpLens/pkg/preset"
+
 	"github.com/gosnmp/gosnmp"
 )
 
-func linuxObjects() []Object {
-	return linuxServer.build(Identity{Name: "srv-01", Seed: 42})
+// modelPresets names the bundled presets each model feeds. Every model is in
+// it: a model added without saying what it answers is one nobody checked.
+var modelPresets = map[string][]string{
+	"linux-server":      {"interfaces.json", "host-resources.json"},
+	"windows-server":    {"interfaces.json", "host-resources.json"},
+	"cisco-catalyst-24": {"interfaces.json", "switch-ports.json", "switch-drawing.json", "cisco-generic.json"},
+	"cisco-catalyst-48": {"interfaces.json", "switch-ports.json", "cisco-generic.json"},
+	"cisco-isr-4331":    {"interfaces.json", "cisco-generic.json"},
+	"synology-nas":      {"interfaces.json", "host-resources.json"},
+	"apc-smart-ups":     {"ups.json", "interfaces.json"},
+	"hp-laserjet":       {"interfaces.json"},
+	"environment-probe": {"interfaces.json"},
 }
 
-// Every OID the bundled "Interfaces" and "Host resources" presets poll is one
-// the Linux model answers, for every instance the preset's own discovery walk
-// finds on it. Read from the preset files themselves, so a preset that grows a
-// widget the model cannot feed fails here rather than as an empty chart.
-func TestTheLinuxModelFeedsItsPresets(t *testing.T) {
-	tr, err := newTree(linuxObjects())
+type presetFile struct {
+	Match struct {
+		SysObjectIDPrefix []string `json:"sysObjectIdPrefix"`
+	} `json:"match"`
+	Widgets []struct {
+		Title    string   `json:"title"`
+		OIDs     []string `json:"oids"`
+		Discover *struct {
+			Walk string `json:"walk"`
+		} `json:"discover"`
+	} `json:"widgets"`
+}
+
+func readPreset(t *testing.T, file string) presetFile {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "presets", file))
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, file := range []string{"interfaces.json", "host-resources.json"} {
-		raw, err := os.ReadFile(filepath.Join("..", "..", "presets", file))
+	var p presetFile
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("%s: %v", file, err)
+	}
+	if len(p.Widgets) == 0 {
+		t.Fatalf("%s has no widgets; the test reads the wrong shape", file)
+	}
+	return p
+}
+
+func sysObjectIDOf(t *testing.T, tr *tree) string {
+	t.Helper()
+	id, _ := parseOID(oidSysObjectID)
+	e := tr.get(id)
+	if e == nil {
+		t.Fatal("no sysObjectID")
+	}
+	s, _ := e.val.read(clock{}).(string)
+	return s
+}
+
+// Every OID a model's presets poll is one the model answers, for every
+// instance the preset's own discovery walk finds on it. Read from the preset
+// files themselves, so a preset that grows a widget a model cannot feed fails
+// here rather than as an empty chart.
+func TestEveryModelFeedsItsPresets(t *testing.T) {
+	for _, m := range models {
+		files, ok := modelPresets[m.ID]
+		if !ok {
+			t.Errorf("%s: say in modelPresets which bundled presets it feeds", m.ID)
+			continue
+		}
+		tr, err := newTree(m.build(Identity{Name: "dev-01", Seed: 42}))
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("%s: %v", m.ID, err)
 		}
-		var p struct {
-			Widgets []struct {
-				Title    string   `json:"title"`
-				OIDs     []string `json:"oids"`
-				Discover *struct {
-					Walk string `json:"walk"`
-				} `json:"discover"`
-			} `json:"widgets"`
-		}
-		if err := json.Unmarshal(raw, &p); err != nil {
-			t.Fatalf("%s: %v", file, err)
-		}
-		if len(p.Widgets) == 0 {
-			t.Fatalf("%s has no widgets; the test reads the wrong shape", file)
-		}
-		for _, w := range p.Widgets {
-			instances := []string{""}
-			if w.Discover != nil {
-				column, err := parseOID(w.Discover.Walk)
-				if err != nil {
-					t.Fatal(err)
+		for _, file := range files {
+			for _, w := range readPreset(t, file).Widgets {
+				instances := []string{""}
+				if w.Discover != nil {
+					column, err := parseOID(w.Discover.Walk)
+					if err != nil {
+						t.Fatal(err)
+					}
+					instances = nil
+					for e := tr.next(column, nil); e != nil && e.oid.hasPrefix(column); e = tr.next(e.oid, nil) {
+						instances = append(instances, strings.TrimPrefix(e.oid[len(column):].String(), "."))
+					}
+					if len(instances) == 0 {
+						t.Errorf("%s, %s, %q: walking %s finds nothing", m.ID, file, w.Title, w.Discover.Walk)
+						continue
+					}
 				}
-				instances = nil
-				for e := tr.next(column, nil); e != nil && e.oid.hasPrefix(column); e = tr.next(e.oid, nil) {
-					instances = append(instances, strings.TrimPrefix(e.oid[len(column):].String(), "."))
-				}
-				if len(instances) == 0 {
-					t.Errorf("%s, %q: walking %s finds nothing", file, w.Title, w.Discover.Walk)
-					continue
-				}
-			}
-			for _, template := range w.OIDs {
-				for _, instance := range instances {
-					name := strings.ReplaceAll(template, "{#}", instance)
-					if id, err := parseOID(name); err != nil || tr.get(id) == nil {
-						t.Errorf("%s, %q: %s is not answered", file, w.Title, name)
+				for _, template := range w.OIDs {
+					for _, instance := range instances {
+						name := strings.ReplaceAll(template, "{#}", instance)
+						if id, err := parseOID(name); err != nil || tr.get(id) == nil {
+							t.Errorf("%s, %s, %q: %s is not answered", m.ID, file, w.Title, name)
+						}
 					}
 				}
 			}
@@ -71,35 +111,76 @@ func TestTheLinuxModelFeedsItsPresets(t *testing.T) {
 	}
 }
 
-// The whole model goes out over the wire: every value encodes, and a walk
-// visits every object. A value gosnmp cannot encode would otherwise fail the one
-// response that carries it, as a timeout.
-func TestTheLinuxModelServesAWalk(t *testing.T) {
-	objects := linuxObjects()
-	a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public", Objects: objects})
-	g := connect(t, manager(a, gosnmp.Version2c, "public"))
-
-	n := 0
-	err := g.BulkWalk(".1.3.6.1", func(gosnmp.SnmpPDU) error {
-		n++
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
+// The preset matched to Cisco equipment claims a simulated Catalyst and a
+// simulated ISR, as it would the real ones — identified by their sysObjectID,
+// read the way SnmpLens reads it when a target is added — and no other model.
+func TestTheCiscoPresetClaimsTheSimulatedCiscos(t *testing.T) {
+	prefixes := readPreset(t, "cisco-generic.json").Match.SysObjectIDPrefix
+	if len(prefixes) == 0 {
+		t.Fatal("cisco-generic.json claims nothing; the test reads the wrong shape")
 	}
-	if n != len(objects) {
-		t.Errorf("walked %d objects of %d", n, len(objects))
-	}
-	res, err := g.Get([]string{".1.3.6.1.2.1.1.5.0"})
-	if err != nil || text(res.Variables[0]) != "srv-01" {
-		t.Errorf("sysName: %v, %v", res, err)
-	}
-	if s := a.Stats(); s.Faults != 0 {
-		t.Errorf("%d answers failed to encode", s.Faults)
+	for _, m := range models {
+		tr, err := newTree(m.build(Identity{Name: "dev-01", Seed: 1}))
+		if err != nil {
+			t.Fatalf("%s: %v", m.ID, err)
+		}
+		sysObjectID := sysObjectIDOf(t, tr)
+		cisco := strings.HasPrefix(m.ID, "cisco-")
+		if claimed := preset.MatchDepth(prefixes, sysObjectID) > 0; claimed != cisco {
+			t.Errorf("%s (%s): the Cisco preset claims it: %v, want %v", m.ID, sysObjectID, claimed, cisco)
+		}
 	}
 }
 
-// Two servers of one model are two different machines.
+// Every model goes out over the wire whole: every value encodes and a walk
+// visits every object. A value gosnmp cannot encode would otherwise fail the
+// one response that carries it, as a timeout.
+func TestEveryModelServesAWalk(t *testing.T) {
+	for _, m := range models {
+		t.Run(m.ID, func(t *testing.T) {
+			objects := m.build(Identity{Name: "dev-01", Seed: 7})
+			a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public", Objects: objects})
+			g := connect(t, manager(a, gosnmp.Version2c, "public"))
+			n := 0
+			if err := g.BulkWalk(".1.3.6.1", func(gosnmp.SnmpPDU) error {
+				n++
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if n != len(objects) {
+				t.Errorf("walked %d objects of %d", n, len(objects))
+			}
+			res, err := g.Get([]string{".1.3.6.1.2.1.1.5.0"})
+			if err != nil || text(res.Variables[0]) != "dev-01" {
+				t.Errorf("sysName: %v, %v", res, err)
+			}
+			if s := a.Stats(); s.Faults != 0 {
+				t.Errorf("%d answers failed to encode", s.Faults)
+			}
+		})
+	}
+}
+
+// Every model makes a device: a category the interface files it under, and an
+// engine ID in its vendor's MAC format.
+func TestEveryModelMakesADevice(t *testing.T) {
+	seen := map[string]bool{}
+	for _, m := range Models() {
+		if seen[m.ID] {
+			t.Errorf("%s is listed twice", m.ID)
+		}
+		seen[m.ID] = true
+		if m.Category == "" {
+			t.Errorf("%s has no category", m.ID)
+		}
+		if _, err := NewEngineID(m.ID, "one"); err != nil {
+			t.Errorf("%s: %v", m.ID, err)
+		}
+	}
+}
+
+// Two devices of one model are two different machines.
 func TestTwoDevicesOfOneModelDiffer(t *testing.T) {
 	one := linuxServer.build(Identity{Name: "a", Seed: 1})
 	two := linuxServer.build(Identity{Name: "b", Seed: 2})

--- a/pkg/simulator/printer.go
+++ b/pkg/simulator/printer.go
@@ -1,0 +1,86 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// hpLaserJet is an HP LaserJet on its Jetdirect card, answering the Printer MIB
+// (RFC 3805): its page count, a black cartridge running low and the alert that
+// says so, and the printer's status in the host resources, as printers report
+// it.
+var hpLaserJet = model{
+	ModelInfo:  ModelInfo{ID: "hp-laserjet", Category: "printing"},
+	enterprise: 11, // HP
+	build:      buildHPLaserJet,
+	notifications: []Notification{{
+		Name: "printerV2Alert",
+		OID:  ".1.3.6.1.2.1.43.18.2.0.1",
+		// prtAlertIndex, …SeverityLevel, …Group, …GroupIndex, …Location, …Code
+		Objects: []string{
+			".1.3.6.1.2.1.43.18.1.1.1.1.1",
+			".1.3.6.1.2.1.43.18.1.1.2.1.1",
+			".1.3.6.1.2.1.43.18.1.1.4.1.1",
+			".1.3.6.1.2.1.43.18.1.1.5.1.1",
+			".1.3.6.1.2.1.43.18.1.1.6.1.1",
+			".1.3.6.1.2.1.43.18.1.1.7.1.1",
+		},
+	}},
+}
+
+func buildHPLaserJet(id Identity) []Object {
+	var o objects
+	addSystem(&o, id, "HP ETHERNET MULTI-ENVIRONMENT,ROM none,JETDIRECT,JD153,EEPROM JSI23900051,CIDATE 06/17/2019",
+		".1.3.6.1.4.1.11.2.3.9.1", // hpNetPrinter
+		"helpdesk@example.com", "Floor 1, copy room", 72)
+	addInterfaces(&o, id.Seed, []iface{
+		{index: 1, descr: "HP ETHERNET MULTI-ENVIRONMENT", ifType: ifTypeEthernet, mtu: 1500,
+			speed: 1_000_000_000, mac: deviceMAC(id.Seed, 1), up: true, inRate: 1_500, outRate: 900},
+	})
+
+	// Host resources: the printer as a device, and its status.
+	o.add("1.3.6.1.2.1.25.1.1.0", gosnmp.TimeTicks, Uptime())
+	o.add("1.3.6.1.2.1.25.2.2.0", gosnmp.Integer, Const(524288)) // 512 MiB
+	device := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.25.3.2.1.%d.1", c) }
+	o.add(device(1), gosnmp.Integer, Const(1))
+	o.add(device(2), gosnmp.ObjectIdentifier, Const(".1.3.6.1.2.1.25.3.1.5")) // hrDevicePrinter
+	o.add(device(3), gosnmp.OctetString, Const("HP LaserJet Pro M404dn"))
+	o.add(device(5), gosnmp.Integer, Const(2))                                 // hrDeviceStatus: running
+	o.add("1.3.6.1.2.1.25.3.5.1.1.1", gosnmp.Integer, Const(3))                // hrPrinterStatus: idle
+	o.add("1.3.6.1.2.1.25.3.5.1.2.1", gosnmp.OctetString, Const([]byte{0x00})) // no error detected
+
+	const prt = "1.3.6.1.2.1.43."
+	o.add(prt+"5.1.1.16.1", gosnmp.OctetString, Const("HP LaserJet Pro M404dn"))
+	o.add(prt+"5.1.1.17.1", gosnmp.OctetString, Const(fmt.Sprintf("PHB%07d", int(unit(id.Seed+41)*1e7))))
+	// The marker, and the pages it has printed: about fourteen an hour.
+	o.add(prt+"10.2.1.2.1.1", gosnmp.Integer, Const(4)) // electrophotographicLaser
+	o.add(prt+"10.2.1.3.1.1", gosnmp.Integer, Const(7)) // counted in impressions
+	o.add(prt+"10.2.1.4.1.1", gosnmp.Counter32, Counter(0.004, uint64(18_000+40_000*unit(id.Seed+42)),
+		Swing{Depth: 0.9, Period: 2 * time.Hour, Seed: id.Seed + 40000}))
+	o.add(prt+"10.2.1.15.1.1", gosnmp.Integer, Const(0)) // prtMarkerStatus: available and idle
+	// The black cartridge, at 17 to 18 percent.
+	supply := func(c int) string { return fmt.Sprintf(prt+"11.1.1.%d.1.1", c) }
+	o.add(supply(1), gosnmp.Integer, Const(1))
+	o.add(supply(2), gosnmp.Integer, Const(1))
+	o.add(supply(3), gosnmp.Integer, Const(1))
+	o.add(supply(4), gosnmp.Integer, Const(3)) // supplyThatIsConsumed
+	o.add(supply(5), gosnmp.Integer, Const(3)) // toner
+	o.add(supply(6), gosnmp.OctetString, Const("Black Cartridge HP 59A"))
+	o.add(supply(7), gosnmp.Integer, Const(19)) // in percent
+	o.add(supply(8), gosnmp.Integer, Const(100))
+	o.add(supply(9), gosnmp.Integer, IntegerGauge(17, 18, Swing{Period: 6 * time.Hour, Seed: id.Seed + 40001}))
+	// The alert the cartridge raised, which printerV2Alert carries.
+	alert := func(c int) string { return fmt.Sprintf(prt+"18.1.1.%d.1.1", c) }
+	o.add(alert(1), gosnmp.Integer, Const(1))
+	o.add(alert(2), gosnmp.Integer, Const(4))    // severity: warning
+	o.add(alert(3), gosnmp.Integer, Const(4))    // training: trained
+	o.add(alert(4), gosnmp.Integer, Const(11))   // group: markerSupplies
+	o.add(alert(5), gosnmp.Integer, Const(1))    // the supply's index
+	o.add(alert(6), gosnmp.Integer, Const(-2))   // location: unknown
+	o.add(alert(7), gosnmp.Integer, Const(1104)) // markerTonerAlmostEmpty
+	o.add(alert(8), gosnmp.OctetString, Const("Black cartridge low"))
+	o.add(alert(9), gosnmp.TimeTicks, Const(uint32(0)))
+	return o
+}

--- a/pkg/simulator/probe.go
+++ b/pkg/simulator/probe.go
@@ -1,0 +1,69 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// environmentProbe is a temperature and humidity probe answering the standard
+// ENTITY-SENSOR-MIB (RFC 3433) rather than a vendor's: two sensors in
+// ENTITY-MIB's physical table, and their readings, as a server room's cold aisle
+// reads. The MIB defines no notification, and the probe sends only the generic
+// ones.
+var environmentProbe = model{
+	ModelInfo:  ModelInfo{ID: "environment-probe", Category: "environment"},
+	enterprise: 8072, // an embedded net-snmp
+	build:      buildEnvironmentProbe,
+}
+
+func buildEnvironmentProbe(id Identity) []Object {
+	var o objects
+	addSystem(&o, id, "Environment monitor, 2 sensors (temperature, humidity), firmware 2.4.1",
+		".1.3.6.1.4.1.8072.3.2.10", "facilities@example.com", "Server room, cold aisle", 72)
+	addInterfaces(&o, id.Seed, []iface{
+		{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
+			mac: deviceMAC(id.Seed, 1), up: true, inRate: 300, outRate: 500},
+	})
+
+	// ENTITY-MIB's physical table: the probe, and the two sensors in it.
+	const physical = "1.3.6.1.2.1.47.1.1.1.1."
+	for _, e := range []struct {
+		index            int
+		descr, name      string
+		class, container int
+	}{
+		{1, "Environment monitor", "chassis", 3, 0}, // chassis
+		{2, "Temperature sensor", "temperature", 8, 1},
+		{3, "Humidity sensor", "humidity", 8, 1}, // sensor
+	} {
+		o.add(fmt.Sprintf(physical+"2.%d", e.index), gosnmp.OctetString, Const(e.descr))
+		o.add(fmt.Sprintf(physical+"4.%d", e.index), gosnmp.Integer, Const(e.container))
+		o.add(fmt.Sprintf(physical+"5.%d", e.index), gosnmp.Integer, Const(e.class))
+		o.add(fmt.Sprintf(physical+"7.%d", e.index), gosnmp.OctetString, Const(e.name))
+	}
+
+	// ENTITY-SENSOR-MIB: the readings, in tenths.
+	const sensor = "1.3.6.1.2.1.99.1.1.1."
+	for i, s := range []struct {
+		index, kind int
+		lo, hi      float64
+		units       string
+		period      time.Duration
+	}{
+		{2, 8, 215, 245, "degrees Celsius", 50 * time.Minute}, // celsius: 21.5 to 24.5
+		{3, 9, 380, 460, "percent RH", 70 * time.Minute},      // percentRH: 38 to 46
+	} {
+		col := func(c int) string { return fmt.Sprintf(sensor+"%d.%d", c, s.index) }
+		o.add(col(1), gosnmp.Integer, Const(s.kind))
+		o.add(col(2), gosnmp.Integer, Const(9)) // scale: units
+		o.add(col(3), gosnmp.Integer, Const(1)) // precision: one decimal
+		o.add(col(4), gosnmp.Integer, IntegerGauge(s.lo, s.hi, Swing{Period: s.period, Seed: id.Seed + 50000 + uint64(i)}))
+		o.add(col(5), gosnmp.Integer, Const(1)) // operational status: ok
+		o.add(col(6), gosnmp.OctetString, Const(s.units))
+		o.add(col(7), gosnmp.TimeTicks, Uptime())           // read continuously: the last reading is now
+		o.add(col(8), gosnmp.Gauge32, Const(uint32(10000))) // update rate, in milliseconds
+	}
+	return o
+}

--- a/pkg/simulator/synology.go
+++ b/pkg/simulator/synology.go
@@ -1,0 +1,89 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// synologyNAS is a DS920+ running DSM, whose agent is net-snmp — so its
+// sysObjectID is net-snmp's Linux one, as a real DiskStation's is — with
+// Synology's own system, disk and RAID tables beside the host resources and
+// the interfaces.
+var synologyNAS = model{
+	ModelInfo:     ModelInfo{ID: "synology-nas", Category: "storage"},
+	enterprise:    8072, // net-snmp
+	build:         buildSynologyNAS,
+	notifications: []Notification{linkNotification(false, 3), linkNotification(true, 2)},
+}
+
+func buildSynologyNAS(id Identity) []Object {
+	var o objects
+	addSystem(&o, id, fmt.Sprintf("Linux %s 4.4.302+ #69057 SMP Fri Jan 12 17:02:28 CST 2024 x86_64", id.Name),
+		".1.3.6.1.4.1.8072.3.2.10", "admin@"+id.Name, "Office, storage shelf", 76)
+	addInterfaces(&o, id.Seed, []iface{
+		{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
+			up: true, inRate: 5_000, outRate: 5_000},
+		{index: 2, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+			mac: deviceMAC(id.Seed, 1), up: true, inRate: 3_800_000, outRate: 1_100_000, errorRate: 0.0002},
+		{index: 3, descr: "eth1", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+			mac: deviceMAC(id.Seed, 2)},
+	})
+	addHostResources(&o, id.Seed, hostResources{
+		memoryKiB: 4194304, // 4 GiB
+		users:     [2]float64{0, 1},
+		processes: [2]float64{260, 320},
+		storage: []storageArea{
+			{1, hrStorageRam, "Physical memory", 1024, 4194304, 0.4, 0.6, 4 * time.Minute},
+			{3, hrStorageVirtualMemory, "Virtual memory", 1024, 6291456, 0.3, 0.45, 5 * time.Minute},
+			{31, hrStorageFixedDisk, "/", 4096, 614400, 0.55, 0.56, 6 * time.Hour},
+			{51, hrStorageFixedDisk, "/volume1", 65536, 332640000, 0.37, 0.38, 12 * time.Hour},
+		},
+		processors: []int{196608, 196609, 196610, 196611},
+		cpuLo:      2,
+		cpuHi:      30,
+	})
+
+	// SYNOLOGY-SYSTEM-MIB, -DISK-MIB and -RAID-MIB. "Normal" is 1 throughout.
+	const syno = "1.3.6.1.4.1.6574."
+	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 30000 + n} }
+	o.add(syno+"1.1.0", gosnmp.Integer, Const(1))                                       // systemStatus
+	o.add(syno+"1.2.0", gosnmp.Integer, IntegerGauge(39, 45, swing(0, 40*time.Minute))) // °C
+	o.add(syno+"1.3.0", gosnmp.Integer, Const(1))                                       // powerStatus
+	o.add(syno+"1.4.1.0", gosnmp.Integer, Const(1))                                     // systemFanStatus
+	o.add(syno+"1.4.2.0", gosnmp.Integer, Const(1))                                     // cpuFanStatus
+	o.add(syno+"1.5.1.0", gosnmp.OctetString, Const("DS920+"))
+	o.add(syno+"1.5.2.0", gosnmp.OctetString, Const(fmt.Sprintf("20B0PDN%06d", int(unit(id.Seed+31)*1e6))))
+	o.add(syno+"1.5.3.0", gosnmp.OctetString, Const("DSM 7.2.1-69057 Update 5"))
+	o.add(syno+"1.5.4.0", gosnmp.Integer, Const(2)) // upgradeAvailable: unavailable
+
+	// Four disks, numbered from 0 as DSM numbers them.
+	for disk := 0; disk < 4; disk++ {
+		col := func(c int) string { return fmt.Sprintf(syno+"2.1.1.%d.%d", c, disk) }
+		o.add(col(1), gosnmp.Integer, Const(disk))
+		o.add(col(2), gosnmp.OctetString, Const(fmt.Sprintf("Disk %d", disk+1)))
+		o.add(col(3), gosnmp.OctetString, Const("ST8000VN004-2M2101"))
+		o.add(col(4), gosnmp.OctetString, Const("SATA"))
+		o.add(col(5), gosnmp.Integer, Const(1)) // diskStatus
+		o.add(col(6), gosnmp.Integer, IntegerGauge(33, 38, swing(10+uint64(disk), time.Hour)))
+		o.add(col(7), gosnmp.OctetString, Const("data"))
+		o.add(col(8), gosnmp.Integer, Const(0))   // retries
+		o.add(col(9), gosnmp.Integer, Const(0))   // bad sectors
+		o.add(col(10), gosnmp.Integer, Const(0))  // identify failures
+		o.add(col(11), gosnmp.Integer, Const(-1)) // remaining life: a hard disk reports none
+		o.add(col(12), gosnmp.OctetString, Const(fmt.Sprintf("Drive %d", disk+1)))
+		o.add(col(13), gosnmp.Integer, Const(1)) // diskHealthStatus
+	}
+
+	// One volume over the four disks, SHR: 21.8 TB, 62% free. The sizes are
+	// Counter64 in the MIB, so SNMPv1 does not see them.
+	raid := func(c int) string { return fmt.Sprintf(syno+"3.1.1.%d.0", c) }
+	o.add(raid(1), gosnmp.Integer, Const(0))
+	o.add(raid(2), gosnmp.OctetString, Const("Volume 1"))
+	o.add(raid(3), gosnmp.Integer, Const(1)) // raidStatus
+	o.add(raid(4), gosnmp.Counter64, Const(uint64(13_516_000_000_000)))
+	o.add(raid(5), gosnmp.Counter64, Const(uint64(21_800_000_000_000)))
+	o.add(raid(6), gosnmp.Integer, Const(0)) // hot spares
+	return o
+}

--- a/pkg/simulator/ups.go
+++ b/pkg/simulator/ups.go
@@ -1,0 +1,89 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// apcSmartUPS is a three-phase APC Smart-UPS on its network management card,
+// answering the standard UPS-MIB (RFC 1628): the MIB the "UPS (RFC 1628)" preset
+// polls, three output lines included — which is why it is the three-phase model
+// rather than a single-phase one. It runs on mains, charged.
+var apcSmartUPS = model{
+	ModelInfo:  ModelInfo{ID: "apc-smart-ups", Category: "power"},
+	enterprise: 318, // APC
+	build:      buildAPCSmartUPS,
+	notifications: []Notification{{
+		Name: "upsTrapOnBattery",
+		OID:  ".1.3.6.1.2.1.33.2.1",
+		// upsEstimatedMinutesRemaining, upsSecondsOnBattery, upsConfigLowBattTime
+		Objects: []string{".1.3.6.1.2.1.33.1.2.3.0", ".1.3.6.1.2.1.33.1.2.2.0", ".1.3.6.1.2.1.33.1.9.7.0"},
+	}},
+}
+
+func buildAPCSmartUPS(id Identity) []Object {
+	var o objects
+	serial := fmt.Sprintf("5A%04dT%05d", 2100+int(unit(id.Seed+1)*4), int(unit(id.Seed+2)*100000))
+	addSystem(&o, id, "APC Web/SNMP Management Card (MB:v4.1.0 PF:v6.9.6 PN:apc_hw05_aos_696.bin AF1:v6.9.6 "+
+		"AN1:apc_hw05_sumx_696.bin MN:SUVTP10KH3B4S HR:05 SN: "+serial+" MD:03/14/2021) "+
+		"(Embedded PowerNet SNMP Agent SW v2.2 compatible)",
+		".1.3.6.1.4.1.318.1.3.17.1", // smartUPS3Phase10kVA
+		"facilities@example.com", "Server room, UPS bay", 72)
+	addInterfaces(&o, id.Seed, []iface{
+		{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
+			mac: deviceMAC(id.Seed, 1), up: true, inRate: 400, outRate: 700},
+	})
+
+	const ups = "1.3.6.1.2.1.33.1."
+	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 20000 + n} }
+	// upsIdent
+	o.add(ups+"1.1.0", gosnmp.OctetString, Const("APC"))
+	o.add(ups+"1.2.0", gosnmp.OctetString, Const("Smart-UPS VT 10kVA"))
+	o.add(ups+"1.3.0", gosnmp.OctetString, Const("UPS 09.1 / ID=1015"))
+	o.add(ups+"1.4.0", gosnmp.OctetString, Const("v6.9.6"))
+	o.add(ups+"1.5.0", gosnmp.OctetString, Const(id.Name))
+	o.add(ups+"1.6.0", gosnmp.OctetString, Const("Racks A1 to A4"))
+	// upsBattery
+	o.add(ups+"2.1.0", gosnmp.Integer, Const(2))                                           // upsBatteryStatus: normal
+	o.add(ups+"2.2.0", gosnmp.Integer, Const(0))                                           // upsSecondsOnBattery
+	o.add(ups+"2.3.0", gosnmp.Integer, IntegerGauge(38, 44, swing(0, 20*time.Minute)))     // minutes remaining
+	o.add(ups+"2.4.0", gosnmp.Integer, IntegerGauge(99, 100, swing(1, 40*time.Minute)))    // % charge remaining
+	o.add(ups+"2.5.0", gosnmp.Integer, IntegerGauge(2180, 2200, swing(2, 15*time.Minute))) // 0.1 V DC
+	o.add(ups+"2.6.0", gosnmp.Integer, Const(0))                                           // 0.1 A: not discharging
+	o.add(ups+"2.7.0", gosnmp.Integer, IntegerGauge(24, 27, swing(3, 3*time.Hour)))        // °C
+	// upsInput, one line per phase
+	o.add(ups+"3.1.0", gosnmp.Counter32, Const(uint32(0))) // upsInputLineBads
+	o.add(ups+"3.2.0", gosnmp.Integer, Const(3))
+	for line := 1; line <= 3; line++ {
+		n := 10 + uint64(line)*8
+		col := func(c int) string { return fmt.Sprintf(ups+"3.3.1.%d.%d", c, line) }
+		o.add(col(1), gosnmp.Integer, Const(line))
+		o.add(col(2), gosnmp.Integer, IntegerGauge(499, 501, swing(n, 3*time.Minute)))     // 0.1 Hz
+		o.add(col(3), gosnmp.Integer, IntegerGauge(228, 234, swing(n+1, 9*time.Minute)))   // V RMS
+		o.add(col(4), gosnmp.Integer, IntegerGauge(95, 140, swing(n+2, 7*time.Minute)))    // 0.1 A RMS
+		o.add(col(5), gosnmp.Integer, IntegerGauge(2100, 3100, swing(n+3, 7*time.Minute))) // W
+	}
+	// upsOutput, one line per phase, each loaded differently
+	o.add(ups+"4.1.0", gosnmp.Integer, Const(3)) // upsOutputSource: normal, which is mains
+	o.add(ups+"4.2.0", gosnmp.Integer, Const(500))
+	o.add(ups+"4.3.0", gosnmp.Integer, Const(3))
+	for i, load := range [][2]float64{{34, 42}, {41, 48}, {28, 37}} {
+		line := i + 1
+		n := 50 + uint64(line)*8
+		col := func(c int) string { return fmt.Sprintf(ups+"4.4.1.%d.%d", c, line) }
+		o.add(col(1), gosnmp.Integer, Const(line))
+		o.add(col(2), gosnmp.Integer, Const(230))
+		o.add(col(3), gosnmp.Integer, IntegerGauge(80+load[0], 80+load[1], swing(n, 6*time.Minute)))   // 0.1 A RMS
+		o.add(col(4), gosnmp.Integer, IntegerGauge(load[0]*55, load[1]*55, swing(n+1, 6*time.Minute))) // W
+		o.add(col(5), gosnmp.Integer, IntegerGauge(load[0], load[1], swing(n+2, 6*time.Minute)))       // %
+	}
+	o.add(ups+"6.1.0", gosnmp.Gauge32, Const(uint32(0))) // upsAlarmsPresent
+	// upsConfig: 230 V and 50 Hz in and out, 10 kVA, 8 kW, two minutes' warning
+	// of a low battery, the alarm on, and the transfer points.
+	for i, v := range []int{230, 50, 230, 50, 10000, 8000, 2, 2, 160, 282} {
+		o.add(fmt.Sprintf(ups+"9.%d.0", i+1), gosnmp.Integer, Const(v))
+	}
+	return o
+}

--- a/pkg/simulator/values.go
+++ b/pkg/simulator/values.go
@@ -163,6 +163,21 @@ func (g gauge) check(t gosnmp.Asn1BER) error {
 	return nil
 }
 
+// SecondsUp answers the seconds since the agent started as a Gauge32: how long
+// something the device brought up at boot, a BGP session, has been up.
+func SecondsUp() Reading { return secondsUp{} }
+
+type secondsUp struct{}
+
+func (secondsUp) read(c clock) any { return uint32(c.now.Sub(c.started) / time.Second) }
+
+func (secondsUp) check(t gosnmp.Asn1BER) error {
+	if t != gosnmp.Gauge32 {
+		return fmt.Errorf("seconds up are a Gauge32, not a %v", t)
+	}
+	return nil
+}
+
 // engineSeconds is snmpEngineTime: the seconds since the agent started.
 type engineSeconds struct{}
 

--- a/pkg/simulator/windows.go
+++ b/pkg/simulator/windows.go
@@ -1,0 +1,51 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+)
+
+// windowsServer is a Windows Server 2022 host with the SNMP service: the system
+// group as Windows answers it, the loopback and two adapters, and the host
+// resources — its drives by letter, its memory and four processors, numbered as
+// Windows numbers them. It fits the "Interfaces" and "Host resources" presets.
+var windowsServer = model{
+	ModelInfo:     ModelInfo{ID: "windows-server", Category: "server"},
+	enterprise:    311, // Microsoft
+	build:         buildWindowsServer,
+	notifications: []Notification{linkNotification(false, 7), linkNotification(true, 6)},
+}
+
+func buildWindowsServer(id Identity) []Object {
+	var o objects
+	addSystem(&o, id,
+		"Hardware: Intel64 Family 6 Model 85 Stepping 7 AT/AT COMPATIBLE - Software: Windows Version 6.3 (Build 20348 Multiprocessor Free)",
+		".1.3.6.1.4.1.311.1.1.3.1.2", // a Windows server
+		"Administrator", "Server room, rack B2", 76)
+	addInterfaces(&o, id.Seed, []iface{
+		{index: 1, descr: "Software Loopback Interface 1", name: "loopback_0", ifType: ifTypeSoftwareLoopback,
+			mtu: 1500, speed: 1_073_741_824, up: true},
+		{index: 6, descr: "Intel(R) Ethernet Server Adapter I350-T2", name: "ethernet_32768", ifType: ifTypeEthernet,
+			mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, 1), up: true,
+			inRate: 2_100_000, outRate: 4_600_000, errorRate: 0.001},
+		{index: 7, descr: "Intel(R) Ethernet Server Adapter I350-T2 #2", name: "ethernet_32769", ifType: ifTypeEthernet,
+			mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, 2)},
+	})
+	// A volume serial number, as Windows writes one into hrStorageDescr.
+	serial := func(n uint64) string { return fmt.Sprintf("%08x", uint32(mix(id.Seed+n))) }
+	addHostResources(&o, id.Seed, hostResources{
+		memoryKiB: 16777216, // 16 GiB
+		users:     [2]float64{1, 3},
+		processes: [2]float64{110, 140},
+		storage: []storageArea{
+			{1, hrStorageFixedDisk, `C:\ Label:  Serial Number ` + serial(1), 4096, 32768000, 0.46, 0.52, 3 * time.Hour},
+			{2, hrStorageFixedDisk, `D:\ Label:Data  Serial Number ` + serial(2), 4096, 131072000, 0.61, 0.62, 12 * time.Hour},
+			{3, hrStorageVirtualMemory, "Virtual Memory", 65536, 327680, 0.35, 0.55, 6 * time.Minute},
+			{4, hrStorageRam, "Physical Memory", 65536, 262144, 0.5, 0.7, 4 * time.Minute},
+		},
+		processors: []int{5, 6, 7, 8},
+		cpuLo:      3,
+		cpuHi:      45,
+	})
+	return o
+}


### PR DESCRIPTION
## Summary

Step 5 of the simulator: the catalogue of models.

> **Stacked on #66, which is stacked on #65.** Until those are merged, the diff includes them. This PR's own changes are the last commit.

### Nine models

| Model | Category | What it answers | Presets it feeds | Its own notifications |
|---|---|---|---|---|
| Linux server | server | net-snmp: system, interfaces, host resources | Interfaces, Host resources | linkDown/Up, nsNotifyShutdown/Restart |
| Windows Server 2022 | server | the Windows SNMP service: drives by letter, four CPUs | Interfaces, Host resources | linkDown/Up |
| Catalyst 2960, 24 ports | network | 24 Fast Ethernet ports, 2 uplinks, VLAN 1, CPU load, configuration history | Interfaces, Switch ports, Switch drawing, Cisco | linkDown/Up, ciscoConfigManEvent |
| Catalyst 2960, 48 ports | network | the same, with 48 ports | Interfaces, Switch ports, Cisco | linkDown/Up, ciscoConfigManEvent |
| ISR 4331 | network | WAN, LAN and management ports, two eBGP peers (one established, one active) | Interfaces, Cisco | linkDown/Up, both BGP notifications, ciscoConfigManEvent |
| Synology DS920+ | storage | Synology's system, disk and RAID tables, plus host resources | Interfaces, Host resources | linkDown/Up |
| APC Smart-UPS, three-phase | power | UPS-MIB: battery, and input and output per phase | UPS, Interfaces | upsTrapOnBattery |
| HP LaserJet | printing | Printer MIB: pages, a black cartridge running low and its alert | Interfaces | printerV2Alert |
| Environment probe | environment | ENTITY-SENSOR-MIB: temperature and humidity | Interfaces | — |

Every model also sends coldStart, warmStart and authenticationFailure.

### Choices that follow from the presets

- **The Catalyst numbers its ports from 1.** "Switch drawing (24 ports)" polls `ifOperStatus.1` to `.26`. A real 2960 numbers them from 10001.
- **The UPS is three-phase.** "UPS (RFC 1628)" charts three output lines.
- **The "Cisco (IF-MIB)" preset claims the two Catalysts and the ISR, and nothing else.** Their sysObjectIDs are CISCO-PRODUCTS-MIB's `catalyst296024TT`, `catalyst296048TT` and `ciscoISR4331`.
- **The NAS and the probe report net-snmp's Linux sysObjectID.** DSM's agent is net-snmp, as most embedded probes' is.
- **Shared builders.** Interfaces, host resources and the system group are shared, so a preset reads the same thing on every model.
- **Vendor OIDs are sourced.** They were read from the published MIBs: Cisco, APC, Synology, UPS-MIB, Printer-MIB, ENTITY-SENSOR-MIB and BGP4-MIB.

### Interface

- The model list is grouped by category.
- A new device's name follows its model until someone types another name.
- All five locales name and describe every model and every category.

## Verification

- `TestEveryModelFeedsItsPresets` expands each preset's widgets against each model, discovery walks included. Every model must be listed in it.
- `TestTheCiscoPresetClaimsTheSimulatedCiscos` runs `preset.MatchDepth` against every model's sysObjectID.
- `TestEveryModelServesAWalk`: every model is walked in full over the wire, with no encoding fault.
- `TestEveryNotificationOfAModelIsWhole`: every notification has all its objects and an SNMPv1 form.
- `tests/simulator.test.mjs` checks that `en.json` names every model and every category found in `pkg/simulator`, and it tests the grouping.
- Clean: `go vet`, `go test -race ./pkg/simulator/` and staticcheck 0.8.1. Passing: `npm test` and `svelte-check --fail-on-warnings`.
- The `simulator` scene now shows a Linux server, a Catalyst and a UPS, checked in both themes.
