### PR TITLE
Test SnmpLens against its own simulator, across features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,12 +88,16 @@ does and reporting them takes the count from 8 to 82; and `const`, which cannot 
 NOT exempt — props are the state most likely to arrive after the first render, and forgetting that
 `ExportNamedDeclaration` wraps the declaration hid half of them.
 
-Two tests in `pkg/monitor` talk to a real agent and skip unless you point them at one:
-
-```bash
-python tools/snmp_test_agent.py --port 11611 --no-traps
-SNMPLENS_TEST_AGENT=127.0.0.1:11611 go test ./pkg/monitor/ -run Integration -v
-```
+The integration tests talk to a real agent — the simulator, run in-process by `pkg/simulator/simtest` — so they
+run on every build and every platform. They used to need the Python agent and `SNMPLENS_TEST_AGENT`, and in
+practice ran nowhere. `pkg/monitor`'s poll a simulated server, and a 32-bit counter that wraps every two seconds
+to prove the delta goes through the wrap; `pkg/snmp`'s run every operation and a discovery scan against simulated
+devices. `app_integration_test.go` follows one thing through several features at once: a model identified, a
+preset bound and polled with every OID answered; a band crossed, journalled and delivered to a webhook; a device
+going down and coming back; a switch's notifications in every version, journalled as coming from the switch and
+routed; a request SnmpLens sends with the wrong community coming back as the device's authenticationFailure; a v3
+session outliving the device's restart. What a feature does on its own is tested beside it — these are for the
+seams between features, which no package owns.
 
 Beyond that, correctness is verified by the build + `go vet` + `staticcheck` passing, and by manual testing
 against the bundled Python SNMP simulator:

--- a/app_integration_test.go
+++ b/app_integration_test.go
@@ -1,0 +1,482 @@
+package main
+
+// SnmpLens against its own simulator, one thing followed through several
+// features at once: a device identified, a preset bound to it and polled; a
+// threshold crossed, journalled and delivered to a webhook; a device going down
+// and coming back; its notifications journalled and routed; a request it
+// refuses coming back as a trap; a v3 session outliving the device's restart.
+//
+// Each feature has its own tests. These are for the seams between them, which
+// no single package owns and which only a real agent on the other side of a real
+// socket exercises.
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/events"
+	"SnmpLens/pkg/monitor"
+	"SnmpLens/pkg/notify"
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
+	"SnmpLens/pkg/snmp"
+	"SnmpLens/pkg/storage"
+)
+
+const liveUptime = "1.3.6.1.2.1.1.3.0"
+
+var liveUser = snmp.V3Params{User: "ops", SecLevel: "AuthPriv",
+	AuthProto: "SHA256", AuthPass: "authpass-1", PrivProto: "AES", PrivPass: "privpass-1"}
+
+var liveSimUser = simulator.User{Name: "ops", SecLevel: "AuthPriv",
+	AuthProto: "SHA256", AuthPass: "authpass-1", PrivProto: "AES", PrivPass: "privpass-1"}
+
+// liveApp is an App wired as startup wires it — the poll clock persisting and
+// evaluating, the event router, the notification dispatcher, the simulator, and
+// a headless SNMP client journalling what it hears — with no window.
+type liveApp struct {
+	*App
+	presets string
+
+	mu     sync.Mutex
+	points []monitor.Point
+}
+
+func newLiveApp(t *testing.T) *liveApp {
+	t.Helper()
+	a, presetDir := newBindApp(t)
+	l := &liveApp{App: a, presets: presetDir}
+
+	// Headless: a client whose context the Wails runtime did not issue ends the
+	// process the first time it emits, which a received trap does.
+	//lint:ignore SA1012 a nil context is how pkg/snmp tells a headless client
+	a.snmpClient = snmp.NewClient(nil)
+	a.snmpClient.SetRecorder(events.RecorderFunc(a.recordEvent))
+	a.trapEngineID = loadTrapEngineID(t.TempDir())
+	a.snmpClient.SetTrapEngineID(a.trapEngineID)
+
+	a.scheduler.StopAll()
+	a.initScheduler()
+	persist := a.scheduler.Persist
+	a.scheduler.Persist = func(p []monitor.Point) {
+		l.mu.Lock()
+		l.points = append(l.points, p...)
+		l.mu.Unlock()
+		persist(p)
+	}
+	t.Cleanup(a.scheduler.StopAll)
+	a.initEvaluator()
+	a.router = newEventRouter(a)
+	a.router.start()
+	t.Cleanup(a.router.stop)
+	a.initDispatcher()
+	t.Cleanup(a.dispatcher.Stop)
+	a.sim = newSimulatorService(t.TempDir())
+	t.Cleanup(a.sim.fleet.StopAll)
+	return l
+}
+
+// await waits until done holds over what session has polled so far.
+func (l *liveApp) await(t *testing.T, session string, within time.Duration, done func([]monitor.Point) bool) []monitor.Point {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		l.mu.Lock()
+		var got []monitor.Point
+		for _, p := range l.points {
+			if p.SessionID == session {
+				got = append(got, p)
+			}
+		}
+		l.mu.Unlock()
+		if done(got) {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d sample(s) in %v, and not the ones awaited: %+v", len(got), within, got)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// awaitEvents waits until done holds over the journal's events matching f.
+func (l *liveApp) awaitEvents(t *testing.T, f events.Filter, within time.Duration, done func([]events.Event) bool) []events.Event {
+	t.Helper()
+	f.Limit = 500
+	deadline := time.Now().Add(within)
+	for {
+		page, err := l.storage.QueryEvents(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if done(page.Items) {
+			return page.Items
+		}
+		if time.Now().After(deadline) {
+			var lines []string
+			for _, e := range page.Items {
+				lines = append(lines, e.Kind+" "+e.Source+" "+e.OID)
+			}
+			t.Fatalf("the journal holds %d matching event(s), and not the ones awaited:\n%s",
+				len(page.Items), strings.Join(lines, "\n"))
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+func some(n int) func([]events.Event) bool {
+	return func(e []events.Event) bool { return len(e) >= n }
+}
+
+// listen starts the application's trap listener, accepting users, and returns
+// its port. It binds on a goroutine of its own, hence the pause the listener's
+// other tests take too.
+func (l *liveApp) listen(t *testing.T, users []snmp.V3Params) int {
+	t.Helper()
+	port := freeUDPPort(t)
+	if _, err := l.snmpClient.StartTrapListener(port, users); err != nil {
+		t.Fatalf("cannot bind a trap listener: %v", err)
+	}
+	t.Cleanup(l.snmpClient.StopTrapListener)
+	time.Sleep(400 * time.Millisecond)
+	return port
+}
+
+func copyPresets(t *testing.T, dir string, files ...string) {
+	t.Helper()
+	for _, f := range files {
+		raw, err := os.ReadFile(filepath.Join("presets", f))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, f), raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// hookServer is a webhook receiver, keeping every body it is sent.
+type hookServer struct {
+	*httptest.Server
+	mu     sync.Mutex
+	bodies []string
+}
+
+func newHookServer(t *testing.T) *hookServer {
+	t.Helper()
+	h := &hookServer{}
+	h.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		h.mu.Lock()
+		h.bodies = append(h.bodies, string(b))
+		h.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(h.Close)
+	return h
+}
+
+// await waits for n bodies containing want.
+func (h *hookServer) await(t *testing.T, n int, want string, within time.Duration) []string {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		h.mu.Lock()
+		var got []string
+		for _, b := range h.bodies {
+			if strings.Contains(b, want) {
+				got = append(got, b)
+			}
+		}
+		total := len(h.bodies)
+		h.mu.Unlock()
+		if len(got) >= n {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d of %d webhook bodies contain %q in %v, want %d", len(got), total, want, within, n)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// route sends the events match selects to a webhook, as an operator sets it up
+// in the settings.
+func (l *liveApp) route(t *testing.T, match notify.RouteMatch) *hookServer {
+	t.Helper()
+	h := newHookServer(t)
+	sink, err := l.NotifySaveSink(notify.SinkConfig{Name: "NOC", Kind: notify.SinkWebhook, Enabled: true,
+		Webhook: notify.WebhookConfig{URL: h.URL}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := l.storage.SaveRoute(notify.Route{Name: "test", Enabled: true, Priority: 1,
+		Match: match, SinkIDs: []string{sink.ID}}); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+// ownAddress is 127.0.0.n where this machine answers on it, 127.0.0.1 where it
+// does not (macOS without aliases): a device on an address of its own is how
+// the journal's source is told from the listener's own.
+func ownAddress(n int) string {
+	address := "127.0.0." + string(rune('0'+n/10)) + string(rune('0'+n%10))
+	c, err := net.ListenPacket("udp", net.JoinHostPort(address, "0"))
+	if err != nil {
+		return "127.0.0.1"
+	}
+	c.Close()
+	return address
+}
+
+// Every model is identified as what it is, the preset written for it comes
+// first, each preset it feeds binds — discovery included, through a target
+// naming its port — and the first round of polling answers every OID the preset
+// asks for. A healthy device raises none of the bands those presets carry.
+func TestSnmpLensIdentifiesBindsAndPollsEachSimulatedModel(t *testing.T) {
+	bundled := []string{"interfaces.json", "host-resources.json", "switch-drawing.json",
+		"switch-ports.json", "cisco-generic.json", "ups.json"}
+	for _, c := range []struct {
+		model   string
+		presets []string
+		first   string // the preset that claims the device, if one does
+	}{
+		{"linux-server", []string{"interfaces.json", "host-resources.json"}, ""},
+		{"windows-server", []string{"host-resources.json"}, ""},
+		{"cisco-catalyst-24", []string{"switch-drawing.json", "switch-ports.json", "cisco-generic.json"}, "cisco-generic.json"},
+		{"cisco-isr-4331", []string{"cisco-generic.json"}, "cisco-generic.json"},
+		{"synology-nas", []string{"host-resources.json"}, ""},
+		{"apc-smart-ups", []string{"ups.json"}, ""},
+	} {
+		t.Run(c.model, func(t *testing.T) {
+			l := newLiveApp(t)
+			copyPresets(t, l.presets, bundled...)
+			d := simtest.Start(t, simulator.Device{Model: c.model, Name: "dev-" + c.model})
+
+			id := l.IdentifyDevice(snmp.TestRequest{Target: d.Target(), Community: "public", Version: "v2c", Timeout: 2})
+			if id.Error != "" || id.SysName != d.Name {
+				t.Fatalf("identified as %+v", id)
+			}
+			switch {
+			case c.first != "" && (id.Matched < 1 || id.Presets[0].File != c.first):
+				t.Errorf("%d preset(s) claim it and %q comes first; want %s first", id.Matched, id.Presets[0].File, c.first)
+			case c.first == "" && id.Matched != 0:
+				t.Errorf("%d preset(s) claim a device none is written for", id.Matched)
+			}
+
+			for _, file := range c.presets {
+				sess, err := l.PresetBind(file, d.Target(), "v2c", MonitorConnection{TimeoutSec: 2, Retries: 1, Community: "public"})
+				if err != nil {
+					t.Fatalf("%s: %v", file, err)
+				}
+				oids := strings.Split(sess.OID, ",")
+				round := l.await(t, sess.ID, 10*time.Second, func(p []monitor.Point) bool { return len(p) >= len(oids) })
+				for _, p := range round[:len(oids)] {
+					if p.Error != "" {
+						t.Errorf("%s: %s answered %q", file, p.OID, p.Error)
+					}
+				}
+				opened, err := l.storage.QueryEvents(events.Filter{Kinds: []string{events.KindThresholdOpened}, SessionID: sess.ID})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(opened.Items) != 0 {
+					t.Errorf("%s: a healthy %s raised %s", file, c.model, opened.Items[0].Summary)
+				}
+			}
+		})
+	}
+}
+
+// A band crossed on a simulated device is journalled, routed and delivered: the
+// processor load of the Linux model swings from 4 to 55 %, and the band allows 1.
+func TestAThresholdOnASimulatedDeviceReachesAWebhook(t *testing.T) {
+	l := newLiveApp(t)
+	hook := l.route(t, notify.RouteMatch{Kinds: []string{events.KindThresholdOpened}})
+	d := simtest.Start(t, simulator.Device{})
+
+	const load = "1.3.6.1.2.1.25.3.3.1.2.196608"
+	limit := 1.0
+	id, err := l.MonitorCreateSession(load, []string{d.Target()}, 300, "v2c",
+		map[string]*storage.Thresholds{load: {Max: &limit, AlertEnabled: true}},
+		"CPU", MonitorConnection{TimeoutSec: 2, Community: "public"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.MonitorStart(id); err != nil {
+		t.Fatal(err)
+	}
+
+	opened := l.awaitEvents(t, events.Filter{Kinds: []string{events.KindThresholdOpened}, SessionID: id}, 10*time.Second, some(1))
+	if opened[0].OID != load {
+		t.Errorf("the incident is about %q, not the processor load", opened[0].OID)
+	}
+	hook.await(t, 1, events.KindThresholdOpened, 10*time.Second)
+}
+
+// A device that stops answering is journalled as down, and as up again once it
+// is back.
+func TestASimulatedDeviceGoingDownAndComingBackIsJournalled(t *testing.T) {
+	l := newLiveApp(t)
+	d := simtest.Start(t, simulator.Device{})
+	id, err := l.MonitorCreateSession(liveUptime, []string{d.Target()}, 300, "v2c", nil, "uptime",
+		MonitorConnection{TimeoutSec: 1, Community: "public"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.MonitorStart(id); err != nil {
+		t.Fatal(err)
+	}
+	l.await(t, id, 8*time.Second, func(p []monitor.Point) bool { return len(p) > 0 && p[len(p)-1].Error == "" })
+
+	d.Stop()
+	l.awaitEvents(t, events.Filter{Kinds: []string{events.KindReachabilityDown}, SessionID: id}, 15*time.Second, some(1))
+	d.Restart()
+	l.awaitEvents(t, events.Filter{Kinds: []string{events.KindReachabilityUp}, SessionID: id}, 15*time.Second, some(1))
+}
+
+// A simulated switch's notifications, in every version, reach the journal as
+// coming from the switch, and a route on the switch's address delivers them.
+// It sends coldStart when it starts, and ciscoConfigManEvent on request —
+// SNMPv1, v2c, a v3 trap as the switch's own engine, and a v3 INFORM to the
+// engine ID the listener stands for, acknowledged.
+func TestASimulatedSwitchsNotificationsAreJournalledAndRouted(t *testing.T) {
+	l := newLiveApp(t)
+	address := ownAddress(21)
+	hook := l.route(t, notify.RouteMatch{Categories: []string{events.CategoryTrap}, Sources: []string{address + "/32"}})
+	port := l.listen(t, []snmp.V3Params{liveUser})
+
+	to := func(version string, inform bool) simulator.Destination {
+		dest := simulator.Destination{Host: "127.0.0.1", Port: port, Version: version, Inform: inform}
+		if version == "v3" {
+			dest.User = "ops"
+			if inform {
+				dest.EngineID = l.TrapListenerEngineID()
+			}
+		} else {
+			dest.Community = "traps"
+		}
+		return dest
+	}
+	saved, err := l.SimulatorSaveDevice(simulator.Device{
+		Name: "sw-traps", Model: "cisco-catalyst-24", Address: address, Port: simtest.FreePort(t, address),
+		Versions: []string{"v2c", "v3"}, Community: "public", Users: []simulator.User{liveSimUser},
+		Traps: simulator.Traps{OnStart: true, Destinations: []simulator.Destination{
+			to("v1", false), to("v2c", false), to("v3", false), to("v3", true),
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.SimulatorStartDevice(saved.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	const coldStart = ".1.3.6.1.6.3.1.1.5.1"
+	fromSwitch := events.Filter{Categories: []string{events.CategoryTrap}, Source: address}
+	l.awaitEvents(t, fromSwitch, 10*time.Second, func(e []events.Event) bool { return countOID(e, coldStart) >= 3 })
+
+	deliveries, err := l.SimulatorSendTrap(saved.ID, "ciscoConfigManEvent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range deliveries {
+		if d.Error != "" || d.Inform != d.Acknowledged {
+			t.Errorf("%s: %+v", d.Destination, d)
+		}
+	}
+
+	const configChange = ".1.3.6.1.4.1.9.9.43.2.0.1"
+	got := l.awaitEvents(t, fromSwitch, 10*time.Second, func(e []events.Event) bool {
+		return countOID(e, configChange) >= 3 && countOID(e, ".1.3.6.1.4.1.9.9.43.2") >= 4
+	})
+	informs := 0
+	for _, e := range got {
+		if e.Source != address {
+			t.Errorf("journalled as coming from %q, not from the switch's %s", e.Source, address)
+		}
+		if e.Kind == events.KindTrapInform && e.OID == configChange {
+			informs++
+		}
+	}
+	if informs != 1 {
+		t.Errorf("%d INFORM(s) journalled for the configuration change, want 1", informs)
+	}
+	// SNMPv1 carries no snmpTrapOID: its trap is journalled under its
+	// enterprise, the CISCO-CONFIG-MAN-MIB's notification prefix.
+	if n := countOID(got, ".1.3.6.1.4.1.9.9.43.2") - countOID(got, configChange); n != 1 {
+		t.Errorf("%d SNMPv1 configuration change(s) journalled, want 1", n)
+	}
+	hook.await(t, 8, address, 10*time.Second)
+}
+
+func countOID(e []events.Event, prefix string) int {
+	n := 0
+	for _, x := range e {
+		if strings.HasPrefix(x.OID, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// A request the device refuses — SnmpLens asking with the wrong community — comes
+// back as the device's authenticationFailure, journalled.
+func TestARefusedRequestComesBackAsAuthenticationFailure(t *testing.T) {
+	l := newLiveApp(t)
+	port := l.listen(t, nil)
+	d := simtest.Start(t, simulator.Device{Traps: simulator.Traps{OnAuthFailure: true,
+		Destinations: []simulator.Destination{{ID: "nms", Host: "127.0.0.1", Port: port, Version: "v2c", Community: "public"}}}})
+
+	res := l.snmpClient.Get([]string{d.Target()}, liveUptime, "not-the-community", "v2c", 0, 1, 0, snmp.V3Params{})
+	if len(res) != 1 || res[0].Error == "" {
+		t.Fatalf("a wrong community was answered: %+v", res)
+	}
+	l.awaitEvents(t, events.Filter{Categories: []string{events.CategoryTrap}, OID: ".1.3.6.1.6.3.1.1.5.5"},
+		10*time.Second, some(1))
+}
+
+// An SNMPv3 session keeps polling a device that restarts: the device comes back
+// one boot later with its clock started over, says so with coldStart, and the
+// session's next readings are the new uptime rather than failures.
+func TestAV3SessionOutlivesTheDevicesRestart(t *testing.T) {
+	l := newLiveApp(t)
+	port := l.listen(t, nil)
+	d := simtest.Start(t, simulator.Device{Versions: []string{"v3"}, Users: []simulator.User{liveSimUser},
+		Traps: simulator.Traps{OnStart: true, Destinations: []simulator.Destination{
+			{ID: "nms", Host: "127.0.0.1", Port: port, Version: "v2c", Community: "public"}}}})
+
+	id, err := l.MonitorCreateSession(liveUptime, []string{d.Target()}, 300, "v3", nil, "v3 uptime",
+		MonitorConnection{TimeoutSec: 1, Retries: 1, V3: liveUser})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := l.MonitorStart(id); err != nil {
+		t.Fatal(err)
+	}
+	up := func(p []monitor.Point, atLeast float64) bool {
+		n := len(p)
+		return n > 0 && p[n-1].Error == "" && p[n-1].Value != nil && *p[n-1].Value >= atLeast
+	}
+	before := l.await(t, id, 8*time.Second, func(p []monitor.Point) bool { return up(p, 100) })
+	last := *before[len(before)-1].Value
+
+	d.Restart()
+	after := l.await(t, id, 10*time.Second, func(p []monitor.Point) bool {
+		return len(p) > len(before) && up(p, 0) && *p[len(p)-1].Value < last
+	})
+	if n := len(after); after[n-1].Error != "" {
+		t.Errorf("the session's last reading failed: %s", after[n-1].Error)
+	}
+	l.awaitEvents(t, events.Filter{Categories: []string{events.CategoryTrap}, OID: ".1.3.6.1.6.3.1.1.5.1"},
+		10*time.Second, some(2))
+}

--- a/app_presetdiscover_test.go
+++ b/app_presetdiscover_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"net"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
 
 	"SnmpLens/pkg/preset"
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
 )
 
 // A preset that discovers its ports, of the shape the shipped ones now have:
@@ -81,16 +82,12 @@ func TestAPresetWithoutDiscoveryIsNeverWalked(t *testing.T) {
 	}
 }
 
-// The whole of discovery against a real agent: bind, and the session polls the
-// interfaces the equipment actually has, named as it names them.
-//
-// Skipped unless you point it at the bundled simulator, the way pkg/monitor's
-// integration tests are:
-//
-//	python tools/snmp_test_agent.py --port 11611 --no-traps
-//	SNMPLENS_TEST_AGENT=127.0.0.1:11611 go test . -run Integration -v
+// The whole of discovery against a real agent — the simulator, run in-process:
+// bind, and the session polls the interfaces the equipment actually has, named
+// as it names them.
 func TestPresetDiscoveryIntegration(t *testing.T) {
-	host, port := testAgent(t)
+	d := simtest.Start(t, simulator.Device{})
+	host, port := d.Address, d.Port
 	a, dir := newBindApp(t)
 	putPreset(t, dir, "ports.json", discoveringPreset)
 
@@ -146,24 +143,6 @@ func TestPresetDiscoveryIntegration(t *testing.T) {
 			t.Errorf("%s is labelled %q, which is an index rather than a name", oid, label)
 		}
 	}
-}
-
-// testAgent reads SNMPLENS_TEST_AGENT, the variable CLAUDE.md documents.
-func testAgent(t *testing.T) (string, int) {
-	t.Helper()
-	addr := os.Getenv("SNMPLENS_TEST_AGENT")
-	if addr == "" {
-		t.Skip("set SNMPLENS_TEST_AGENT=127.0.0.1:11611 to run against the bundled simulator")
-	}
-	host, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("SNMPLENS_TEST_AGENT must be host:port, got %q: %v", addr, err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatalf("bad port in SNMPLENS_TEST_AGENT: %v", err)
-	}
-	return host, port
 }
 
 // closedUDPPort returns a loopback UDP port nothing is listening on.

--- a/pkg/monitor/integration_test.go
+++ b/pkg/monitor/integration_test.go
@@ -1,60 +1,44 @@
 package monitor_test
 
-// Integration check for the Go poll clock against a REAL SNMP agent.
+// Integration checks for the Go poll clock against a real SNMP agent: the
+// simulator the application ships, run in-process (pkg/simulator/simtest), so
+// they run wherever the unit tests do instead of skipping for want of an agent.
 //
 // The unit tests in this package drive the scheduler with a stub fetcher, which
 // proves the clock and the derived maths but says nothing about whether the
-// thing actually talks to an agent. This test closes that gap using the bundled
-// simulator, the same way the SNMPv3 fix was verified rather than assumed.
-//
-// It is skipped unless SNMPLENS_TEST_AGENT points at a running simulator:
-//
-//	python tools/snmp_test_agent.py --port 11611 --no-traps
-//	SNMPLENS_TEST_AGENT=127.0.0.1:11611 go test ./pkg/monitor/ -run Integration -v
+// thing actually talks to an agent. These close that gap, against counters that
+// move and wrap the way a device's do.
 
 import (
 	"context"
-	"net"
-	"os"
-	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"SnmpLens/pkg/monitor"
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
 	"SnmpLens/pkg/snmp"
+
+	"github.com/gosnmp/gosnmp"
 )
 
-// sysUpTime is a TimeTicks counter that always moves, which makes it the one
-// OID guaranteed to produce a non-zero delta between two polls.
-const sysUpTime = "1.3.6.1.2.1.1.3.0"
+const (
+	// sysUpTime is a TimeTicks counter that always moves, which makes it the
+	// one OID guaranteed to produce a non-zero delta between two polls.
+	sysUpTime = "1.3.6.1.2.1.1.3.0"
+	// eth0HCIn is ifHCInOctets of the Linux model's eth0: a Counter64 moving
+	// at about 1.25 MB/s, between 0.4 and 1.6 times that.
+	eth0HCIn = "1.3.6.1.2.1.31.1.1.1.6.2"
+)
 
-func agentAddr(t *testing.T) (string, int) {
-	t.Helper()
-	addr := os.Getenv("SNMPLENS_TEST_AGENT")
-	if addr == "" {
-		t.Skip("set SNMPLENS_TEST_AGENT=host:port to run against the bundled simulator")
-	}
-	host, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("SNMPLENS_TEST_AGENT must be host:port, got %q: %v", addr, err)
-	}
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		t.Fatalf("bad port in SNMPLENS_TEST_AGENT: %v", err)
-	}
-	return host, port
-}
-
-func TestIntegrationSchedulerPollsARealAgent(t *testing.T) {
-	host, port := agentAddr(t)
-
+// fetcher polls as the application does (app_monitor.go, buildFetch): GetMany,
+// one connection per target and every OID in one PDU.
+func fetcher(port int) monitor.FetchFunc {
 	client := snmp.NewClient(context.Background())
-	// GetMany, which is what the scheduler drives in production: one
-	// connection per target with every OID in one PDU, against a real agent.
-	fetch := func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
+	return func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
 		out := []monitor.Reading{}
-		for _, m := range client.GetMany(ctx, targets, oids, "public", "v2c", port, 2, 1, snmp.V3Params{}) {
+		for _, m := range client.GetMany(ctx, targets, oids, "public", "v2c", port, 1, 0, snmp.V3Params{}) {
 			for _, oid := range oids {
 				reading := monitor.Reading{
 					Target: m.Target, OID: oid,
@@ -62,18 +46,7 @@ func TestIntegrationSchedulerPollsARealAgent(t *testing.T) {
 				}
 				if r := m.Results[oid]; r != nil {
 					reading.SnmpType = r.Type
-					switch v := r.Value.(type) {
-					case uint32:
-						f := float64(v)
-						reading.Value = &f
-					case int:
-						f := float64(v)
-						reading.Value = &f
-					case int64:
-						f := float64(v)
-						reading.Value = &f
-					case uint64:
-						f := float64(v)
+					if f, ok := number(r.Value); ok {
 						reading.Value = &f
 					}
 				}
@@ -82,117 +55,205 @@ func TestIntegrationSchedulerPollsARealAgent(t *testing.T) {
 		}
 		return out
 	}
-
-	var mu sync.Mutex
-	var points []monitor.Point
-
-	s := monitor.NewScheduler()
-	s.Persist = func(p []monitor.Point) {
-		mu.Lock()
-		defer mu.Unlock()
-		points = append(points, p...)
-	}
-
-	s.Start(monitor.SessionSpec{
-		ID: "integration", OIDs: []string{sysUpTime}, Targets: []string{host},
-		Interval: 400 * time.Millisecond, Fetch: fetch,
-	})
-	defer s.StopAll()
-
-	deadline := time.Now().Add(8 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(points)
-		mu.Unlock()
-		if n >= 3 {
-			break
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	mu.Lock()
-	got := append([]monitor.Point(nil), points...)
-	mu.Unlock()
-
-	if len(got) < 3 {
-		t.Fatalf("only %d samples in 8s; is the simulator running on %s:%d?", len(got), host, port)
-	}
-	for i, p := range got {
-		if p.Error != "" {
-			t.Fatalf("sample %d returned an error: %s", i, p.Error)
-		}
-		if p.Value == nil {
-			t.Fatalf("sample %d has no value; sysUpTime must parse as a number", i)
-		}
-	}
-	// The very first sample has nothing to compare against; every later one
-	// must carry a derived delta and rate, which is the whole reason the clock
-	// moved into Go.
-	if got[1].Delta == nil || *got[1].Delta <= 0 {
-		t.Errorf("second sample delta = %v, want a positive value", got[1].Delta)
-	}
-	if got[1].Rate == nil || *got[1].Rate <= 0 {
-		t.Errorf("second sample rate = %v, want a positive value", got[1].Rate)
-	}
-	if got[0].SnmpType == "" {
-		t.Error("the SNMP type was not carried through; delta correction depends on it")
-	}
-	t.Logf("%d samples, type=%s, delta=%v rate=%v/s", len(got), got[0].SnmpType, *got[1].Delta, *got[1].Rate)
 }
 
-// An unreachable target must produce recorded failures rather than silence:
-// that is what reachability alerting is built on.
-func TestIntegrationUnreachableTargetIsRecorded(t *testing.T) {
-	_, port := agentAddr(t)
+func number(v any) (float64, bool) {
+	switch n := v.(type) {
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	}
+	return 0, false
+}
 
-	client := snmp.NewClient(context.Background())
-	fetch := func(ctx context.Context, oids []string, targets []string) []monitor.Reading {
-		out := []monitor.Reading{}
-		for _, m := range client.GetMany(ctx, targets, oids, "public", "v2c", port, 1, 0, snmp.V3Params{}) {
-			for _, oid := range oids {
-				out = append(out, monitor.Reading{Target: m.Target, OID: oid, Error: m.Errors[oid]})
-			}
+// collector keeps what a scheduler persists.
+type collector struct {
+	mu     sync.Mutex
+	points []monitor.Point
+}
+
+func (c *collector) persist(p []monitor.Point) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.points = append(c.points, p...)
+}
+
+// of is every point kept so far for oid.
+func (c *collector) of(oid string) []monitor.Point {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var out []monitor.Point
+	for _, p := range c.points {
+		if p.OID == oid {
+			out = append(out, p)
 		}
-		return out
 	}
+	return out
+}
 
-	var mu sync.Mutex
-	var points []monitor.Point
-	s := monitor.NewScheduler()
-	s.Persist = func(p []monitor.Point) {
-		mu.Lock()
-		defer mu.Unlock()
-		points = append(points, p...)
-	}
-
-	// 192.0.2.0/24 is TEST-NET-1: reserved for documentation, so it is
-	// guaranteed not to answer.
-	s.Start(monitor.SessionSpec{
-		ID: "unreachable", OIDs: []string{sysUpTime}, Targets: []string{"192.0.2.1"},
-		Interval: 500 * time.Millisecond, Fetch: fetch,
-	})
-	defer s.StopAll()
-
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		mu.Lock()
-		n := len(points)
-		mu.Unlock()
-		if n >= 1 {
-			break
+// await waits until done holds for the points of oid, and returns them.
+func (c *collector) await(t *testing.T, oid string, within time.Duration, done func([]monitor.Point) bool) []monitor.Point {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		got := c.of(oid)
+		if done(got) {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d sample(s) of %s in %v, and not the ones awaited", len(got), oid, within)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
 
-	mu.Lock()
-	defer mu.Unlock()
-	if len(points) == 0 {
-		t.Fatal("an unreachable target produced no sample at all; nothing would ever alert")
+func atLeast(n int) func([]monitor.Point) bool {
+	return func(p []monitor.Point) bool { return len(p) >= n }
+}
+
+// The scheduler polls a simulated server: every sample a value, and from the
+// second on a delta and a rate — the reason the clock moved into Go — including
+// for a 64-bit counter, whose rate is the one the device actually moves at.
+func TestIntegrationSchedulerPollsASimulatedDevice(t *testing.T) {
+	d := simtest.Start(t, simulator.Device{})
+	var c collector
+	s := monitor.NewScheduler()
+	s.Persist = c.persist
+	s.Start(monitor.SessionSpec{
+		ID: "integration", OIDs: []string{sysUpTime, eth0HCIn}, Targets: []string{d.Address},
+		Interval: 400 * time.Millisecond, Fetch: fetcher(d.Port),
+	})
+	defer s.StopAll()
+
+	got := c.await(t, eth0HCIn, 8*time.Second, atLeast(3))
+	for i, p := range got {
+		if p.Error != "" || p.Value == nil {
+			t.Fatalf("sample %d: error %q, value %v", i, p.Error, p.Value)
+		}
 	}
-	if points[0].Error == "" {
-		t.Errorf("expected a recorded error, got %+v", points[0])
+	if got[0].SnmpType != "Counter64" {
+		t.Errorf("the SNMP type came through as %q; delta correction depends on it", got[0].SnmpType)
 	}
-	if points[0].Value != nil {
+	for _, p := range got[1:] {
+		if p.Rate == nil || *p.Rate < 0.3e6 || *p.Rate > 2.5e6 {
+			t.Errorf("eth0 moves at 0.5 to 2 MB/s, and the derived rate is %v", p.Rate)
+		}
+	}
+	up := c.of(sysUpTime)
+	if len(up) < 2 || up[1].Delta == nil || *up[1].Delta <= 0 {
+		t.Errorf("sysUpTime did not advance between two polls: %+v", up)
+	}
+}
+
+// A 32-bit counter wraps, and the scheduler's delta goes through the wrap: never
+// negative, and the rate the one the device counts at. The counter here counts
+// two gigabytes a second from a gigabyte short of the top, so it wraps within
+// half a second of starting and every 2.1 seconds after.
+func TestIntegrationACounterThatWrapsIsCorrected(t *testing.T) {
+	const fast = "1.3.6.1.4.1.99999.1.0"
+	a, err := simulator.NewAgent(simulator.Config{
+		Listen: "127.0.0.1:0", Versions: []string{"v2c"}, Community: "public",
+		Objects: []simulator.Object{
+			{OID: sysUpTime, Type: gosnmp.TimeTicks, Value: simulator.Uptime()},
+			{OID: fast, Type: gosnmp.Counter32, Value: simulator.Counter(2e9, 1<<32-1_000_000_000, simulator.Swing{})},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(a.Stop)
+
+	var c collector
+	s := monitor.NewScheduler()
+	s.Persist = c.persist
+	s.Start(monitor.SessionSpec{
+		ID: "wrap", OIDs: []string{fast}, Targets: []string{"127.0.0.1"},
+		Interval: 300 * time.Millisecond, Fetch: fetcher(int(a.Addr().Port())),
+	})
+	defer s.StopAll()
+
+	// Until a sample is below the one before it: the wrap, seen on the wire.
+	got := c.await(t, fast, 10*time.Second, func(p []monitor.Point) bool {
+		for i := 1; i < len(p); i++ {
+			if p[i].Value != nil && p[i-1].Value != nil && *p[i].Value < *p[i-1].Value {
+				return i+1 < len(p) // and one more after it
+			}
+		}
+		return false
+	})
+	for i, p := range got[1:] {
+		if p.Error != "" {
+			t.Fatalf("sample %d: %s", i+1, p.Error)
+		}
+		if p.Delta == nil || *p.Delta <= 0 {
+			t.Errorf("sample %d: delta %v across a wrap; a Counter32 wraps, it does not go back", i+1, p.Delta)
+		}
+		if p.Rate == nil || *p.Rate < 1.5e9 || *p.Rate > 2.5e9 {
+			t.Errorf("sample %d: rate %v, and the counter counts 2e9 a second", i+1, p.Rate)
+		}
+	}
+}
+
+// A device that stops answering produces recorded failures rather than
+// silence — what reachability alerting is built on — and polling picks up
+// again when it comes back, uptime started over.
+func TestIntegrationADeviceThatStopsIsRecordedAndComesBack(t *testing.T) {
+	d := simtest.Start(t, simulator.Device{})
+	var c collector
+	s := monitor.NewScheduler()
+	s.Persist = c.persist
+	s.Start(monitor.SessionSpec{
+		ID: "outage", OIDs: []string{sysUpTime}, Targets: []string{d.Address},
+		Interval: 300 * time.Millisecond, Fetch: fetcher(d.Port),
+	})
+	defer s.StopAll()
+
+	// Up for a second, so a restarted uptime is told apart from a running one.
+	before := c.await(t, sysUpTime, 8*time.Second, func(p []monitor.Point) bool {
+		return len(p) > 0 && p[len(p)-1].Value != nil && *p[len(p)-1].Value >= 100
+	})
+	last := *before[len(before)-1].Value
+
+	d.Stop()
+	c.await(t, sysUpTime, 8*time.Second, func(p []monitor.Point) bool {
+		n := len(p)
+		return n > len(before) && p[n-1].Error != "" && p[n-1].Value == nil
+	})
+
+	d.Restart()
+	after := c.await(t, sysUpTime, 8*time.Second, func(p []monitor.Point) bool {
+		return len(p) > 0 && p[len(p)-1].Error == "" && p[len(p)-1].Value != nil
+	})
+	if again := *after[len(after)-1].Value; again >= last {
+		t.Errorf("uptime %v after the restart, %v before it: the device did not start over", again, last)
+	}
+}
+
+// An address that nothing answers on is a recorded error too, not a hang. Its
+// port is irrelevant: 192.0.2.0/24 is TEST-NET-1, reserved for documentation.
+func TestIntegrationUnreachableTargetIsRecorded(t *testing.T) {
+	var c collector
+	s := monitor.NewScheduler()
+	s.Persist = c.persist
+	s.Start(monitor.SessionSpec{
+		ID: "unreachable", OIDs: []string{sysUpTime}, Targets: []string{"192.0.2.1"},
+		Interval: 500 * time.Millisecond, Fetch: fetcher(161),
+	})
+	defer s.StopAll()
+
+	got := c.await(t, sysUpTime, 10*time.Second, atLeast(1))
+	if got[0].Error == "" {
+		t.Errorf("expected a recorded error, got %+v", got[0])
+	}
+	if got[0].Value != nil {
 		t.Error("a failed poll must not carry a value")
 	}
 }

--- a/pkg/simulator/simtest/simtest.go
+++ b/pkg/simulator/simtest/simtest.go
@@ -1,0 +1,133 @@
+// Package simtest runs simulated devices for the length of a test, so that a
+// test in any package talks to a real SNMP agent — the one the application
+// ships — instead of skipping for want of one.
+//
+// It is for tests only. pkg/simulator's own tests cannot use it: it imports
+// pkg/simulator, and the cycle would not build.
+package simtest
+
+import (
+	"net"
+	"strconv"
+	"testing"
+
+	"SnmpLens/pkg/simulator"
+)
+
+// Device is a simulated device that runs until its test ends.
+type Device struct {
+	simulator.Device
+	fleet *simulator.Fleet
+	t     testing.TB
+}
+
+// Start runs d, filling in what a test does not care about: an ID and a name,
+// the Linux server model, v2c with the community "public", 127.0.0.1 at a free
+// port, and the model's engine ID. A port that is found free can be taken
+// before the device binds it — `go test ./...` runs every package at once — so
+// a failed bind tries another, unless d names its own port.
+func Start(t testing.TB, d simulator.Device) *Device {
+	t.Helper()
+	if d.Model == "" {
+		d.Model = "linux-server"
+	}
+	if d.ID == "" {
+		d.ID = simulator.NewDeviceID()
+	}
+	if d.Name == "" {
+		d.Name = "sim-" + d.ID[:6]
+	}
+	if len(d.Versions) == 0 {
+		d.Versions = []string{"v2c"}
+	}
+	if d.Community == "" {
+		d.Community = "public"
+	}
+	if d.Address == "" {
+		d.Address = "127.0.0.1"
+	}
+	if d.EngineID == "" {
+		id, err := simulator.NewEngineID(d.Model, d.ID)
+		if err != nil {
+			t.Fatalf("simtest: %v", err)
+		}
+		d.EngineID = id
+	}
+	if d.EngineBoots == 0 {
+		d.EngineBoots = 1
+	}
+	s := &Device{Device: d, fleet: simulator.NewFleet(), t: t}
+	t.Cleanup(s.fleet.StopAll)
+
+	fixed := d.Port != 0
+	var err error
+	for attempt := 0; attempt < 5; attempt++ {
+		if !fixed {
+			s.Port = FreePort(t, d.Address)
+		}
+		if err = s.fleet.Start(s.Device); err == nil || fixed {
+			break
+		}
+	}
+	if err != nil {
+		t.Fatalf("simtest: the %s device would not start on %s: %v", d.Model, s.Target(), err)
+	}
+	return s
+}
+
+// Target is the device as a target is written in SnmpLens: "127.0.0.1:1161".
+func (d *Device) Target() string {
+	return net.JoinHostPort(d.Address, strconv.Itoa(d.Port))
+}
+
+// Stop stops the device. It answers nothing until Restart.
+func (d *Device) Stop() { d.fleet.Stop(d.ID) }
+
+// Restart starts the device again on the same address and port, one boot
+// later, as a device coming back from a reboot does: its uptime starts over,
+// and a manager holding its SNMPv3 clock has to resynchronise.
+func (d *Device) Restart() {
+	d.t.Helper()
+	d.fleet.Stop(d.ID)
+	d.EngineBoots++
+	if err := d.fleet.Start(d.Device); err != nil {
+		d.t.Fatalf("simtest: the device would not start again: %v", err)
+	}
+}
+
+// Notify has the device send the notification named name now.
+func (d *Device) Notify(name string) ([]simulator.Delivery, error) {
+	return d.fleet.Notify(d.ID, name)
+}
+
+// Stats is what the device has counted since it last started.
+func (d *Device) Stats() simulator.Stats {
+	s, _ := d.fleet.Status(d.ID)
+	return s
+}
+
+// FreePort is a UDP port nothing holds on address, at the moment of asking.
+func FreePort(t testing.TB, address string) int {
+	t.Helper()
+	c, err := net.ListenPacket("udp", net.JoinHostPort(address, "0"))
+	if err != nil {
+		t.Skipf("simtest: no UDP socket on %s: %v", address, err)
+	}
+	defer c.Close()
+	return c.LocalAddr().(*net.UDPAddr).Port
+}
+
+// OwnAddress is 127.0.0.n when this machine answers on it — Windows and Linux
+// answer on the whole of 127.0.0.0/8, macOS on 127.0.0.1 alone unless aliases
+// were added — and skips the test otherwise. A device on an address of its own
+// is how a test tells its traffic from anything else on 127.0.0.1.
+func OwnAddress(t testing.TB, n int) string {
+	t.Helper()
+	address := "127.0.0." + strconv.Itoa(n)
+	c, err := net.ListenPacket("udp", net.JoinHostPort(address, "0"))
+	if err != nil {
+		t.Skipf("simtest: this machine does not answer on %s", address)
+	}
+	c.Close()
+	return address
+}

--- a/pkg/snmp/debuglog_test.go
+++ b/pkg/snmp/debuglog_test.go
@@ -2,11 +2,13 @@ package snmp
 
 import (
 	"context"
-	"net"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
 
 	"github.com/gosnmp/gosnmp"
 )
@@ -149,28 +151,20 @@ func TestScrubRedactsRawPacketDumps(t *testing.T) {
 	}
 }
 
-// End to end against the bundled simulator, when one is pointed at.
+// End to end against the simulator the application ships, run in-process.
 //
-// SNMPLENS_TEST_AGENT is the variable CLAUDE.md documents for exactly this;
-// an earlier version invented SNMPLENS_AGENT_PORT, which nothing sets, so the
-// only test of the production path never ran anywhere.
+// It used to need an external agent named by SNMPLENS_TEST_AGENT, and before
+// that by SNMPLENS_AGENT_PORT, which nothing set: the only test of the
+// production path never ran anywhere. Now it runs on every CI build.
 func TestDebugLogNeverHoldsTheCommunity(t *testing.T) {
-	addr := os.Getenv("SNMPLENS_TEST_AGENT")
-	if addr == "" {
-		t.Skip("set SNMPLENS_TEST_AGENT=127.0.0.1:11611 to run against the simulator")
-	}
-	_, portStr, err := net.SplitHostPort(addr)
-	if err != nil {
-		t.Fatalf("SNMPLENS_TEST_AGENT: %v", err)
-	}
-	port, _ := strconv.Atoi(portStr)
+	const community = "s3cr3t-community"
+	d := simtest.Start(t, simulator.Device{Community: community})
 
 	c := NewClient(context.Background())
 	c.SetDebugMode(true)
 	defer c.SetDebugMode(false)
 
-	const community = "s3cr3t-community"
-	c.Get([]string{"127.0.0.1"}, "1.3.6.1.2.1.1.1.0", community, "v2c", port, 2, 0, V3Params{})
+	c.Get([]string{d.Address}, "1.3.6.1.2.1.1.1.0", community, "v2c", d.Port, 2, 0, V3Params{})
 
 	entries := c.GetDebugLog()
 	if len(entries) == 0 {

--- a/pkg/snmp/discovery.go
+++ b/pkg/snmp/discovery.go
@@ -53,14 +53,14 @@ func (c *Client) Discover(cidr, community, version string, port, timeoutSec int,
 				result.Error = err.Error()
 				result.ResponseTime = time.Since(start).Milliseconds()
 				resultsChan <- result
-				runtime.EventsEmit(c.ctx, "discoveryProgress", map[string]interface{}{"current": index + 1, "total": total, "ip": ipAddr})
+				c.discoveryProgress(index+1, total, ipAddr)
 				return
 			}
 			if err = g.Connect(); err != nil {
 				result.Error = fmt.Sprintf("connect failed: %v", err)
 				result.ResponseTime = time.Since(start).Milliseconds()
 				resultsChan <- result
-				runtime.EventsEmit(c.ctx, "discoveryProgress", map[string]interface{}{"current": index + 1, "total": total, "ip": ipAddr})
+				c.discoveryProgress(index+1, total, ipAddr)
 				return
 			}
 			defer g.Conn.Close()
@@ -77,7 +77,7 @@ func (c *Client) Discover(cidr, community, version string, port, timeoutSec int,
 			if err != nil {
 				result.Error = fmt.Sprintf("get failed: %v", err)
 				resultsChan <- result
-				runtime.EventsEmit(c.ctx, "discoveryProgress", map[string]interface{}{"current": index + 1, "total": total, "ip": ipAddr})
+				c.discoveryProgress(index+1, total, ipAddr)
 				return
 			}
 
@@ -96,7 +96,7 @@ func (c *Client) Discover(cidr, community, version string, port, timeoutSec int,
 				}
 			}
 			resultsChan <- result
-			runtime.EventsEmit(c.ctx, "discoveryProgress", map[string]interface{}{"current": index + 1, "total": total, "ip": ipAddr})
+			c.discoveryProgress(index+1, total, ipAddr)
 		}(ip, i)
 	}
 
@@ -111,6 +111,16 @@ func (c *Client) Discover(cidr, community, version string, port, timeoutSec int,
 		return compareIPs(results[i].IP, results[j].IP)
 	})
 	return results
+}
+
+// discoveryProgress tells a window how far a scan has got. Only a window: the
+// Wails runtime refuses a context it did not issue and ends the process, so a
+// client without one — a test, a headless run — scans without saying so, as
+// handleTrap receives without emitting.
+func (c *Client) discoveryProgress(current, total int, ip string) {
+	if c.ctx != nil {
+		runtime.EventsEmit(c.ctx, "discoveryProgress", map[string]interface{}{"current": current, "total": total, "ip": ip})
+	}
 }
 
 // MaxDiscoveryHosts caps a scan.

--- a/pkg/snmp/simulated_test.go
+++ b/pkg/snmp/simulated_test.go
@@ -1,0 +1,88 @@
+package snmp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
+)
+
+// Every operation of the Operations tab against a simulated Catalyst, read
+// back through SnmpLens's own client. The target names its port and the port
+// field says 161: the target's port wins, as it does everywhere.
+func TestTheOperationsAgainstASimulatedSwitch(t *testing.T) {
+	d := simtest.Start(t, simulator.Device{Model: "cisco-catalyst-24", Name: "sw-floor-2"})
+	c := NewClient(context.Background())
+	targets := []string{d.Target()}
+	answer := func(t *testing.T, res []*BulkResult) *Result {
+		t.Helper()
+		if len(res) != 1 || res[0].Error != "" || res[0].Result == nil {
+			t.Fatalf("%+v", res[0])
+		}
+		return res[0].Result
+	}
+
+	t.Run("GET", func(t *testing.T) {
+		r := answer(t, c.Get(targets, "1.3.6.1.2.1.1.5.0", "public", "v2c", 161, 2, 0, V3Params{}))
+		if r.Value != "sw-floor-2" {
+			t.Errorf("sysName = %v", r.Value)
+		}
+	})
+	t.Run("GETNEXT", func(t *testing.T) {
+		r := answer(t, c.GetNext(targets, "1.3.6.1.2.1.1.5.0", "public", "v2c", 161, 2, 0, V3Params{}))
+		if r.Oid != ".1.3.6.1.2.1.1.6.0" || r.Value != "Wiring closet, floor 2" {
+			t.Errorf("after sysName: %s = %v", r.Oid, r.Value)
+		}
+	})
+	t.Run("WALK", func(t *testing.T) {
+		rows, _ := answer(t, c.Walk(targets, "1.3.6.1.2.1.2.2.1.2", "public", "v2c", 161, 2, 0, V3Params{})).Value.([]*Result)
+		// 24 Fast Ethernet ports, two gigabit uplinks and VLAN 1.
+		if len(rows) != 27 || rows[0].Value != "FastEthernet0/1" || rows[26].Value != "Vlan1" {
+			t.Fatalf("walked %d interface(s): %+v", len(rows), rows)
+		}
+	})
+	t.Run("GETBULK", func(t *testing.T) {
+		rows, _ := answer(t, c.GetBulk(targets, "1.3.6.1.2.1.2.2.1.2", "public", "v2c", 161, 2, 0, 0, 10, V3Params{})).Value.([]interface{})
+		if len(rows) != 10 {
+			t.Fatalf("%d row(s) for ten repetitions", len(rows))
+		}
+		if r, _ := rows[9].(*Result); r == nil || r.Value != "FastEthernet0/10" {
+			t.Errorf("the tenth row is %+v", rows[9])
+		}
+	})
+	t.Run("SET", func(t *testing.T) {
+		res := c.Set(targets, "1.3.6.1.2.1.1.5.0", "public", "renamed", "OctetString", "v2c", 161, 2, 0, V3Params{})
+		if len(res) != 1 || !strings.Contains(strings.ToLower(res[0].Error), "notwritable") {
+			t.Errorf("a SET the device refuses came back as %+v", res[0])
+		}
+	})
+}
+
+// A scan of a loopback range finds the simulated devices on it, each named and
+// identified as what it is — the sysObjectID a preset is matched on.
+func TestDiscoveryFindsTheSimulatedDevices(t *testing.T) {
+	server, sw := simtest.OwnAddress(t, 2), simtest.OwnAddress(t, 3)
+	port := simtest.FreePort(t, server)
+	simtest.Start(t, simulator.Device{Address: server, Port: port, Name: "scan-server"})
+	simtest.Start(t, simulator.Device{Address: sw, Port: port, Name: "scan-switch", Model: "cisco-catalyst-24"})
+
+	// Headless: the scan reports its progress to a window only when there is one.
+	//lint:ignore SA1012 a nil context is how this package tells a headless client
+	c := NewClient(nil)
+	found := map[string]DiscoveryResult{}
+	for _, r := range c.Discover("127.0.0.0/29", "public", "v2c", port, 1, V3Params{}) {
+		if r.Reachable {
+			found[r.IP] = r
+		}
+	}
+	for ip, want := range map[string][2]string{
+		server: {"scan-server", ".1.3.6.1.4.1.8072.3.2.10"},
+		sw:     {"scan-switch", ".1.3.6.1.4.1.9.1.716"},
+	} {
+		if r, ok := found[ip]; !ok || r.SysName != want[0] || r.SysObjectID != want[1] {
+			t.Errorf("%s: found %v as %+v, want %s (%s)", ip, ok, r, want[0], want[1])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR tests SnmpLens against its own simulator, following a single case through several features at once.

> **Stacked on #67, which is stacked on #66 and #65.** Until those are merged the diff includes them. This PR's own changes are the last commit.

### The integration tests now run

Before this PR, the integration tests needed the Python agent and `SNMPLENS_TEST_AGENT`, and in practice they ran nowhere. `pkg/simulator/simtest` now starts a simulated device in-process from any package's tests, so they run on every build and on all three platforms.

- `pkg/monitor`:
  - polls a simulated server; the rate derived for a Counter64 matches the rate the device counts at;
  - a 32-bit counter that wraps every two seconds: the delta goes through the wrap and is never negative;
  - a device that stops is recorded as failing, and polling picks up again when it comes back.
- `pkg/snmp`:
  - GET, GETNEXT, WALK, GETBULK and a refused SET against a simulated Catalyst;
  - a discovery scan of a loopback range, which finds the simulated devices by name and sysObjectID;
  - the debug-log scrubbing test now runs instead of skipping.
- The preset-discovery test now runs instead of skipping.

### Across features: `app_integration_test.go`

The App is wired as startup wires it, with no window:
- the poll clock, persisting and evaluating;
- the event router;
- the notification dispatcher;
- the simulator;
- a headless trap listener.

| Scenario | Features crossed |
|---|---|
| Six models are each identified, and the preset written for the model is ranked first. Each preset the model feeds binds (discovery included, through a target that names its port) and polls every OID without error. A healthy device raises none of the preset's bands. | simulator, identification, presets, discovery, polling, thresholds |
| A processor-load band is crossed. | polling, thresholds, journal, routing, webhook |
| A device goes down and comes back. | polling, reachability, journal |
| A switch sends coldStart at start and ciscoConfigManEvent on request, in v1, v2c, v3 and as an acknowledged v3 INFORM. Each notification is journalled as coming from the switch's own address, and a route on that address delivers them. | simulator traps, trap listener (v3 users, engine ID), journal, routing, webhook |
| SnmpLens sends a GET with the wrong community, and it comes back as the device's authenticationFailure. | operations, simulator USM, traps, journal |
| An SNMPv3 session outlives the device's restart: new uptime, no stuck failure, coldStart journalled. | v3 polling, engine boots, traps |

### A fix found on the way

Discovery reported its progress to a window unconditionally, so a client without a window (a headless run, or a test) ended the process on the first host it scanned. It now reports progress only when there is a window, as trap reception already did.

## Verification

- `go test -race` passes on the root package and on `pkg/monitor`, `pkg/snmp` and `pkg/simulator`. The new scenarios take between 0.4 s and 9 s each.
- `go vet` and staticcheck 0.8.1 are clean.
- `CLAUDE.md` describes the integration tests and no longer mentions `SNMPLENS_TEST_AGENT`.
