### PR TITLE
Simulate whole agents, not a handful of OIDs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,6 +632,27 @@ Catalysts and the ISR by their CISCO-PRODUCTS-MIB OIDs, and nothing else. The NA
 net-snmp's Linux sysObjectID because their agent is net-snmp, as most embedded devices' is; their own tables tell
 them apart. The vendor OIDs were read from the MIBs (LibreNMS keeps them), not remembered.
 
+**A model answers a whole agent's walk** (`stack.go`, `bridge.go`, `ucd.go`, `hostres.go`), from about 300 objects
+for the probe to 5 600 for the 48-port Catalyst. A device is described ONCE — its interfaces, addresses, gateway and
+routes, sockets, hardware, bridge ports and VLANs, LLDP neighbours — and every standard MIB is built from that one
+description, so they agree the way a real agent's do: an address sits on an interface ifTable lists, a route leaves
+through one, tcpCurrEstab counts the sessions tcpConnTable lists and hrSystemProcesses the rows of hrSWRunTable, a
+bridge port is an interface and the stations learnt on it sit behind it, a port in ENTITY-MIB points at its interface,
+the ISR's BGP-learnt routes go through the peer BGP4-MIB says is established, over the TCP session on port 179 its
+tcpConnTable lists. IF-MIB is whole — every column of ifTable and ifXTable, a 32-bit counter and its 64-bit twin built
+from the same arguments — and a figure a MIB states twice (memory used and available, a percentage and its parts,
+the two halves of a 64-bit disk size, APC's run time in TimeTicks and UPS-MIB's in minutes) is DERIVED from one reading
+at the same instant rather than drawn twice. `TestTheStandardMIBsAgree` holds the cross-references, and `pkg/mib`'s
+`TestSimulatedTablesDecode` walks every model and decodes every table the bundled MIBs describe with SnmpLens's own
+decoder: an index written any other way than RFC 2578 7.7 reads it back fails there rather than as a table of garbled
+rows. LLDP-MIB lives under 1.0.8802, outside .1.3.6.1, as on a real device — a walk of .1.3.6.1 does not see it.
+
+**What the agent counts is the agent's** (`agentobjects.go`). SNMPv2-MIB's snmp group, and for v3 snmpEngine, the MPD
+and USM statistics and snmpUnknownContexts, are read live from the counters the agent keeps as it answers — the
+request counted on ARRIVAL, as net-snmp does, so a GET of snmpInGetRequests counts itself — through the clock each
+request carries. Every device has them beside its model's objects, so neither a built-in model nor a file somebody
+wrote may answer them; a custom model that tries is refused at import, naming the OID.
+
 **What only a notification carries** (`Object.NotifyOnly`). An iDRAC alert carries eleven objects its MIB makes
 accessible-for-notify (RFC 2578 7.3) — a message ID, the message, the service tag — and no request may read them.
 They are kept beside the tree rather than in it: a GET answers `noSuchObject`, a walk passes them by, and

--- a/README.md
+++ b/README.md
@@ -431,7 +431,9 @@ The simulator's catalogue can be extended with models of your own: a JSON file s
 | `notifyOnly` | An accessible-for-notify object: carried by notifications, never answered to a request |
 | `notifications` | The model's own, beside `coldStart`, `warmStart` and `authenticationFailure`, which every device sends |
 
-A file is checked in full when it is imported — unknown fields, types, ranges, an OID given twice — and a refusal names the field or the OID. The example is `pkg/simulator/testdata/custom-model.json`; 32473 is the enterprise number RFC 5612 reserves for documentation.
+Some OIDs are the agent's own and no model may answer them: SNMPv2-MIB's snmp group on every device, and for SNMPv3 snmpEngine, the MPD and USM statistics and snmpUnknownContexts. They are read live from what the agent counts as it answers — requests, varbinds, a refused community, notifications sent.
+
+A file is checked in full when it is imported — unknown fields, types, ranges, an OID given twice, an OID the agent keeps — and a refusal names the field or the OID. The example is `pkg/simulator/testdata/custom-model.json`; 32473 is the enterprise number RFC 5612 reserves for documentation.
 
 ---
 

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1339,59 +1339,59 @@
     "model": {
       "windows-server": {
         "name": "Windows-Server",
-        "description": "Ein Windows-Server-2022-Host mit seinem SNMP-Dienst: System, zwei Netzwerkadapter, Host-Ressourcen nach Laufwerksbuchstaben. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
+        "description": "Ein Windows-Server-2022-Host mit seinem SNMP-Dienst: Netzwerkkarten und die Pseudo-Schnittstellen von Windows, Adressen, Routen und Sockets (RDP, SMB, IIS), Laufwerke nach Buchstaben, Prozesse und installierte Programme. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
       },
       "cisco-catalyst-24": {
         "name": "Cisco Catalyst 2960, 24 Ports",
-        "description": "Ein Access-Switch: 24 Fast-Ethernet-Ports, zwei Gigabit-Uplinks und VLAN 1, mit CPU-Last und Konfigurationsänderungen von Cisco. Als Cisco erkannt, daher steht das Preset „Cisco (IF-MIB)“ an erster Stelle; passt auch zu „Switch ports“ und „Switch drawing (24 ports)“."
+        "description": "Ein Access-Switch: 24 Fast-Ethernet-Ports, zwei Gigabit-Uplinks und VLAN 1, mit MAC-Adresstabelle, Spanning Tree, VLANs (Q-BRIDGE und VTP), LLDP- und CDP-Nachbarn, Hardware in der ENTITY-MIB sowie Ciscos CPU, Speicher und Umgebung. Als Cisco erkannt, daher steht das Preset „Cisco (IF-MIB)“ an erster Stelle; passt auch zu „Switch ports“ und „Switch drawing (24 ports)“."
       },
       "cisco-catalyst-48": {
         "name": "Cisco Catalyst 2960, 48 Ports",
-        "description": "Derselbe Access-Switch mit 48 Ports. Als Cisco erkannt, daher steht das Preset „Cisco (IF-MIB)“ an erster Stelle; passt auch zu „Switch ports“."
+        "description": "Derselbe Access-Switch mit 48 Ports und allem, was dazugehört. Als Cisco erkannt, daher steht das Preset „Cisco (IF-MIB)“ an erster Stelle; passt auch zu „Switch ports“."
       },
       "cisco-isr-4331": {
         "name": "Cisco-Router ISR 4331",
-        "description": "Ein Filialrouter: WAN-, LAN- und Management-Ports, zwei eBGP-Sitzungen — eine aufgebaut, eine nicht — und die CPU-Last von Cisco. Sendet die BGP-Benachrichtigungen und Konfigurationsänderungen."
+        "description": "Ein Filialrouter: WAN-, LAN- und Management-Ports, zwei eBGP-Sitzungen — eine aufgebaut, eine nicht — und die Routen der ersten, sein ARP-Cache und seine Sockets, Hardware in der ENTITY-MIB sowie Ciscos CPU, Speicher und Umgebung. Sendet die BGP-Benachrichtigungen und Konfigurationsänderungen."
       },
       "synology-nas": {
         "name": "Synology-NAS",
-        "description": "Eine DS920+ mit DSM: Synologys System-, Festplatten- und RAID-Tabellen neben Schnittstellen und Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
+        "description": "Eine DS920+ mit DSM: Synologys System-, Festplatten- und RAID-Tabellen, dazu Schnittstellen, die Sockets eines Dateiservers (SMB, AFP, NFS), Host-Ressourcen mit Prozessen und Paketen sowie die UCD-SNMP-MIB. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
       },
       "apc-smart-ups": {
         "name": "APC Smart-UPS, dreiphasig",
-        "description": "Eine 10-kVA-USV an ihrer Netzwerkkarte, die die Standard-UPS-MIB beantwortet: Batterie, Eingang und Ausgang je Phase. Passt zum Preset „UPS (RFC 1628)“ und sendet upsTrapOnBattery."
+        "description": "Eine 10-kVA-USV an ihrer Netzwerkkarte, die die Standard-UPS-MIB — Batterie, Eingang und Ausgang je Phase — ebenso beantwortet wie die PowerNet-MIB von APC, aus denselben Messwerten. Passt zum Preset „UPS (RFC 1628)“ und sendet upsTrapOnBattery."
       },
       "hp-laserjet": {
         "name": "HP-LaserJet-Drucker",
-        "description": "Ein Netzwerk-Laserdrucker, der die Printer-MIB beantwortet: Seitenzähler, eine fast leere schwarze Kartusche und ihr Alarm. Sendet printerV2Alert."
+        "description": "Ein Netzwerk-Laserdrucker, der die Printer-MIB beantwortet: Fächer, Ausgabefach, Klappe, Seitenzähler, eine fast leere schwarze Kartusche und ihr Alarm, die Sprachen, die er liest, und sein Display, mit dem Drucker in den Host-Ressourcen. Sendet printerV2Alert."
       },
       "environment-probe": {
         "name": "Umgebungssensor",
-        "description": "Ein Temperatur- und Feuchtesensor, der die Standard-ENTITY-SENSOR-MIB beantwortet, wie im Kaltgang eines Serverraums."
+        "description": "Ein Temperatur- und Feuchtesensor, der die Standard-ENTITY-SENSOR-MIB beantwortet, wie im Kaltgang eines Serverraums, mit seiner Hardware in der ENTITY-MIB."
       },
       "linux-server": {
         "name": "Linux-Server",
-        "description": "Ein Ubuntu-Host mit net-snmp: System, drei Schnittstellen, Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
+        "description": "Ein Ubuntu-24.04-Host mit net-snmp, wie ein Walk ihn zeigt: Schnittstellen, Adressen, Routen und Sockets; Geräte, Dateisysteme, Prozesse und Pakete; Speicher, Last und Datenträger der UCD-SNMP-MIB. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
       },
       "dell-idrac9": {
         "name": "Dell iDRAC9 (PowerEdge R750)",
-        "description": "Der Out-of-Band-Controller eines PowerEdge R750: Gesamt- und Speicherstatus, Betriebszustand, Temperaturen, Lüfterdrehzahlen und Leistungsaufnahme (IDRAC-MIB). Sendet alertTemperatureProbeWarning."
+        "description": "Der Out-of-Band-Controller eines PowerEdge R750 (IDRAC-MIB): Gesamt-, Speicher- und Stromstatus, BIOS, Prozessoren, Speichermodule, Netzteile, Temperaturen, Lüfter, Leistungsaufnahme sowie der RAID-Controller mit seinen physischen und virtuellen Laufwerken. Sendet alertTemperatureProbeWarning."
       },
       "mikrotik-rb4011": {
         "name": "MikroTik-Router RB4011",
-        "description": "Ein RouterOS-Router: zehn Gigabit-Ports und ein leerer SFP+-Schacht, Spannung, Temperaturen und Leistungsaufnahme der Platine (MIKROTIK-MIB) sowie Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
+        "description": "Ein RouterOS-Router für ein kleines Büro: zehn Gigabit-Ports und ein leerer SFP+-Schacht, eine LAN-Bridge in 192.168.88.0/24, seine Routen und Dienste, der Zustand der Platine (MIKROTIK-MIB), die von MNDP und LLDP gefundenen Nachbarn und Host-Ressourcen. Passt zu den Presets „Interfaces (IF-MIB)“ und „Server (HOST-RESOURCES-MIB)“."
       },
       "fortigate-60f": {
         "name": "Fortinet FortiGate 60F",
-        "description": "Eine Filial-Firewall mit FortiOS 7.2: zwei WAN-Ports — der Backup-Port ausgefallen —, DMZ, LAN und der SSL-VPN-Tunnel, mit CPU-, Speicher-, Festplatten- und Sitzungswerten von FortiGate. Sendet die CPU- und Speicher-Schwellwertbenachrichtigungen."
+        "description": "Eine Filial-Firewall mit FortiOS 7.2: zwei WAN-Ports — der Backup-Port ausgefallen —, DMZ, LAN und der SSL-VPN-Tunnel, ihre Routen sowie CPU, Speicher, Festplatte, Sitzungen, VDOM, HA-Modus, Richtlinienzähler und IPsec-Tunnel von FortiGate. Sendet die CPU- und Speicher-Schwellwertbenachrichtigungen."
       },
       "unifi-u6-pro": {
         "name": "UniFi-Access-Point U6 Pro",
-        "description": "Ein Wi-Fi-6-Access-Point: zwei Funkmodule mit ihrer Kanalauslastung, drei SSIDs mit ihren Clients und ihrem Datenverkehr (UBNT-UniFi-MIB), dazu Schnittstellen und Host-Ressourcen."
+        "description": "Ein Wi-Fi-6-Access-Point: zwei Funkmodule mit ihrer Kanalauslastung, drei SSIDs mit ihren Clients, ihrem Datenverkehr, ihren Fehlern und Wiederholungen (UBNT-UniFi-MIB), sein LLDP-Nachbar, Host-Ressourcen und die UCD-SNMP-MIB."
       },
       "apc-rack-pdu": {
         "name": "Schaltbare APC-Rack-PDU",
-        "description": "Eine AP7921B: acht Steckdosen, eine davon ausgeschaltet, die Phasenlast in Ampere und die aufgenommene Leistung (PowerNet-MIB). Sendet rPDUOutletOff und rPDUNearOverload."
+        "description": "Eine AP7921B: acht Steckdosen, eine davon ausgeschaltet, die Phasenlast in Ampere und die aufgenommene Leistung (PowerNet-MIB), dazu Adresse und Dienste der Karte. Sendet rPDUOutletOff und rPDUNearOverload."
       }
     },
     "userN": "Benutzer {n}",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1339,59 +1339,59 @@
     "model": {
       "windows-server": {
         "name": "Windows server",
-        "description": "A Windows Server 2022 host with its SNMP service: system, two network adapters, host resources by drive letter. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
+        "description": "A Windows Server 2022 host with its SNMP service: adapters and Windows’s pseudo-interfaces, addresses, routes and sockets (RDP, SMB, IIS), drives by letter, processes and installed programs. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
       },
       "cisco-catalyst-24": {
         "name": "Cisco Catalyst 2960, 24 ports",
-        "description": "An access switch: 24 Fast Ethernet ports, two gigabit uplinks and VLAN 1, with Cisco's CPU load and configuration changes. Recognised as a Cisco, so the “Cisco (IF-MIB)” preset comes first; also fits “Switch ports” and “Switch drawing (24 ports)”."
+        "description": "An access switch: 24 Fast Ethernet ports, two gigabit uplinks and VLAN 1, with its MAC address table, spanning tree, VLANs (Q-BRIDGE and VTP), LLDP and CDP neighbours, ENTITY-MIB hardware, and Cisco’s CPU, memory and environment. Recognised as a Cisco, so the “Cisco (IF-MIB)” preset comes first; also fits “Switch ports” and “Switch drawing (24 ports)”."
       },
       "cisco-catalyst-48": {
         "name": "Cisco Catalyst 2960, 48 ports",
-        "description": "The same access switch with 48 ports. Recognised as a Cisco, so the “Cisco (IF-MIB)” preset comes first; also fits “Switch ports”."
+        "description": "The same access switch with 48 ports, and everything that goes with them. Recognised as a Cisco, so the “Cisco (IF-MIB)” preset comes first; also fits “Switch ports”."
       },
       "cisco-isr-4331": {
         "name": "Cisco ISR 4331 router",
-        "description": "A branch router: WAN, LAN and management ports, two eBGP sessions — one established, one not — and Cisco's CPU load. Sends the BGP notifications and configuration changes."
+        "description": "A branch router: WAN, LAN and management ports, two eBGP sessions — one established, one not — and the routes the first brought, its ARP cache and sockets, ENTITY-MIB hardware, and Cisco’s CPU, memory and environment. Sends the BGP notifications and configuration changes."
       },
       "synology-nas": {
         "name": "Synology NAS",
-        "description": "A DS920+ on DSM: Synology's system, disk and RAID tables beside interfaces and host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
+        "description": "A DS920+ on DSM: Synology’s system, disk and RAID tables beside interfaces, a file server’s sockets (SMB, AFP, NFS), host resources with processes and packages, and UCD-SNMP-MIB. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
       },
       "apc-smart-ups": {
         "name": "APC Smart-UPS, three-phase",
-        "description": "A 10 kVA UPS on its network card, answering the standard UPS-MIB: battery, input and output per phase. Fits the “UPS (RFC 1628)” preset and sends upsTrapOnBattery."
+        "description": "A 10 kVA UPS on its network card, answering the standard UPS-MIB — battery, input and output per phase — and APC’s PowerNet-MIB alike, from the same readings. Fits the “UPS (RFC 1628)” preset and sends upsTrapOnBattery."
       },
       "hp-laserjet": {
         "name": "HP LaserJet printer",
-        "description": "A network laser printer answering the Printer MIB: page count, a black cartridge running low and its alert. Sends printerV2Alert."
+        "description": "A network laser printer answering the Printer MIB: trays, output bin, cover, marker and page counts, a black cartridge running low and its alert, the languages it reads and its panel, with the printer in the host resources. Sends printerV2Alert."
       },
       "environment-probe": {
         "name": "Environment probe",
-        "description": "A temperature and humidity probe answering the standard ENTITY-SENSOR-MIB, as a server room's cold aisle reads."
+        "description": "A temperature and humidity probe answering the standard ENTITY-SENSOR-MIB, as a server room’s cold aisle reads, with its hardware in ENTITY-MIB."
       },
       "linux-server": {
         "name": "Linux server",
-        "description": "An Ubuntu host running net-snmp: system, three interfaces, host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
+        "description": "An Ubuntu 24.04 host running net-snmp, as a walk of one finds it: interfaces, addresses, routes and sockets; its devices, file systems, processes and packages; UCD-SNMP-MIB’s memory, load and disks. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
       },
       "dell-idrac9": {
         "name": "Dell iDRAC9 (PowerEdge R750)",
-        "description": "The out-of-band controller of a PowerEdge R750: global and storage status, power state, temperatures, fan speeds and power consumption (IDRAC-MIB). Sends alertTemperatureProbeWarning."
+        "description": "The out-of-band controller of a PowerEdge R750 (IDRAC-MIB): global, storage and power status, BIOS, processors, memory modules, power supplies, temperatures, fans, consumption, and the RAID controller with its physical and virtual disks. Sends alertTemperatureProbeWarning."
       },
       "mikrotik-rb4011": {
         "name": "MikroTik RB4011 router",
-        "description": "A RouterOS router: ten gigabit ports and an empty SFP+ cage, the board’s voltage, temperatures and power draw (MIKROTIK-MIB), and host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
+        "description": "A RouterOS router for a small office: ten gigabit ports and an empty SFP+ cage, a LAN bridge on 192.168.88.0/24, its routes and services, the board’s health (MIKROTIK-MIB), the neighbours MNDP and LLDP found, and host resources. Fits the “Interfaces (IF-MIB)” and “Server (HOST-RESOURCES-MIB)” presets."
       },
       "fortigate-60f": {
         "name": "Fortinet FortiGate 60F",
-        "description": "A branch firewall on FortiOS 7.2: two WAN ports — the backup one down —, DMZ, LAN and the SSL VPN tunnel, with FortiGate’s processor, memory, disk and session counts. Sends the processor and memory threshold notifications."
+        "description": "A branch firewall on FortiOS 7.2: two WAN ports — the backup one down —, DMZ, LAN and the SSL VPN tunnel, its routes, and FortiGate’s processor, memory, disk, sessions, VDOM, HA mode, policy counters and IPsec tunnels. Sends the processor and memory threshold notifications."
       },
       "unifi-u6-pro": {
         "name": "UniFi U6 Pro access point",
-        "description": "A Wi-Fi 6 access point: two radios and how busy their channels are, three SSIDs with their clients and traffic (UBNT-UniFi-MIB), beside interfaces and host resources."
+        "description": "A Wi-Fi 6 access point: two radios and how busy their channels are, three SSIDs with their clients, traffic, errors and retries (UBNT-UniFi-MIB), its LLDP neighbour, host resources and UCD-SNMP-MIB."
       },
       "apc-rack-pdu": {
         "name": "APC switched rack PDU",
-        "description": "An AP7921B: eight outlets, one of them switched off, the phase load in amps and the power drawn (PowerNet-MIB). Sends rPDUOutletOff and rPDUNearOverload."
+        "description": "An AP7921B: eight outlets, one of them switched off, the phase load in amps and the power drawn (PowerNet-MIB), beside the card’s address and services. Sends rPDUOutletOff and rPDUNearOverload."
       }
     },
     "userN": "User {n}",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1339,59 +1339,59 @@
     "model": {
       "windows-server": {
         "name": "Servidor Windows",
-        "description": "Un host Windows Server 2022 con su servicio SNMP: sistema, dos adaptadores de red, recursos del host por letra de unidad. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
+        "description": "Un host Windows Server 2022 con su servicio SNMP: adaptadores y pseudointerfaces de Windows, direcciones, rutas y sockets (RDP, SMB, IIS), unidades por letra, procesos y programas instalados. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
       },
       "cisco-catalyst-24": {
         "name": "Cisco Catalyst 2960, 24 puertos",
-        "description": "Un switch de acceso: 24 puertos Fast Ethernet, dos enlaces ascendentes gigabit y la VLAN 1, con la carga de CPU y los cambios de configuración de Cisco. Se reconoce como Cisco, así que el preset «Cisco (IF-MIB)» aparece primero; también encaja con «Switch ports» y «Switch drawing (24 ports)»."
+        "description": "Un switch de acceso: 24 puertos Fast Ethernet, dos enlaces ascendentes gigabit y la VLAN 1, con su tabla de direcciones MAC, su spanning tree, sus VLAN (Q-BRIDGE y VTP), sus vecinos LLDP y CDP, su hardware en la ENTITY-MIB y la CPU, la memoria y el entorno de Cisco. Se reconoce como Cisco, así que el preset «Cisco (IF-MIB)» aparece primero; también encaja con «Switch ports» y «Switch drawing (24 ports)»."
       },
       "cisco-catalyst-48": {
         "name": "Cisco Catalyst 2960, 48 puertos",
-        "description": "El mismo switch de acceso con 48 puertos. Se reconoce como Cisco, así que el preset «Cisco (IF-MIB)» aparece primero; también encaja con «Switch ports»."
+        "description": "El mismo switch de acceso con 48 puertos, y todo lo que conlleva. Se reconoce como Cisco, así que el preset «Cisco (IF-MIB)» aparece primero; también encaja con «Switch ports»."
       },
       "cisco-isr-4331": {
         "name": "Router Cisco ISR 4331",
-        "description": "Un router de sucursal: puertos WAN, LAN y de gestión, dos sesiones eBGP —una establecida y otra no— y la carga de CPU de Cisco. Envía las notificaciones BGP y los cambios de configuración."
+        "description": "Un router de sucursal: puertos WAN, LAN y de gestión, dos sesiones eBGP —una establecida y otra no— y las rutas que trajo la primera, su caché ARP y sus sockets, su hardware en la ENTITY-MIB y la CPU, la memoria y el entorno de Cisco. Envía las notificaciones BGP y los cambios de configuración."
       },
       "synology-nas": {
         "name": "NAS Synology",
-        "description": "Un DS920+ con DSM: las tablas de sistema, discos y RAID de Synology junto a las interfaces y los recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
+        "description": "Un DS920+ con DSM: las tablas de sistema, discos y RAID de Synology, las interfaces, los sockets de un servidor de archivos (SMB, AFP, NFS), los recursos del host con procesos y paquetes, y la UCD-SNMP-MIB. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
       },
       "apc-smart-ups": {
         "name": "SAI APC Smart-UPS, trifásico",
-        "description": "Un SAI de 10 kVA en su tarjeta de red, que responde a la UPS-MIB estándar: batería, entrada y salida por fase. Encaja con el preset «UPS (RFC 1628)» y envía upsTrapOnBattery."
+        "description": "Un SAI de 10 kVA en su tarjeta de red, que responde a la UPS-MIB estándar —batería, entrada y salida por fase— y a la PowerNet-MIB de APC, a partir de las mismas medidas. Encaja con el preset «UPS (RFC 1628)» y envía upsTrapOnBattery."
       },
       "hp-laserjet": {
         "name": "Impresora HP LaserJet",
-        "description": "Una impresora láser de red que responde a la Printer MIB: contador de páginas, un cartucho negro casi vacío y su alerta. Envía printerV2Alert."
+        "description": "Una impresora láser de red que responde a la Printer MIB: bandejas, bandeja de salida, cubierta, contadores de páginas, un cartucho negro casi vacío y su alerta, los lenguajes que lee y su panel, con la impresora en los recursos del host. Envía printerV2Alert."
       },
       "environment-probe": {
         "name": "Sonda ambiental",
-        "description": "Una sonda de temperatura y humedad que responde a la ENTITY-SENSOR-MIB estándar, como en el pasillo frío de una sala de servidores."
+        "description": "Una sonda de temperatura y humedad que responde a la ENTITY-SENSOR-MIB estándar, como en el pasillo frío de una sala de servidores, con su hardware en la ENTITY-MIB."
       },
       "linux-server": {
         "name": "Servidor Linux",
-        "description": "Un host Ubuntu con net-snmp: sistema, tres interfaces, recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
+        "description": "Un host Ubuntu 24.04 con net-snmp, tal como lo muestra un walk: interfaces, direcciones, rutas y sockets; dispositivos, sistemas de archivos, procesos y paquetes; memoria, carga y discos de la UCD-SNMP-MIB. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
       },
       "dell-idrac9": {
         "name": "Dell iDRAC9 (PowerEdge R750)",
-        "description": "El controlador fuera de banda de un PowerEdge R750: estado global y del almacenamiento, estado de alimentación, temperaturas, velocidad de los ventiladores y consumo (IDRAC-MIB). Envía alertTemperatureProbeWarning."
+        "description": "El controlador fuera de banda de un PowerEdge R750 (IDRAC-MIB): estado global, del almacenamiento y de la alimentación, BIOS, procesadores, módulos de memoria, fuentes, temperaturas, ventiladores, consumo y la controladora RAID con sus discos físicos y virtuales. Envía alertTemperatureProbeWarning."
       },
       "mikrotik-rb4011": {
         "name": "Router MikroTik RB4011",
-        "description": "Un router RouterOS: diez puertos gigabit y una ranura SFP+ vacía, la tensión, las temperaturas y el consumo de la placa (MIKROTIK-MIB), y los recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
+        "description": "Un router RouterOS para una oficina pequeña: diez puertos gigabit y una ranura SFP+ vacía, un bridge LAN en 192.168.88.0/24, sus rutas y servicios, la salud de la placa (MIKROTIK-MIB), los vecinos que encontraron MNDP y LLDP, y los recursos del host. Encaja con los presets «Interfaces (IF-MIB)» y «Server (HOST-RESOURCES-MIB)»."
       },
       "fortigate-60f": {
         "name": "Fortinet FortiGate 60F",
-        "description": "Un cortafuegos de sucursal con FortiOS 7.2: dos puertos WAN —el de respaldo caído—, DMZ, LAN y el túnel VPN SSL, con la carga de CPU, la memoria, el disco y las sesiones de FortiGate. Envía las notificaciones de umbral de CPU y memoria."
+        "description": "Un cortafuegos de sucursal con FortiOS 7.2: dos puertos WAN —el de respaldo caído—, DMZ, LAN y el túnel VPN SSL, sus rutas, y la CPU, la memoria, el disco, las sesiones, el VDOM, el modo HA, los contadores de políticas y los túneles IPsec de FortiGate. Envía las notificaciones de umbral de CPU y memoria."
       },
       "unifi-u6-pro": {
         "name": "Punto de acceso UniFi U6 Pro",
-        "description": "Un punto de acceso Wi-Fi 6: dos radios con la ocupación de su canal, tres SSID con sus clientes y su tráfico (UBNT-UniFi-MIB), además de interfaces y recursos del host."
+        "description": "Un punto de acceso Wi-Fi 6: dos radios con la ocupación de su canal, tres SSID con sus clientes, su tráfico, sus errores y reintentos (UBNT-UniFi-MIB), su vecino LLDP, los recursos del host y la UCD-SNMP-MIB."
       },
       "apc-rack-pdu": {
         "name": "PDU de rack conmutable APC",
-        "description": "Una AP7921B: ocho tomas, una de ellas apagada, la carga de la fase en amperios y la potencia consumida (PowerNet-MIB). Envía rPDUOutletOff y rPDUNearOverload."
+        "description": "Una AP7921B: ocho tomas, una de ellas apagada, la carga de la fase en amperios y la potencia consumida (PowerNet-MIB), además de la dirección y los servicios de la tarjeta. Envía rPDUOutletOff y rPDUNearOverload."
       }
     },
     "userN": "Usuario {n}",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1339,59 +1339,59 @@
     "model": {
       "windows-server": {
         "name": "Serveur Windows",
-        "description": "Un hôte Windows Server 2022 avec son service SNMP : système, deux cartes réseau, ressources de l’hôte par lettre de lecteur. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
+        "description": "Un hôte Windows Server 2022 avec son service SNMP : cartes réseau et pseudo-interfaces de Windows, adresses, routes et sockets (RDP, SMB, IIS), lecteurs par lettre, processus et programmes installés. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
       },
       "cisco-catalyst-24": {
         "name": "Cisco Catalyst 2960, 24 ports",
-        "description": "Un commutateur d’accès : 24 ports Fast Ethernet, deux liens montants gigabit et le VLAN 1, avec la charge CPU et les changements de configuration de Cisco. Reconnu comme un Cisco : le preset « Cisco (IF-MIB) » vient en premier ; convient aussi à « Switch ports » et « Switch drawing (24 ports) »."
+        "description": "Un commutateur d’accès : 24 ports Fast Ethernet, deux liens montants gigabit et le VLAN 1, avec sa table d’adresses MAC, son spanning tree, ses VLAN (Q-BRIDGE et VTP), ses voisins LLDP et CDP, son matériel dans l’ENTITY-MIB, et le CPU, la mémoire et l’environnement de Cisco. Reconnu comme un Cisco : le preset « Cisco (IF-MIB) » vient en premier ; convient aussi à « Switch ports » et « Switch drawing (24 ports) »."
       },
       "cisco-catalyst-48": {
         "name": "Cisco Catalyst 2960, 48 ports",
-        "description": "Le même commutateur d’accès, avec 48 ports. Reconnu comme un Cisco : le preset « Cisco (IF-MIB) » vient en premier ; convient aussi à « Switch ports »."
+        "description": "Le même commutateur d’accès, avec 48 ports et tout ce qui va avec. Reconnu comme un Cisco : le preset « Cisco (IF-MIB) » vient en premier ; convient aussi à « Switch ports »."
       },
       "cisco-isr-4331": {
         "name": "Routeur Cisco ISR 4331",
-        "description": "Un routeur d’agence : ports WAN, LAN et d’administration, deux sessions eBGP — l’une établie, l’autre non — et la charge CPU de Cisco. Envoie les notifications BGP et les changements de configuration."
+        "description": "Un routeur d’agence : ports WAN, LAN et d’administration, deux sessions eBGP — l’une établie, l’autre non — et les routes apportées par la première, son cache ARP et ses sockets, son matériel dans l’ENTITY-MIB, et le CPU, la mémoire et l’environnement de Cisco. Envoie les notifications BGP et les changements de configuration."
       },
       "synology-nas": {
         "name": "NAS Synology",
-        "description": "Un DS920+ sous DSM : les tables système, disques et RAID de Synology, à côté des interfaces et des ressources de l’hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
+        "description": "Un DS920+ sous DSM : les tables système, disques et RAID de Synology, les interfaces, les sockets d’un serveur de fichiers (SMB, AFP, NFS), les ressources de l’hôte avec processus et paquets, et l’UCD-SNMP-MIB. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
       },
       "apc-smart-ups": {
         "name": "Onduleur APC Smart-UPS, triphasé",
-        "description": "Un onduleur de 10 kVA sur sa carte réseau, qui répond à l’UPS-MIB standard : batterie, entrée et sortie par phase. Convient au preset « UPS (RFC 1628) » et envoie upsTrapOnBattery."
+        "description": "Un onduleur de 10 kVA sur sa carte réseau, qui répond à l’UPS-MIB standard — batterie, entrée et sortie par phase — comme à la PowerNet-MIB d’APC, à partir des mêmes mesures. Convient au preset « UPS (RFC 1628) » et envoie upsTrapOnBattery."
       },
       "hp-laserjet": {
         "name": "Imprimante HP LaserJet",
-        "description": "Une imprimante laser réseau qui répond à la Printer MIB : compteur de pages, une cartouche noire presque vide et son alerte. Envoie printerV2Alert."
+        "description": "Une imprimante laser réseau qui répond à la Printer MIB : bacs, réceptacle, capot, compteurs de pages, une cartouche noire presque vide et son alerte, les langages qu’elle lit et son panneau, avec l’imprimante dans les ressources de l’hôte. Envoie printerV2Alert."
       },
       "environment-probe": {
         "name": "Sonde d’environnement",
-        "description": "Une sonde de température et d’humidité qui répond à l’ENTITY-SENSOR-MIB standard, comme dans l’allée froide d’une salle serveurs."
+        "description": "Une sonde de température et d’humidité qui répond à l’ENTITY-SENSOR-MIB standard, comme dans l’allée froide d’une salle serveurs, avec son matériel dans l’ENTITY-MIB."
       },
       "linux-server": {
         "name": "Serveur Linux",
-        "description": "Un hôte Ubuntu avec net-snmp : système, trois interfaces, ressources de l'hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
+        "description": "Un hôte Ubuntu 24.04 avec net-snmp, tel qu’un walk le montre : interfaces, adresses, routes et sockets ; périphériques, systèmes de fichiers, processus et paquets ; mémoire, charge et disques de l’UCD-SNMP-MIB. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
       },
       "dell-idrac9": {
         "name": "Dell iDRAC9 (PowerEdge R750)",
-        "description": "Le contrôleur hors bande d’un PowerEdge R750 : état global et du stockage, alimentation, températures, vitesse des ventilateurs et consommation (IDRAC-MIB). Envoie alertTemperatureProbeWarning."
+        "description": "Le contrôleur hors bande d’un PowerEdge R750 (IDRAC-MIB) : état global, du stockage et de l’alimentation, BIOS, processeurs, barrettes mémoire, alimentations, températures, ventilateurs, consommation, et le contrôleur RAID avec ses disques physiques et virtuels. Envoie alertTemperatureProbeWarning."
       },
       "mikrotik-rb4011": {
         "name": "Routeur MikroTik RB4011",
-        "description": "Un routeur RouterOS : dix ports gigabit et une cage SFP+ vide, la tension, les températures et la consommation de la carte (MIKROTIK-MIB), et les ressources de l’hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
+        "description": "Un routeur RouterOS de petit bureau : dix ports gigabit et une cage SFP+ vide, un bridge LAN en 192.168.88.0/24, ses routes et ses services, la santé de la carte (MIKROTIK-MIB), les voisins trouvés par MNDP et LLDP, et les ressources de l’hôte. Convient aux presets « Interfaces (IF-MIB) » et « Server (HOST-RESOURCES-MIB) »."
       },
       "fortigate-60f": {
         "name": "Fortinet FortiGate 60F",
-        "description": "Un pare-feu d’agence sous FortiOS 7.2 : deux ports WAN — celui de secours en panne —, DMZ, LAN et le tunnel VPN SSL, avec la charge processeur, la mémoire, le disque et les sessions de FortiGate. Envoie les notifications de seuil processeur et mémoire."
+        "description": "Un pare-feu d’agence sous FortiOS 7.2 : deux ports WAN — celui de secours en panne —, DMZ, LAN et le tunnel VPN SSL, ses routes, et le processeur, la mémoire, le disque, les sessions, le VDOM, le mode HA, les compteurs des règles et les tunnels IPsec de FortiGate. Envoie les notifications de seuil processeur et mémoire."
       },
       "unifi-u6-pro": {
         "name": "Point d’accès UniFi U6 Pro",
-        "description": "Un point d’accès Wi-Fi 6 : deux radios et l’occupation de leur canal, trois SSID avec leurs clients et leur trafic (UBNT-UniFi-MIB), plus les interfaces et les ressources de l’hôte."
+        "description": "Un point d’accès Wi-Fi 6 : deux radios et l’occupation de leur canal, trois SSID avec leurs clients, leur trafic, leurs erreurs et leurs retransmissions (UBNT-UniFi-MIB), son voisin LLDP, les ressources de l’hôte et l’UCD-SNMP-MIB."
       },
       "apc-rack-pdu": {
         "name": "PDU APC commutable",
-        "description": "Une AP7921B : huit prises, dont une coupée, la charge de la phase en ampères et la puissance consommée (PowerNet-MIB). Envoie rPDUOutletOff et rPDUNearOverload."
+        "description": "Une AP7921B : huit prises, dont une coupée, la charge de la phase en ampères et la puissance consommée (PowerNet-MIB), plus l’adresse et les services de la carte. Envoie rPDUOutletOff et rPDUNearOverload."
       }
     },
     "userN": "Utilisateur {n}",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1339,59 +1339,59 @@
     "model": {
       "windows-server": {
         "name": "Windows 服务器",
-        "description": "带 SNMP 服务的 Windows Server 2022 主机：系统、两块网卡、按盘符列出的主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
+        "description": "带 SNMP 服务的 Windows Server 2022 主机：网卡及 Windows 的伪接口、地址、路由和套接字（RDP、SMB、IIS）、按盘符列出的驱动器、进程和已安装程序。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
       },
       "cisco-catalyst-24": {
         "name": "Cisco Catalyst 2960，24 端口",
-        "description": "一台接入交换机：24 个快速以太网端口、两个千兆上联口和 VLAN 1，带有 Cisco 的 CPU 负载和配置变更。被识别为 Cisco 设备，因此“Cisco (IF-MIB)”预设排在最前；也适用于“Switch ports”和“Switch drawing (24 ports)”。"
+        "description": "一台接入交换机：24 个快速以太网端口、两个千兆上联口和 VLAN 1，带 MAC 地址表、生成树、VLAN（Q-BRIDGE 和 VTP）、LLDP 和 CDP 邻居、ENTITY-MIB 硬件，以及 Cisco 的 CPU、内存和环境。被识别为 Cisco 设备，因此“Cisco (IF-MIB)”预设排在最前；也适用于“Switch ports”和“Switch drawing (24 ports)”。"
       },
       "cisco-catalyst-48": {
         "name": "Cisco Catalyst 2960，48 端口",
-        "description": "同一款接入交换机，48 个端口。被识别为 Cisco 设备，因此“Cisco (IF-MIB)”预设排在最前；也适用于“Switch ports”。"
+        "description": "同一款接入交换机的 48 端口版本，以及随之而来的一切。被识别为 Cisco 设备，因此“Cisco (IF-MIB)”预设排在最前；也适用于“Switch ports”。"
       },
       "cisco-isr-4331": {
         "name": "Cisco ISR 4331 路由器",
-        "description": "一台分支路由器：WAN、LAN 和管理端口，两个 eBGP 会话（一个已建立，一个未建立），以及 Cisco 的 CPU 负载。发送 BGP 通知和配置变更。"
+        "description": "一台分支路由器：WAN、LAN 和管理端口，两个 eBGP 会话（一个已建立，一个未建立）及第一个会话带来的路由，其 ARP 缓存和套接字、ENTITY-MIB 硬件，以及 Cisco 的 CPU、内存和环境。发送 BGP 通知和配置变更。"
       },
       "synology-nas": {
         "name": "Synology NAS",
-        "description": "运行 DSM 的 DS920+：Synology 的系统、磁盘和 RAID 表，外加接口和主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
+        "description": "一台运行 DSM 的 DS920+：Synology 的系统、磁盘和 RAID 表，加上接口、文件服务器的套接字（SMB、AFP、NFS）、带进程和软件包的主机资源，以及 UCD-SNMP-MIB。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
       },
       "apc-smart-ups": {
         "name": "APC Smart-UPS 三相 UPS",
-        "description": "一台通过网卡管理的 10 kVA UPS，响应标准 UPS-MIB：电池、各相输入和输出。适用于“UPS (RFC 1628)”预设，并发送 upsTrapOnBattery。"
+        "description": "一台通过网卡管理的 10 kVA UPS，同时响应标准 UPS-MIB（电池、各相输入和输出）和 APC 的 PowerNet-MIB，二者基于相同的读数。适用于“UPS (RFC 1628)”预设，并发送 upsTrapOnBattery。"
       },
       "hp-laserjet": {
         "name": "HP LaserJet 打印机",
-        "description": "一台响应 Printer MIB 的网络激光打印机：页数计数、即将耗尽的黑色硒鼓及其告警。发送 printerV2Alert。"
+        "description": "一台响应 Printer MIB 的网络激光打印机：纸盒、出纸槽、机盖、页数计数、即将耗尽的黑色硒鼓及其告警、支持的打印语言和面板，打印机也列在主机资源中。发送 printerV2Alert。"
       },
       "environment-probe": {
         "name": "环境探头",
-        "description": "一个响应标准 ENTITY-SENSOR-MIB 的温湿度探头，读数如同服务器机房的冷通道。"
+        "description": "一个响应标准 ENTITY-SENSOR-MIB 的温湿度探头，读数如同服务器机房的冷通道，其硬件列在 ENTITY-MIB 中。"
       },
       "linux-server": {
         "name": "Linux 服务器",
-        "description": "运行 net-snmp 的 Ubuntu 主机：系统、三个接口、主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
+        "description": "运行 net-snmp 的 Ubuntu 24.04 主机，与 walk 所见一致：接口、地址、路由和套接字；设备、文件系统、进程和软件包；UCD-SNMP-MIB 的内存、负载和磁盘。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
       },
       "dell-idrac9": {
         "name": "Dell iDRAC9（PowerEdge R750）",
-        "description": "PowerEdge R750 的带外管理控制器：整体和存储状态、电源状态、温度、风扇转速和功耗（IDRAC-MIB）。发送 alertTemperatureProbeWarning。"
+        "description": "PowerEdge R750 的带外管理控制器（IDRAC-MIB）：整体、存储和电源状态，BIOS、处理器、内存模块、电源、温度、风扇、功耗，以及 RAID 控制器及其物理磁盘和虚拟磁盘。发送 alertTemperatureProbeWarning。"
       },
       "mikrotik-rb4011": {
         "name": "MikroTik RB4011 路由器",
-        "description": "一台 RouterOS 路由器：十个千兆端口和一个空的 SFP+ 插槽，主板的电压、温度和功耗（MIKROTIK-MIB），以及主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
+        "description": "一台面向小型办公室的 RouterOS 路由器：十个千兆端口和一个空的 SFP+ 插槽，192.168.88.0/24 上的 LAN 网桥，其路由和服务，主板健康状况（MIKROTIK-MIB），MNDP 和 LLDP 发现的邻居，以及主机资源。适用于“Interfaces (IF-MIB)”和“Server (HOST-RESOURCES-MIB)”预设。"
       },
       "fortigate-60f": {
         "name": "Fortinet FortiGate 60F",
-        "description": "一台运行 FortiOS 7.2 的分支防火墙：两个 WAN 端口（备用端口已断开）、DMZ、LAN 和 SSL VPN 隧道，以及 FortiGate 的 CPU、内存、磁盘和会话数。发送 CPU 和内存阈值通知。"
+        "description": "一台运行 FortiOS 7.2 的分支防火墙：两个 WAN 端口（备用端口已断开）、DMZ、LAN 和 SSL VPN 隧道，其路由，以及 FortiGate 的 CPU、内存、磁盘、会话、VDOM、HA 模式、策略计数器和 IPsec 隧道。发送 CPU 和内存阈值通知。"
       },
       "unifi-u6-pro": {
         "name": "UniFi U6 Pro 无线接入点",
-        "description": "一台 Wi-Fi 6 接入点：两个射频及其信道占用率，三个 SSID 及其客户端和流量（UBNT-UniFi-MIB），另有接口和主机资源。"
+        "description": "一台 Wi-Fi 6 接入点：两个射频及其信道占用率，三个 SSID 及其客户端、流量、错误和重传（UBNT-UniFi-MIB），其 LLDP 邻居、主机资源和 UCD-SNMP-MIB。"
       },
       "apc-rack-pdu": {
         "name": "APC 可开关机架 PDU",
-        "description": "一台 AP7921B：八个插座（其中一个已关闭），相位负载（安培）和功耗（PowerNet-MIB）。发送 rPDUOutletOff 和 rPDUNearOverload。"
+        "description": "一台 AP7921B：八个插座（其中一个已关闭），相位负载（安培）和功耗（PowerNet-MIB），以及网卡的地址和服务。发送 rPDUOutletOff 和 rPDUNearOverload。"
       }
     },
     "userN": "用户 {n}",

--- a/pkg/mib/simulator_test.go
+++ b/pkg/mib/simulator_test.go
@@ -1,0 +1,125 @@
+package mib
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// The conceptual tables the simulator serves from a bundled MIB, and what
+// their index is made of.
+var simulatedTables = []string{
+	"1.3.6.1.2.1.1.9",    // sysORTable: an integer
+	"1.3.6.1.2.1.2.2",    // ifTable
+	"1.3.6.1.2.1.31.1.1", // ifXTable, which AUGMENTS it
+	"1.3.6.1.2.1.31.1.2", // ifStackTable: two interfaces, zero allowed
+	"1.3.6.1.2.1.4.20",   // ipAddrTable: an IpAddress
+	"1.3.6.1.2.1.4.22",   // ipNetToMediaTable: an interface and an IpAddress
+	"1.3.6.1.2.1.4.32",   // ipAddressPrefixTable: an InetAddress, its length first
+	"1.3.6.1.2.1.4.34",   // ipAddressTable
+	"1.3.6.1.2.1.6.13",   // tcpConnTable: four parts
+	"1.3.6.1.2.1.7.5",    // udpTable
+	"1.3.6.1.2.1.25.2.3", // hrStorageTable
+	"1.3.6.1.2.1.25.3.2", // hrDeviceTable
+	"1.3.6.1.2.1.25.3.3", // hrProcessorTable
+	"1.3.6.1.2.1.25.3.4", // hrNetworkTable
+	"1.3.6.1.2.1.25.3.5", // hrPrinterTable
+	"1.3.6.1.2.1.25.3.6", // hrDiskStorageTable
+	"1.3.6.1.2.1.25.3.8", // hrFSTable
+	"1.3.6.1.2.1.25.4.2", // hrSWRunTable
+	"1.3.6.1.2.1.25.5.1", // hrSWRunPerfTable, which AUGMENTS it
+	"1.3.6.1.2.1.25.6.3", // hrSWInstalledTable
+}
+
+// Every table a simulated device serves from a bundled MIB decodes, row by row,
+// with nothing left over, through SnmpLens's own decoder: the index each model
+// writes is the one RFC 2578 7.7 reads back — an IpAddress as four
+// sub-identifiers, an InetAddress with its length first, tcpConnTable's four
+// parts. The rules come from the MIB, so a model that wrote an index its own
+// way fails here rather than on screen, as a table of garbled rows.
+func TestSimulatedTablesDecode(t *testing.T) {
+	s := loadedService(t)
+	for _, m := range simulator.Models() {
+		t.Run(m.ID, func(t *testing.T) {
+			d := simtest.Start(t, simulator.Device{Model: m.ID})
+			g := &gosnmp.GoSNMP{Target: d.Address, Port: uint16(d.Port), Community: d.Community,
+				Version: gosnmp.Version2c, Timeout: 2 * time.Second, Retries: 1}
+			if err := g.Connect(); err != nil {
+				t.Fatal(err)
+			}
+			defer g.Conn.Close()
+
+			rows := 0
+			for _, table := range simulatedTables {
+				entry := "." + table + ".1."
+				seen := map[string]bool{}
+				var instances []string
+				err := g.BulkWalk("."+table, func(v gosnmp.SnmpPDU) error {
+					rest, ok := strings.CutPrefix(v.Name, entry)
+					if !ok {
+						return nil
+					}
+					// What follows the column is the row's instance.
+					if _, inst, ok := strings.Cut(rest, "."); ok && !seen[inst] {
+						seen[inst] = true
+						instances = append(instances, inst)
+					}
+					return nil
+				})
+				if err != nil {
+					t.Fatalf("%s: %v", table, err)
+				}
+				for _, dec := range s.DecodeIndexes(table, instances) {
+					if dec.Error != "" || len(dec.Parts) == 0 {
+						t.Errorf("%s, row %s: %q", table, dec.Raw, dec.Error)
+					}
+				}
+				rows += len(instances)
+			}
+			if rows == 0 {
+				t.Error("no table has a row")
+			}
+		})
+	}
+}
+
+// tcpConnTable is the one whose index says the most, and a server's is read as
+// what it is: sockets listening on every address, and a session established
+// from a peer.
+func TestASimulatedServersConnectionsDecode(t *testing.T) {
+	s := loadedService(t)
+	d := simtest.Start(t, simulator.Device{Model: "linux-server"})
+	g := &gosnmp.GoSNMP{Target: d.Address, Port: uint16(d.Port), Community: d.Community,
+		Version: gosnmp.Version2c, Timeout: 2 * time.Second, Retries: 1}
+	if err := g.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer g.Conn.Close()
+	var instances []string
+	if err := g.BulkWalk(".1.3.6.1.2.1.6.13.1.1", func(v gosnmp.SnmpPDU) error {
+		instances = append(instances, strings.TrimPrefix(v.Name, ".1.3.6.1.2.1.6.13.1.1."))
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var listening, established int
+	for _, dec := range s.DecodeIndexes("1.3.6.1.2.1.6.13", instances) {
+		if len(dec.Parts) != 4 {
+			t.Fatalf("row %s decodes to %d parts: %q", dec.Raw, len(dec.Parts), dec.Error)
+		}
+		switch {
+		case dec.Parts[0].Display == "0.0.0.0" && dec.Parts[3].Display == "0":
+			listening++
+		case dec.Parts[3].Display != "0":
+			established++
+		}
+	}
+	if listening == 0 || established == 0 {
+		t.Errorf("%d socket(s) listening and %d session(s) established, from %v", listening, established, instances)
+	}
+}

--- a/pkg/simulator/agent.go
+++ b/pkg/simulator/agent.go
@@ -83,6 +83,9 @@ type counters struct {
 	packets, parseErrors, badVersions, badCommunities, unknownSecurityModels, invalidMsgs,
 	unknownEngineIDs, unknownUserNames, unsupportedSecLevels, wrongDigests, notInTimeWindows,
 	decryptionErrors, unknownContexts, unknownPDUHandlers, faults atomic.Uint32
+	// What SNMPv2-MIB's snmp group counts besides: the requests by kind, the
+	// varbinds read, the answers and the notifications sent.
+	inGets, inGetNexts, inSets, inTotalReqVars, outGetResponses, outNoSuchNames, outTraps atomic.Uint32
 }
 
 // Agent is one simulated device answering on one socket.
@@ -155,10 +158,9 @@ func NewAgent(cfg Config) (*Agent, error) {
 			return nil, fmt.Errorf("simulator: %w", err)
 		}
 	}
-	objects := cfg.Objects
-	if a.v3 {
-		objects = slices.Concat(cfg.Objects, engineObjects(a.engineID, a.boots))
-	}
+	// What only the agent knows — its own counters, and for v3 its engine —
+	// beside what the device answers.
+	objects := slices.Concat(cfg.Objects, agentObjects(a.v3, a.engineID, a.boots, cfg.Traps.OnAuthFailure))
 	if a.tree, err = newTree(objects); err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
@@ -277,7 +279,7 @@ func (a *Agent) serve(conn *net.UDPConn, started time.Time, done chan struct{}) 
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}
-		if out := a.handle(buf[:n], clock{started: started, now: time.Now()}); out != nil {
+		if out := a.handle(buf[:n], clock{started: started, now: time.Now(), stats: &a.stats}); out != nil {
 			_, _ = conn.WriteToUDPAddrPort(out, from)
 		}
 	}

--- a/pkg/simulator/agent_test.go
+++ b/pkg/simulator/agent_test.go
@@ -69,8 +69,8 @@ func TestAWalkVisitsEveryObjectInTheAgentsOrder(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", name, err)
 		}
-		if !slices.Equal(got, sampleOrder) {
-			t.Errorf("%s walked\n%v\nwant\n%v", name, got, sampleOrder)
+		if want := walkOrder(false); !slices.Equal(got, want) {
+			t.Errorf("%s walked\n%v\nwant\n%v", name, got, want)
 		}
 	}
 }
@@ -112,7 +112,7 @@ func TestSNMPv1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := slices.DeleteFunc(slices.Clone(sampleOrder), func(n string) bool {
+	want := slices.DeleteFunc(walkOrder(false), func(n string) bool {
 		return strings.HasPrefix(n, ".1.3.6.1.2.1.31.1.1.1.6.")
 	})
 	if !slices.Equal(walked, want) {
@@ -189,7 +189,7 @@ func TestAGetBulkIsCutToFitTheMessage(t *testing.T) {
 		t.Fatalf("%v with %d of %d varbinds; want a shorter answer that is still an answer",
 			res.Error, len(got), len(whole.Variables))
 	}
-	if !slices.Equal(got, sampleOrder[:len(got)]) {
+	if !slices.Equal(got, walkOrder(false)[:len(got)]) {
 		t.Errorf("cut somewhere other than its end: %v", got)
 	}
 }

--- a/pkg/simulator/agentobjects.go
+++ b/pkg/simulator/agentobjects.go
@@ -1,0 +1,100 @@
+package simulator
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// agentObjects are what only the agent can answer, because it counts them: the
+// snmp group of SNMPv2-MIB (RFC 3418) — what it has received, refused and
+// answered since it started — and for SNMPv3 the snmpEngine group, the MPD and
+// USM statistics its Reports name, and snmpUnknownContexts. They are live: a
+// GET of snmpInPkts counts itself.
+//
+// Every device has them, the models' own objects beside, so a model — built-in,
+// or a file somebody wrote — cannot answer them in its own words.
+func agentObjects(v3 bool, engineID []byte, boots uint32, authenTraps bool) []Object {
+	var out []Object
+	count := func(oid string, f func(*counters) uint32) {
+		out = append(out, Object{OID: oid, Type: gosnmp.Counter32, Value: statistic(f)})
+	}
+	load := func(get func(*counters) *atomic.Uint32) func(*counters) uint32 {
+		return func(c *counters) uint32 { return get(c).Load() }
+	}
+	nothing := func(*counters) uint32 { return 0 }
+
+	const snmp = "1.3.6.1.2.1.11."
+	count(snmp+"1.0", load(func(c *counters) *atomic.Uint32 { return &c.packets }))
+	count(snmp+"2.0", func(c *counters) uint32 { return c.outGetResponses.Load() + c.outTraps.Load() })
+	count(snmp+"3.0", load(func(c *counters) *atomic.Uint32 { return &c.badVersions }))
+	count(snmp+"4.0", load(func(c *counters) *atomic.Uint32 { return &c.badCommunities }))
+	count(snmp+"5.0", nothing) // a community used for what it may not do: nothing is writable
+	count(snmp+"6.0", load(func(c *counters) *atomic.Uint32 { return &c.parseErrors }))
+	// What arrived in a response, which an agent receives none of.
+	for _, n := range []int{8, 9, 10, 11, 12} {
+		count(fmt.Sprintf(snmp+"%d.0", n), nothing)
+	}
+	count(snmp+"13.0", load(func(c *counters) *atomic.Uint32 { return &c.inTotalReqVars }))
+	count(snmp+"14.0", nothing) // no SET has succeeded
+	count(snmp+"15.0", load(func(c *counters) *atomic.Uint32 { return &c.inGets }))
+	count(snmp+"16.0", load(func(c *counters) *atomic.Uint32 { return &c.inGetNexts }))
+	count(snmp+"17.0", load(func(c *counters) *atomic.Uint32 { return &c.inSets }))
+	count(snmp+"18.0", nothing)
+	count(snmp+"19.0", nothing)
+	count(snmp+"20.0", nothing)
+	count(snmp+"21.0", load(func(c *counters) *atomic.Uint32 { return &c.outNoSuchNames }))
+	count(snmp+"22.0", nothing)
+	count(snmp+"24.0", nothing)
+	for _, n := range []int{25, 26, 27} {
+		count(fmt.Sprintf(snmp+"%d.0", n), nothing) // requests the agent sent: none
+	}
+	count(snmp+"28.0", load(func(c *counters) *atomic.Uint32 { return &c.outGetResponses }))
+	count(snmp+"29.0", load(func(c *counters) *atomic.Uint32 { return &c.outTraps }))
+	enable := 2
+	if authenTraps {
+		enable = 1
+	}
+	out = append(out, Object{OID: snmp + "30.0", Type: gosnmp.Integer, Value: Const(enable)})
+	count(snmp+"31.0", nothing)
+	count(snmp+"32.0", nothing)
+	if !v3 {
+		return out
+	}
+
+	out = append(out, engineObjects(engineID, boots)...)
+	for oid, get := range map[string]func(*counters) *atomic.Uint32{
+		".1.3.6.1.6.3.11.2.1.1.0": func(c *counters) *atomic.Uint32 { return &c.unknownSecurityModels },
+		".1.3.6.1.6.3.11.2.1.2.0": func(c *counters) *atomic.Uint32 { return &c.invalidMsgs },
+		oidUnknownPDUHandlers:     func(c *counters) *atomic.Uint32 { return &c.unknownPDUHandlers },
+		oidUnknownContexts:        func(c *counters) *atomic.Uint32 { return &c.unknownContexts },
+		oidUnsupportedSecLevels:   func(c *counters) *atomic.Uint32 { return &c.unsupportedSecLevels },
+		oidNotInTimeWindows:       func(c *counters) *atomic.Uint32 { return &c.notInTimeWindows },
+		oidUnknownUserNames:       func(c *counters) *atomic.Uint32 { return &c.unknownUserNames },
+		oidUnknownEngineIDs:       func(c *counters) *atomic.Uint32 { return &c.unknownEngineIDs },
+		oidWrongDigests:           func(c *counters) *atomic.Uint32 { return &c.wrongDigests },
+		oidDecryptionErrors:       func(c *counters) *atomic.Uint32 { return &c.decryptionErrors },
+	} {
+		count(oid, load(get))
+	}
+	count(".1.3.6.1.6.3.12.1.4.0", nothing) // snmpUnavailableContexts
+	return out
+}
+
+// statistic reads one of the agent's own counters at the moment it is asked.
+type statistic func(*counters) uint32
+
+func (s statistic) read(c clock) any {
+	if c.stats == nil {
+		return uint32(0)
+	}
+	return s(c.stats)
+}
+
+func (statistic) check(t gosnmp.Asn1BER) error {
+	if t != gosnmp.Counter32 {
+		return fmt.Errorf("the agent's counters are Counter32, not %v", t)
+	}
+	return nil
+}

--- a/pkg/simulator/bridge.go
+++ b/pkg/simulator/bridge.go
@@ -1,0 +1,284 @@
+package simulator
+
+import (
+	"cmp"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A switch's BRIDGE-MIB (RFC 4188) and Q-BRIDGE-MIB (RFC 4363) — the ports it
+// bridges, the stations learnt on each, its spanning tree, its VLANs — and the
+// LLDP-MIB (IEEE 802.1AB) any device may answer: itself, its ports, and the
+// neighbours it hears on them.
+
+// bridgeInfo is what a switch bridges.
+type bridgeInfo struct {
+	// ports are the interfaces bridged, by ifIndex; a port's number is its
+	// place in the list, from 1.
+	ports []int
+	vlans []vlanInfo
+	// stations is how many MAC addresses an access port that is up has learnt,
+	// and uplinkStations how many the uplink has: the rest of the network sits
+	// behind it.
+	stations, uplinkStations int
+	// uplink is the bridge port towards the root of the spanning tree, whose
+	// MAC is root. No uplink makes this switch the root.
+	uplink int
+	root   net.HardwareAddr
+}
+
+// vlanInfo is one VLAN and the bridge ports it is on.
+type vlanInfo struct {
+	id               int
+	name             string
+	untagged, tagged []int
+}
+
+// pathCost is a port's 802.1D path cost at a speed.
+func pathCost(speed uint64) int {
+	switch {
+	case speed >= 10_000_000_000:
+		return 2
+	case speed >= 1_000_000_000:
+		return 4
+	case speed >= 100_000_000:
+		return 19
+	}
+	return 100
+}
+
+// macArcs is a MAC address as the six sub-identifiers of an index.
+func macArcs(mac net.HardwareAddr) string {
+	parts := make([]string, len(mac))
+	for i, b := range mac {
+		parts[i] = strconv.Itoa(int(b))
+	}
+	return strings.Join(parts, ".")
+}
+
+func addBridge(o *objects, s stack, b bridgeInfo) {
+	const br = "1.3.6.1.2.1.17."
+	zero := Const(uint32(0))
+	own := deviceMAC(s.seed, 0)
+	byIndex := make(map[int]iface, len(s.ifs))
+	for _, f := range s.ifs {
+		byIndex[f.index] = f
+	}
+	bridgeID := func(mac net.HardwareAddr, priority int) []byte {
+		return append([]byte{byte(priority >> 8), byte(priority)}, mac...)
+	}
+	self := bridgeID(own, 32768)
+	root, rootCost := self, 0
+	if b.uplink > 0 {
+		root = bridgeID(b.root, 24576)
+		rootCost = pathCost(byIndex[b.ports[b.uplink-1]].speed)
+	}
+
+	o.add(br+"1.1.0", gosnmp.OctetString, Const([]byte(own)))
+	o.add(br+"1.2.0", gosnmp.Integer, Const(len(b.ports)))
+	o.add(br+"1.3.0", gosnmp.Integer, Const(2)) // transparent-only
+	// dot1dStp: IEEE 802.1D, with its default timers in hundredths.
+	o.add(br+"2.1.0", gosnmp.Integer, Const(3))
+	o.add(br+"2.2.0", gosnmp.Integer, Const(32768))
+	o.add(br+"2.3.0", gosnmp.TimeTicks, Uptime()) // no change since it came up
+	o.add(br+"2.4.0", gosnmp.Counter32, Const(uint32(1)))
+	o.add(br+"2.5.0", gosnmp.OctetString, Const(root))
+	o.add(br+"2.6.0", gosnmp.Integer, Const(rootCost))
+	o.add(br+"2.7.0", gosnmp.Integer, Const(b.uplink))
+	for i, v := range []int{2000, 200, 100, 1500, 2000, 200, 1500} {
+		o.add(fmt.Sprintf(br+"2.%d.0", 8+i), gosnmp.Integer, Const(v))
+	}
+	o.add(br+"4.1.0", gosnmp.Counter32, zero)     // dot1dTpLearnedEntryDiscards
+	o.add(br+"4.2.0", gosnmp.Integer, Const(300)) // dot1dTpAgingTime, seconds
+
+	fdb := func(mac net.HardwareAddr, port, status int) {
+		inst := macArcs(mac)
+		o.add(br+"4.3.1.1."+inst, gosnmp.OctetString, Const([]byte(mac)))
+		o.add(br+"4.3.1.2."+inst, gosnmp.Integer, Const(port))
+		o.add(br+"4.3.1.3."+inst, gosnmp.Integer, Const(status))
+	}
+	fdb(own, 0, 4) // self
+
+	var station uint64
+	for i, ifIndex := range b.ports {
+		port := i + 1
+		f := byIndex[ifIndex]
+		up := f.up && !f.adminDown
+		base := func(c int) string { return fmt.Sprintf(br+"1.4.1.%d.%d", c, port) }
+		o.add(base(1), gosnmp.Integer, Const(port))
+		o.add(base(2), gosnmp.Integer, Const(ifIndex))
+		o.add(base(3), gosnmp.ObjectIdentifier, Const(".0.0"))
+		o.add(base(4), gosnmp.Counter32, zero)
+		o.add(base(5), gosnmp.Counter32, zero)
+
+		// The port's place in the spanning tree: the uplink is the root port and
+		// every other port that is up forwards as the designated one.
+		state, enable := 5, 1 // forwarding, enabled
+		switch {
+		case f.adminDown:
+			state, enable = 1, 2 // disabled
+		case !up:
+			state = 1 // disabled: no link
+		}
+		designatedBridge, designatedCost := self, rootCost
+		if port == b.uplink {
+			designatedBridge, designatedCost = root, 0
+		}
+		transitions := uint32(0)
+		if up {
+			transitions = 1
+		}
+		stp := func(c int) string { return fmt.Sprintf(br+"2.15.1.%d.%d", c, port) }
+		o.add(stp(1), gosnmp.Integer, Const(port))
+		o.add(stp(2), gosnmp.Integer, Const(128))
+		o.add(stp(3), gosnmp.Integer, Const(state))
+		o.add(stp(4), gosnmp.Integer, Const(enable))
+		o.add(stp(5), gosnmp.Integer, Const(pathCost(f.speed)))
+		o.add(stp(6), gosnmp.OctetString, Const(root))
+		o.add(stp(7), gosnmp.Integer, Const(designatedCost))
+		o.add(stp(8), gosnmp.OctetString, Const(designatedBridge))
+		o.add(stp(9), gosnmp.OctetString, Const([]byte{0x80, byte(port)}))
+		o.add(stp(10), gosnmp.Counter32, Const(transitions))
+
+		// dot1dTpPortTable: the frames the port has passed, which follow the
+		// interface's packets.
+		in, out := zero, zero
+		if up {
+			n := uint64(port) * 8
+			in = Counter(f.inRate/700, uint64(1e5+1e6*unit(s.seed+7400+n)), Swing{Depth: 0.6, Period: 5 * 60e9, Seed: s.seed + 7400 + n})
+			out = Counter(f.outRate/700, uint64(1e5+1e6*unit(s.seed+7401+n)), Swing{Depth: 0.5, Period: 7 * 60e9, Seed: s.seed + 7401 + n})
+		}
+		tp := func(c int) string { return fmt.Sprintf(br+"4.4.1.%d.%d", c, port) }
+		o.add(tp(1), gosnmp.Integer, Const(port))
+		o.add(tp(2), gosnmp.Integer, Const(1500))
+		o.add(tp(3), gosnmp.Counter32, in)
+		o.add(tp(4), gosnmp.Counter32, out)
+		o.add(tp(5), gosnmp.Counter32, zero)
+
+		// The stations learnt on the port; the gateway is behind the uplink.
+		if !up {
+			continue
+		}
+		n := b.stations
+		if port == b.uplink {
+			n = b.uplinkStations
+			fdb(peerMAC(s.seed, 0), port, 3)
+		}
+		for k := 0; k < n; k++ {
+			station++
+			fdb(peerMAC(s.seed, 1000+station), port, 3) // learned
+		}
+	}
+
+	// Q-BRIDGE-MIB: the VLANs, the ports each is on as a PortList — one bit a
+	// port, the first port the high bit of the first octet — and each port's
+	// own VLAN.
+	const q = br + "7.1."
+	o.add(q+"1.1.0", gosnmp.Integer, Const(1)) // version1
+	o.add(q+"1.2.0", gosnmp.Integer, Const(4094))
+	o.add(q+"1.3.0", gosnmp.Gauge32, Const(uint32(255)))
+	o.add(q+"1.4.0", gosnmp.Gauge32, Const(uint32(len(b.vlans))))
+	o.add(q+"1.5.0", gosnmp.Integer, Const(2)) // GVRP disabled
+	portList := func(ports ...[]int) []byte {
+		l := make([]byte, (len(b.ports)+7)/8)
+		for _, set := range ports {
+			for _, p := range set {
+				l[(p-1)/8] |= 0x80 >> ((p - 1) % 8)
+			}
+		}
+		return l
+	}
+	pvid := map[int]int{}
+	for _, v := range b.vlans {
+		col := func(c int) string { return fmt.Sprintf(q+"4.3.1.%d.%d", c, v.id) }
+		o.add(col(1), gosnmp.OctetString, Const(v.name))
+		o.add(col(2), gosnmp.OctetString, Const(portList(v.untagged, v.tagged)))
+		o.add(col(3), gosnmp.OctetString, Const(portList()))
+		o.add(col(4), gosnmp.OctetString, Const(portList(v.untagged)))
+		o.add(col(5), gosnmp.Integer, Const(1)) // active
+		for _, p := range v.untagged {
+			pvid[p] = v.id
+		}
+	}
+	for i := range b.ports {
+		port := i + 1
+		o.add(fmt.Sprintf(q+"4.5.1.1.%d", port), gosnmp.Gauge32, Const(uint32(cmp.Or(pvid[port], 1))))
+	}
+}
+
+// lldpInfo is what LLDP says of the device, and what it hears.
+type lldpInfo struct {
+	name, descr string
+	// caps are the system's capabilities, all of them in use.
+	caps       byte
+	neighbours []neighbour
+}
+
+// neighbour is a device heard on a port.
+type neighbour struct {
+	ifIndex                      int
+	name, descr, port, portDescr string
+	chassis                      net.HardwareAddr
+	caps                         byte
+}
+
+// The LLDP system capabilities, as the bits of one octet: bit 0, "other", is
+// the high bit.
+const (
+	capBridge  = 0x20
+	capWLAN    = 0x10
+	capRouter  = 0x08
+	capStation = 0x01
+)
+
+func addLLDP(o *objects, s stack, l lldpInfo) {
+	const lldp = "1.0.8802.1.1.2.1."
+	// lldpConfiguration: a message every 30 s, held four times as long.
+	for i, v := range []int{30, 4, 2, 2, 5} {
+		o.add(fmt.Sprintf(lldp+"1.%d.0", i+1), gosnmp.Integer, Const(v))
+	}
+	o.add(lldp+"3.1.0", gosnmp.Integer, Const(4)) // the chassis is named by a MAC
+	o.add(lldp+"3.2.0", gosnmp.OctetString, Const([]byte(deviceMAC(s.seed, 0))))
+	o.add(lldp+"3.3.0", gosnmp.OctetString, Const(l.name))
+	o.add(lldp+"3.4.0", gosnmp.OctetString, Const(l.descr))
+	o.add(lldp+"3.5.0", gosnmp.OctetString, Const([]byte{l.caps}))
+	o.add(lldp+"3.6.0", gosnmp.OctetString, Const([]byte{l.caps}))
+	// lldpLocPortTable, numbered by ifIndex, a port named by its interface.
+	for _, f := range s.ifs {
+		if f.ifType != ifTypeEthernet {
+			continue
+		}
+		col := func(c int) string { return fmt.Sprintf(lldp+"3.7.1.%d.%d", c, f.index) }
+		o.add(col(2), gosnmp.Integer, Const(5)) // interfaceName
+		o.add(col(3), gosnmp.OctetString, Const(f.ifName()))
+		o.add(col(4), gosnmp.OctetString, Const(f.descr))
+	}
+	// lldpLocManAddrTable: the management address, indexed by its type and
+	// the address with its length first.
+	if len(s.addrs) > 0 {
+		inst := "1.4." + s.primary().String()
+		col := func(c int) string { return fmt.Sprintf(lldp+"3.8.1.%d.%s", c, inst) }
+		o.add(col(3), gosnmp.Integer, Const(5))
+		o.add(col(4), gosnmp.Integer, Const(2)) // an ifIndex
+		o.add(col(5), gosnmp.Integer, Const(s.addrs[0].ifIndex))
+		o.add(col(6), gosnmp.ObjectIdentifier, Const(".0.0"))
+	}
+	// lldpRemTable, indexed by a time mark, the local port and an index.
+	for i, n := range l.neighbours {
+		inst := fmt.Sprintf("0.%d.%d", n.ifIndex, i+1)
+		col := func(c int) string { return fmt.Sprintf(lldp+"4.1.1.%d.%s", c, inst) }
+		o.add(col(4), gosnmp.Integer, Const(4))
+		o.add(col(5), gosnmp.OctetString, Const([]byte(n.chassis)))
+		o.add(col(6), gosnmp.Integer, Const(5))
+		o.add(col(7), gosnmp.OctetString, Const(n.port))
+		o.add(col(8), gosnmp.OctetString, Const(n.portDescr))
+		o.add(col(9), gosnmp.OctetString, Const(n.name))
+		o.add(col(10), gosnmp.OctetString, Const(n.descr))
+		o.add(col(11), gosnmp.OctetString, Const([]byte{n.caps}))
+		o.add(col(12), gosnmp.OctetString, Const([]byte{n.caps}))
+	}
+}

--- a/pkg/simulator/cisco.go
+++ b/pkg/simulator/cisco.go
@@ -1,7 +1,9 @@
 package simulator
 
 import (
+	"encoding/binary"
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -13,6 +15,13 @@ import (
 // sysObjectID is Cisco's, so the "Cisco (IF-MIB)" preset is offered first for
 // it, as it is for a real one.
 //
+// What a walk of one finds is all here and all agrees: BRIDGE-MIB's ports, the
+// stations learnt on each and the spanning tree towards the core; the VLANs,
+// said the same in Q-BRIDGE-MIB and CISCO-VTP-MIB; the neighbours LLDP and CDP
+// hear on the uplink and on the access point's port; ENTITY-MIB's chassis,
+// supply, fan and ports, each port pointing at its interface; the processor,
+// the memory pools and the environment as Cisco's own MIBs give them.
+//
 // The ports are numbered from 1, as the drawing preset polls them, where a
 // real 2960 numbers them from 10001; the names are a 2960's.
 var (
@@ -20,7 +29,7 @@ var (
 		ModelInfo:  ModelInfo{ID: "cisco-catalyst-24", Category: "network"},
 		enterprise: 9, // Cisco
 		build: func(id Identity) []Object {
-			return buildCatalyst(id, 24, ".1.3.6.1.4.1.9.1.716") // catalyst296024TT
+			return buildCatalyst(id, 24, ".1.3.6.1.4.1.9.1.716", "WS-C2960-24TT-L") // catalyst296024TT
 		},
 		notifications: catalystNotifications(24),
 	}
@@ -28,7 +37,7 @@ var (
 		ModelInfo:  ModelInfo{ID: "cisco-catalyst-48", Category: "network"},
 		enterprise: 9,
 		build: func(id Identity) []Object {
-			return buildCatalyst(id, 48, ".1.3.6.1.4.1.9.1.717") // catalyst296048TT
+			return buildCatalyst(id, 48, ".1.3.6.1.4.1.9.1.717", "WS-C2960-48TT-L") // catalyst296048TT
 		},
 		notifications: catalystNotifications(48),
 	}
@@ -39,19 +48,29 @@ const catalystDescr = "Cisco IOS Software, C2960 Software (C2960-LANBASEK9-M), V
 	"Copyright (c) 1986-2017 by Cisco Systems, Inc.\r\n" +
 	"Compiled Sat 19-Aug-17 09:34 by prod_rel_team"
 
-func buildCatalyst(id Identity, ports int, sysObjectID string) []Object {
+// coreDescr is what the core switch the Catalysts hang from says of itself.
+const coreDescr = "Cisco IOS Software [Cupertino], Catalyst L3 Switch Software (CAT9K_IOSXE), Version 17.9.4a, RELEASE SOFTWARE (fc3)"
+
+func buildCatalyst(id Identity, ports int, sysObjectID, model string) []Object {
 	var o objects
 	addSystem(&o, id, catalystDescr, sysObjectID, "noc@example.com", "Wiring closet, floor 2", 2) // layer 2
+	lan := lanPrefix(id.Seed)
+	serial := fmt.Sprintf("FOC%04dX%03d", 1800+int(unit(id.Seed+61)*300), int(unit(id.Seed+62)*1000))
+	uplink, spare, vlan1 := ports+1, ports+2, ports+3
 	ifs := make([]iface, 0, ports+3)
+	var access, printers []int
 	for p := 1; p <= ports; p++ {
 		f := iface{index: p, descr: fmt.Sprintf("FastEthernet0/%d", p), name: fmt.Sprintf("Fa0/%d", p),
 			ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000, mac: deviceMAC(id.Seed, uint64(p))}
 		// Most of an access switch's ports are in use and some are not, which is
-		// also why no bundled preset watches ifOperStatus. The first is always up:
-		// it is where the presets look for traffic.
+		// also why no bundled preset watches ifOperStatus. The first two are
+		// always up: a server, where the presets look for traffic, and the
+		// access point LLDP hears.
 		switch r := unit(id.Seed + 7000 + uint64(p)); {
 		case p == 1:
 			f.up, f.alias, f.inRate, f.outRate = true, "srv-01", 900_000, 2_400_000
+		case p == 2:
+			f.up, f.alias, f.inRate, f.outRate = true, "ap-openspace", 380_000, 1_900_000
 		case r < 0.06:
 			f.adminDown = true
 		case r < 0.64:
@@ -60,21 +79,85 @@ func buildCatalyst(id Identity, ports int, sysObjectID string) []Object {
 			f.outRate = 8_000 + 300_000*unit(id.Seed+7200+uint64(p))
 			f.errorRate = 0.0005
 		}
+		if p > ports-2 {
+			printers = append(printers, p)
+		} else {
+			access = append(access, p)
+		}
 		ifs = append(ifs, f)
 	}
 	ifs = append(ifs,
-		iface{index: ports + 1, descr: "GigabitEthernet0/1", name: "Gi0/1", alias: "uplink core-sw-01",
-			ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(ports+1)),
+		iface{index: uplink, descr: "GigabitEthernet0/1", name: "Gi0/1", alias: "uplink core-sw-01",
+			ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(uplink)),
 			up: true, inRate: 6_500_000, outRate: 2_800_000, errorRate: 0.001},
-		iface{index: ports + 2, descr: "GigabitEthernet0/2", name: "Gi0/2", alias: "spare uplink",
-			ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(ports+2))},
+		iface{index: spare, descr: "GigabitEthernet0/2", name: "Gi0/2", alias: "spare uplink",
+			ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(spare))},
 		// VLAN 1 carries the switch's own address, and its base MAC — the one
 		// its engine ID carries too.
-		iface{index: ports + 3, descr: "Vlan1", name: "Vl1", ifType: ifTypePropVirtual, mtu: 1500,
+		iface{index: vlan1, descr: "Vlan1", name: "Vl1", ifType: ifTypePropVirtual, mtu: 1500,
 			speed: 1_000_000_000, mac: deviceMAC(id.Seed, 0), up: true, inRate: 2_000, outRate: 1_500},
 	)
-	addInterfaces(&o, id.Seed, ifs)
-	addCiscoCPU(&o, id.Seed, 3, 24)
+	bridged := make([]int, 0, ports+2)
+	for p := 1; p <= spare; p++ {
+		bridged = append(bridged, p)
+	}
+	core := peerMAC(id.Seed, 900)
+
+	// ENTITY-MIB: the chassis, its supply, fan and temperature sensor, and a
+	// port for every physical interface.
+	entity := []physical{
+		{index: 1001, class: classChassis, relPos: -1, descr: model, name: "1", model: model, serial: serial,
+			hwRev: "V05", fwRev: "12.2(44r)SE3", swRev: "15.0(2)SE11", mfg: "Cisco Systems, Inc.", fru: false},
+		{index: 1002, container: 1001, class: classPowerSupply, relPos: 1, descr: "Power Supply 1", name: "PS1",
+			mfg: "Cisco Systems, Inc."},
+		{index: 1003, container: 1001, class: classFan, relPos: 1, descr: "Fan 1", name: "Fan 1"},
+		{index: 1004, container: 1001, class: classSensor, relPos: 1, descr: "Temperature Sensor 1", name: "Temp 1"},
+	}
+	for _, f := range ifs[:spare] {
+		entity = append(entity, physical{index: 1010 + f.index, container: 1001, class: classPort, relPos: f.index,
+			descr: f.descr, name: f.ifName(), ifIndex: f.index})
+	}
+
+	addStack(&o, stack{
+		seed:     id.Seed,
+		ifs:      ifs,
+		addrs:    []ifAddr{{ifIndex: vlan1, prefix: addrIn(lan, 2+int(id.Seed%5)), neighbours: 3}},
+		gateway:  hostIn(lan, 1),
+		ttl:      255,
+		pps:      80,
+		listen:   []uint16{22},
+		udp:      []uint16{123, 161},
+		sessions: []session{{22, netip.AddrPortFrom(hostIn(lan, 50), 58113)}},
+		entity:   entity,
+		bridge: &bridgeInfo{
+			ports: bridged,
+			vlans: []vlanInfo{
+				{id: 1, name: "default", untagged: []int{uplink, spare}},
+				{id: 10, name: "USERS", untagged: access, tagged: []int{uplink}},
+				{id: 20, name: "PRINTERS", untagged: printers, tagged: []int{uplink}},
+			},
+			stations: 1, uplinkStations: 40, uplink: uplink, root: core,
+		},
+		lldp: &lldpInfo{name: id.Name, descr: catalystDescr, caps: capBridge, neighbours: []neighbour{
+			{ifIndex: uplink, name: "core-sw-01", descr: coreDescr, port: "Gi1/0/12", portDescr: "GigabitEthernet1/0/12",
+				chassis: core, caps: capBridge | capRouter},
+			{ifIndex: 2, name: "ap-openspace", descr: "U6-Pro 6.6.77.15402", port: "eth0", portDescr: "eth0",
+				chassis: peerMAC(id.Seed, 902), caps: capWLAN | capBridge},
+		}},
+	})
+
+	addCiscoCPU(&o, id.Seed, 1001, 3, 24, 65536)
+	addCiscoMemory(&o, id.Seed, []memPool{
+		{1, "Processor", 91_000_000, [2]float64{0.26, 0.29}},
+		{2, "I/O", 25_000_000, [2]float64{0.3, 0.33}},
+	})
+	addCiscoEnv(&o, id.Seed, []envTemp{{"SW#1, Sensor#1, GREEN ", 36, 41, 60}},
+		[]string{"Switch#1, Fan#1, Normal"}, []string{"Sw1, PS1 Normal, RPS NotExist"})
+	addCDP(&o, id.Name, []cdpNeighbour{
+		{ifIndex: uplink, name: "core-sw-01.example.com", addr: hostIn(lan, 1), version: coreDescr,
+			port: "GigabitEthernet1/0/12", platform: "cisco C9300-48P", caps: 0x29, nativeVLAN: 1},
+	})
+	addVTP(&o, "OFFICE", []vtpVLAN{{1, "default", vlan1}, {10, "USERS", 0}, {20, "PRINTERS", 0}})
 	addCiscoConfigHistory(&o)
 	return o
 }
@@ -85,9 +168,11 @@ func catalystNotifications(ports int) []Notification {
 	return []Notification{linkNotification(false, ports+2), linkNotification(true, ports+1), ciscoConfigManEvent}
 }
 
-// isr4331 is a branch router: a WAN port, a LAN port, a backup WAN port that is
-// down, the management port, and two eBGP sessions, one established and one
-// not.
+// isr4331 is a branch router: a WAN port to its transit provider, a LAN port, a
+// backup WAN port that is down, the management port, and two eBGP sessions, one
+// established and one not. What it routes agrees with BGP4-MIB: the prefixes the
+// established peer sent are in its routing table, through that peer, learnt by
+// BGP from its AS, and the peer's TCP session on port 179 is in tcpConnTable.
 var isr4331 = model{
 	ModelInfo:  ModelInfo{ID: "cisco-isr-4331", Category: "network"},
 	enterprise: 9,
@@ -117,34 +202,237 @@ func buildISR4331(id Identity) []Object {
 	}
 	wan := gig(1, "GigabitEthernet0/0/0", "Gi0/0/0", "WAN transit 203.0.113.0/30")
 	wan.up, wan.inRate, wan.outRate, wan.errorRate = true, 3_200_000, 900_000, 0.002
-	lan := gig(2, "GigabitEthernet0/0/1", "Gi0/0/1", "LAN")
-	lan.up, lan.inRate, lan.outRate = true, 850_000, 3_000_000
+	lanPort := gig(2, "GigabitEthernet0/0/1", "Gi0/0/1", "LAN")
+	lanPort.up, lanPort.inRate, lanPort.outRate = true, 850_000, 3_000_000
 	mgmt := gig(4, "GigabitEthernet0", "Gi0", "management")
 	mgmt.up, mgmt.inRate, mgmt.outRate = true, 3_000, 5_000
-	addInterfaces(&o, id.Seed, []iface{
+	ifs := []iface{
 		wan,
-		lan,
+		lanPort,
 		gig(3, "GigabitEthernet0/0/2", "Gi0/0/2", "backup WAN"),
 		mgmt,
 		{index: 5, descr: "Null0", name: "Nu0", ifType: ifTypeOther, mtu: 1500, speed: 10_000_000_000, up: true},
 		{index: 6, descr: "Loopback0", name: "Lo0", ifType: ifTypeSoftwareLoopback, mtu: 1514,
 			speed: 8_000_000_000, up: true},
+	}
+	lan := lanPrefix(id.Seed)
+	transit := netip.MustParsePrefix(bgpPeers[0].remote + "/30")
+	provider := netip.MustParseAddr(bgpPeers[0].remote)
+	serial := fmt.Sprintf("FDO%04dA%03d", 2100+int(unit(id.Seed+63)*200), int(unit(id.Seed+64)*1000))
+
+	// What the established peer sent, learnt by BGP from its AS.
+	var learnt []route
+	for _, p := range []string{"192.0.2.0/24", "198.18.0.0/15", "203.0.113.64/26", "100.64.0.0/10"} {
+		learnt = append(learnt, route{dest: netip.MustParsePrefix(p), nextHop: provider, ifIndex: 1,
+			proto: protoBGP, as: bgpPeers[0].as})
+	}
+	learnt = append(learnt, route{dest: netip.MustParsePrefix("10.99.0.0/16"), nextHop: hostIn(lan, 254),
+		ifIndex: 2, proto: protoStatic, metric: 1})
+
+	entity := []physical{
+		{index: 1, class: classChassis, relPos: -1, descr: "Cisco ISR4331 Chassis", name: "Chassis", model: "ISR4331/K9",
+			serial: serial, hwRev: "V05", fwRev: "16.12(2r)", swRev: "17.09.04a", mfg: "Cisco Systems Inc"},
+		{index: 2, container: 1, class: classContainer, relPos: 0, descr: "Cisco ISR4331 Module 0 Container", name: "module 0"},
+		{index: 3, container: 2, class: classModule, relPos: 0, descr: "Front Panel 3 ports Gigabitethernet Module",
+			name: "NIM subslot 0/0", model: "ISR4331-3x1GE", mfg: "Cisco Systems Inc", fru: false},
+		{index: 4, container: 1, class: classPowerSupply, relPos: 1, descr: "250W AC Power Supply for Cisco ISR 4330",
+			name: "Power Supply Module 0", model: "PWR-4330-AC", fru: true, mfg: "Cisco Systems Inc"},
+		{index: 5, container: 1, class: classFan, relPos: 1, descr: "Cisco ISR4331 Fan Tray", name: "Fan Tray", fru: true},
+		{index: 6, container: 1, class: classCPU, relPos: 1, descr: "CPU 0 of module R0", name: "cpu R0/0"},
+	}
+	for k, f := range ifs[:3] {
+		entity = append(entity, physical{index: 10 + f.index, container: 3, class: classPort, relPos: k,
+			descr: f.descr, name: f.ifName(), ifIndex: f.index})
+	}
+
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs:  ifs,
+		addrs: []ifAddr{
+			{ifIndex: 1, prefix: netip.PrefixFrom(netip.MustParseAddr(bgpPeers[0].local), transit.Bits())},
+			{ifIndex: 2, prefix: addrIn(lan, 1), neighbours: 20},
+			{ifIndex: 4, prefix: netip.MustParsePrefix("192.168.255.4/24")},
+			{ifIndex: 6, prefix: netip.MustParsePrefix("10.255.0.1/32")},
+		},
+		gateway: provider,
+		router:  true,
+		routes:  learnt,
+		ttl:     255,
+		pps:     300,
+		listen:  []uint16{22},
+		udp:     []uint16{123, 161, 500, 4500},
+		sessions: []session{
+			{36011, netip.AddrPortFrom(provider, 179)}, // BGP, which the router opened
+			{22, netip.AddrPortFrom(hostIn(lan, 50), 58213)},
+		},
+		entity: entity,
+		lldp: &lldpInfo{name: id.Name, descr: isrDescr, caps: capRouter, neighbours: []neighbour{
+			{ifIndex: 2, name: "sw-floor-2", descr: catalystDescr, port: "Gi0/1", portDescr: "GigabitEthernet0/1",
+				chassis: peerMAC(id.Seed, 903), caps: capBridge},
+		}},
 	})
-	addCiscoCPU(&o, id.Seed, 2, 14)
+	addCiscoCPU(&o, id.Seed, 6, 2, 14, 3_900_000)
+	addCiscoMemory(&o, id.Seed, []memPool{
+		{1, "Processor", 1_966_000_000, [2]float64{0.21, 0.24}},
+		{2, "lsmpi_io", 3_149_000, [2]float64{0.99, 0.99}},
+	})
+	addCiscoEnv(&o, id.Seed, []envTemp{
+		{"Temp: Inlet 1", 24, 29, 50},
+		{"Temp: Outlet 1", 31, 38, 60},
+		{"Temp: CPU 0", 41, 55, 90},
+	}, []string{"Fan 1", "Fan 2", "Fan 3"}, []string{"PEM Iout: power-supply 0"})
+	addCDP(&o, id.Name, []cdpNeighbour{
+		{ifIndex: 2, name: "sw-floor-2", addr: hostIn(lan, 2), version: catalystDescr, port: "GigabitEthernet0/1",
+			platform: "cisco WS-C2960-24TT-L", caps: 0x28, nativeVLAN: 1},
+	})
 	addBGP(&o, id.Seed)
 	addCiscoConfigHistory(&o)
 	return o
 }
 
-// addCiscoCPU adds CISCO-PROCESS-MIB's cpmCPUTotalTable for one processor: its
-// load over five seconds, a minute and five minutes, the longer averages
-// steadier than the shorter.
-func addCiscoCPU(o *objects, seed uint64, lo, hi float64) {
+// addCiscoCPU adds CISCO-PROCESS-MIB's cpmCPUTotalTable for one processor: the
+// entity it is, its load over five seconds, a minute and five minutes — the
+// longer averages steadier than the shorter, in the deprecated columns as well
+// as the current ones — and its memory, in kilobytes.
+func addCiscoCPU(o *objects, seed uint64, entity int, lo, hi float64, memKB float64) {
 	col := func(n int) string { return fmt.Sprintf("1.3.6.1.4.1.9.9.109.1.1.1.1.%d.1", n) }
 	span := hi - lo
-	o.add(col(6), gosnmp.Gauge32, Gauge(lo, hi, Swing{Period: 2 * time.Minute, Seed: seed + 9000}))
-	o.add(col(7), gosnmp.Gauge32, Gauge(lo+span*0.2, hi-span*0.3, Swing{Period: 10 * time.Minute, Seed: seed + 9001}))
-	o.add(col(8), gosnmp.Gauge32, Gauge(lo+span*0.3, hi-span*0.5, Swing{Period: 30 * time.Minute, Seed: seed + 9002}))
+	five := Gauge(lo, hi, Swing{Period: 2 * time.Minute, Seed: seed + 9000})
+	minute := Gauge(lo+span*0.2, hi-span*0.3, Swing{Period: 10 * time.Minute, Seed: seed + 9001})
+	fiveMin := Gauge(lo+span*0.3, hi-span*0.5, Swing{Period: 30 * time.Minute, Seed: seed + 9002})
+	used := Gauge(memKB*0.2, memKB*0.24, Swing{Period: 40 * time.Minute, Seed: seed + 9003})
+	o.add(col(2), gosnmp.Integer, Const(entity))
+	for k, r := range []Reading{five, minute, fiveMin} {
+		o.add(col(3+k), gosnmp.Gauge32, r)
+		o.add(col(6+k), gosnmp.Gauge32, r)
+	}
+	o.add(col(12), gosnmp.Gauge32, used)
+	o.add(col(13), gosnmp.Gauge32, remainder(gosnmp.Gauge32, memKB, used))
+}
+
+// memPool is one of CISCO-MEMORY-POOL-MIB's pools.
+type memPool struct {
+	index int
+	name  string
+	size  float64 // bytes
+	used  [2]float64
+}
+
+// addCiscoMemory adds CISCO-MEMORY-POOL-MIB: each pool's use in bytes, what
+// is free of it, and its largest free block.
+func addCiscoMemory(o *objects, seed uint64, pools []memPool) {
+	for _, p := range pools {
+		col := func(c int) string { return fmt.Sprintf("1.3.6.1.4.1.9.9.48.1.1.1.%d.%d", c, p.index) }
+		used := Gauge(p.used[0]*p.size, p.used[1]*p.size, Swing{Period: 45 * time.Minute, Seed: seed + 9100 + uint64(p.index)})
+		free := remainder(gosnmp.Gauge32, p.size, used)
+		o.add(col(2), gosnmp.OctetString, Const(p.name))
+		o.add(col(3), gosnmp.Integer, Const(0))
+		o.add(col(4), gosnmp.Integer, Const(1)) // valid
+		o.add(col(5), gosnmp.Gauge32, used)
+		o.add(col(6), gosnmp.Gauge32, free)
+		o.add(col(7), gosnmp.Gauge32, derived{typ: gosnmp.Gauge32, f: func(c clock) any {
+			return uint32(number(free, c) * 0.8)
+		}})
+	}
+}
+
+// envTemp is a temperature CISCO-ENVMON-MIB reports, its range and threshold.
+type envTemp struct {
+	descr             string
+	lo, hi, threshold float64
+}
+
+// addCiscoEnv adds CISCO-ENVMON-MIB: the temperatures, fans and supplies, all
+// normal.
+func addCiscoEnv(o *objects, seed uint64, temps []envTemp, fans, supplies []string) {
+	const env = "1.3.6.1.4.1.9.9.13.1."
+	for i, t := range temps {
+		n := i + 1
+		col := func(c int) string { return fmt.Sprintf(env+"3.1.%d.%d", c, n) }
+		o.add(col(2), gosnmp.OctetString, Const(t.descr))
+		o.add(col(3), gosnmp.Gauge32, Gauge(t.lo, t.hi, Swing{Period: 50 * time.Minute, Seed: seed + 9200 + uint64(n)}))
+		o.add(col(4), gosnmp.Integer, Const(int(t.threshold)))
+		o.add(col(5), gosnmp.Integer, Const(int(t.threshold+10)))
+		o.add(col(6), gosnmp.Integer, Const(1)) // normal
+	}
+	for i, f := range fans {
+		n := i + 1
+		o.add(fmt.Sprintf(env+"4.1.2.%d", n), gosnmp.OctetString, Const(f))
+		o.add(fmt.Sprintf(env+"4.1.3.%d", n), gosnmp.Integer, Const(1))
+	}
+	for i, s := range supplies {
+		n := i + 1
+		o.add(fmt.Sprintf(env+"5.1.2.%d", n), gosnmp.OctetString, Const(s))
+		o.add(fmt.Sprintf(env+"5.1.3.%d", n), gosnmp.Integer, Const(1))
+		o.add(fmt.Sprintf(env+"5.1.4.%d", n), gosnmp.Integer, Const(2)) // AC
+	}
+}
+
+// cdpNeighbour is a device CDP has heard on a port.
+type cdpNeighbour struct {
+	ifIndex                       int
+	name, version, port, platform string
+	addr                          netip.Addr
+	caps                          uint32 // router 0x01, switch 0x08, IGMP 0x20…
+	nativeVLAN                    int
+}
+
+// addCDP adds CISCO-CDP-MIB: CDP running, and its cache, indexed by the port
+// and a number.
+func addCDP(o *objects, name string, neighbours []cdpNeighbour) {
+	const cdp = "1.3.6.1.4.1.9.9.23.1."
+	o.add(cdp+"3.1.0", gosnmp.Integer, Const(1)) // running
+	o.add(cdp+"3.2.0", gosnmp.Integer, Const(60))
+	o.add(cdp+"3.3.0", gosnmp.Integer, Const(180))
+	o.add(cdp+"3.4.0", gosnmp.OctetString, Const(name))
+	for i, n := range neighbours {
+		col := func(c int) string { return fmt.Sprintf(cdp+"2.1.1.%d.%d.%d", c, n.ifIndex, i+1) }
+		addr := n.addr.As4()
+		caps := binary.BigEndian.AppendUint32(nil, n.caps)
+		o.add(col(3), gosnmp.Integer, Const(1)) // ip
+		o.add(col(4), gosnmp.OctetString, Const(addr[:]))
+		o.add(col(5), gosnmp.OctetString, Const(n.version))
+		o.add(col(6), gosnmp.OctetString, Const(n.name))
+		o.add(col(7), gosnmp.OctetString, Const(n.port))
+		o.add(col(8), gosnmp.OctetString, Const(n.platform))
+		o.add(col(9), gosnmp.OctetString, Const(caps))
+		o.add(col(10), gosnmp.OctetString, Const(""))
+		o.add(col(11), gosnmp.Integer, Const(n.nativeVLAN))
+		o.add(col(12), gosnmp.Integer, Const(3)) // full duplex
+	}
+}
+
+// vtpVLAN is one of CISCO-VTP-MIB's VLANs, and the interface routing it.
+type vtpVLAN struct {
+	id      int
+	name    string
+	ifIndex int
+}
+
+// addVTP adds CISCO-VTP-MIB's management domain and its VLANs: the ones the
+// switch carries, and the four every IOS switch keeps for FDDI and Token Ring.
+func addVTP(o *objects, domain string, vlans []vtpVLAN) {
+	const vtp = "1.3.6.1.4.1.9.9.46.1."
+	o.add(vtp+"2.1.1.2.1", gosnmp.OctetString, Const(domain))
+	type row struct {
+		vtpVLAN
+		kind int // ethernet(1), fddi(2), tokenRing(3), fddiNet(4), trNet(5)
+	}
+	rows := make([]row, 0, len(vlans)+4)
+	for _, v := range vlans {
+		rows = append(rows, row{v, 1})
+	}
+	rows = append(rows, row{vtpVLAN{1002, "fddi-default", 0}, 2}, row{vtpVLAN{1003, "token-ring-default", 0}, 3},
+		row{vtpVLAN{1004, "fddinet-default", 0}, 4}, row{vtpVLAN{1005, "trnet-default", 0}, 5})
+	for _, v := range rows {
+		col := func(c int) string { return fmt.Sprintf(vtp+"3.1.1.%d.1.%d", c, v.id) }
+		o.add(col(2), gosnmp.Integer, Const(1)) // operational
+		o.add(col(3), gosnmp.Integer, Const(v.kind))
+		o.add(col(4), gosnmp.OctetString, Const(v.name))
+		o.add(col(5), gosnmp.Integer, Const(1500))
+		o.add(col(6), gosnmp.OctetString, Const(binary.BigEndian.AppendUint32(nil, uint32(100000+v.id))))
+		o.add(col(18), gosnmp.Integer, Const(v.ifIndex))
+	}
 }
 
 // ciscoConfigManEvent is CISCO-CONFIG-MAN-MIB's notice of a configuration
@@ -193,7 +481,7 @@ func bgpNotification(name string, n int, peer string) Notification {
 func addBGP(o *objects, seed uint64) {
 	o.add("1.3.6.1.2.1.15.1.0", gosnmp.OctetString, Const([]byte{0x10})) // bgpVersion: 4
 	o.add("1.3.6.1.2.1.15.2.0", gosnmp.Integer, Const(65010))            // bgpLocalAs
-	o.add("1.3.6.1.2.1.15.4.0", gosnmp.IPAddress, Const("10.255.0.1"))   // bgpIdentifier
+	o.add("1.3.6.1.2.1.15.4.0", gosnmp.IPAddress, Const("10.255.0.1"))   // bgpIdentifier: Loopback0
 	for i, p := range bgpPeers {
 		col := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.15.3.1.%d.%s", c, p.remote) }
 		n := uint64(i) * 8

--- a/pkg/simulator/custom.go
+++ b/pkg/simulator/custom.go
@@ -356,14 +356,15 @@ func (f customFile) compile() (CustomModel, error) {
 		build:         func(id Identity) []Object { return buildCustom(id, sys, ifs, objs) },
 	}
 
-	// Built once, as a device answering v3 will be: the tree catches what no
-	// field check can — an OID given twice, one under another, a value its type
-	// cannot carry — and names the OID.
-	tr, err := newTree(slices.Concat(m.build(Identity{Name: "model-check", Seed: 1}), engineObjects([]byte{0x80, 0, 0, 0, 0}, 0)))
+	// Built once, as a device answering v3 will be, with what the agent adds:
+	// the tree catches what no field check can — an OID given twice, one under
+	// another, a value its type cannot carry — and names the OID.
+	tr, err := newTree(slices.Concat(m.build(Identity{Name: "model-check", Seed: 1}),
+		agentObjects(true, []byte{0x80, 0, 0, 0, 0}, 1, false)))
 	if err != nil {
 		hint := ""
 		if strings.Contains(err.Error(), "declared twice") {
-			hint = ` ("system" makes the system group, "interfaces" makes IF-MIB's, and snmpEngine is the agent's own)`
+			hint = ` ("system" makes the system group, "interfaces" makes IF-MIB's, and the snmp group, snmpEngine and the USM statistics are the agent's own)`
 		}
 		return CustomModel{}, fmt.Errorf("the model's objects: %w%s", err, hint)
 	}

--- a/pkg/simulator/custom_test.go
+++ b/pkg/simulator/custom_test.go
@@ -255,7 +255,9 @@ func TestCustomModelsAreRefusedForWhatIsWrong(t *testing.T) {
 		{name: "an object under another", edit: withObject(object("oid", "1.3.6.1.4.1.32473.2.1.0.1", "type", "Integer32", "value", 1)),
 			want: "lies under"},
 		{name: "an object of the agent's own", edit: withObject(object("oid", "1.3.6.1.6.3.10.2.1.1.0", "type", "OctetString", "value", "x")),
-			want: "snmpEngine is the agent's own"},
+			want: "are the agent's own"},
+		{name: "an object of the snmp group", edit: withObject(object("oid", "1.3.6.1.2.1.11.1.0", "type", "Counter32", "value", 1)),
+			want: "declared twice"},
 		{name: "more objects than a model makes", edit: func(m map[string]any) { m["objects"] = many }, want: "at most 8192"},
 		{name: "a notification carrying what is not answered", edit: func(m map[string]any) {
 			m["notifications"] = []any{object("name", "probeAlarm", "oid", "1.3.6.1.4.1.32473.0.1", "objects", []any{"1.3.6.1.4.1.32473.9.9.0"})}

--- a/pkg/simulator/fortinet.go
+++ b/pkg/simulator/fortinet.go
@@ -2,6 +2,7 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -9,10 +10,12 @@ import (
 
 // fortiGate60F is a FortiGate 60F on FortiOS 7.2, a branch firewall: two WAN
 // ports, the backup one down; the DMZ; the internal switch; the FortiLink port,
-// with no FortiSwitch behind it; and the SSL VPN tunnel. FORTINET-FORTIGATE-MIB
-// gives the system scalars a FortiGate is watched by — processor, memory, disk,
-// sessions — and FORTINET-CORE-MIB the serial number its notifications carry.
-// Its sysObjectID is fgt60F, under fgModel, which is how a monitoring tool
+// with no FortiSwitch behind it; and the SSL VPN tunnel. It routes, which its
+// IP-MIB and routing table say, and FORTINET-FORTIGATE-MIB gives what a
+// FortiGate is watched by: processor, memory, disk and sessions, the VDOM, the
+// HA mode, the firewall policies' counters and two IPsec tunnels, one up and one
+// not. FORTINET-CORE-MIB gives the serial number its notifications carry. Its
+// sysObjectID is fgt60F, under fgModel, which is how a monitoring tool
 // recognises a FortiGate.
 var fortiGate60F = model{
 	ModelInfo:  ModelInfo{ID: "fortigate-60f", Category: "security"},
@@ -39,6 +42,7 @@ func buildFortiGate60F(id Identity) []Object {
 	var o objects
 	addSystem(&o, id, "FortiGate-60F", ".1.3.6.1.4.1.12356.101.1.644", // fgt60F
 		"secops@example.com", "Branch office, network room", 78)
+	serial := fmt.Sprintf("FGT60FTK2%07d", int(unit(id.Seed+1)*1e7))
 	port := func(index int, descr, alias string) iface {
 		return iface{index: index, descr: descr, alias: alias, ifType: ifTypeEthernet, mtu: 1500,
 			speed: 1_000_000_000, mac: deviceMAC(id.Seed, uint64(index))}
@@ -49,31 +53,154 @@ func buildFortiGate60F(id Identity) []Object {
 	dmz.up, dmz.inRate, dmz.outRate = true, 600_000, 2_100_000
 	internal := port(4, "internal", "LAN")
 	internal.up, internal.inRate, internal.outRate = true, 1_300_000, 5_200_000
-	addInterfaces(&o, id.Seed, []iface{
-		wan1,
-		port(2, "wan2", "ISP backup"),
-		dmz,
-		internal,
-		port(5, "fortilink", ""),
-		// A tunnel has no speed of its own.
-		{index: 6, descr: "ssl.root", alias: "SSL VPN", ifType: ifTypeTunnel, mtu: 1500, up: true,
-			inRate: 45_000, outRate: 110_000},
+	isp := netip.MustParsePrefix("198.51.100.32/29")
+	lan := lanPrefix(id.Seed)
+	dmzNet := netip.MustParsePrefix("172.16.10.0/24")
+	sslvpn := netip.MustParsePrefix("10.212.134.0/24")
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			wan1,
+			port(2, "wan2", "ISP backup"),
+			dmz,
+			internal,
+			port(5, "fortilink", ""),
+			// A tunnel has no speed of its own.
+			{index: 6, descr: "ssl.root", alias: "SSL VPN", ifType: ifTypeTunnel, mtu: 1500, up: true,
+				inRate: 45_000, outRate: 110_000},
+		},
+		addrs: []ifAddr{
+			{ifIndex: 4, prefix: addrIn(lan, 1), neighbours: 16},
+			{ifIndex: 1, prefix: addrIn(isp, 2)},
+			{ifIndex: 3, prefix: addrIn(dmzNet, 1), neighbours: 3},
+			{ifIndex: 6, prefix: addrIn(sslvpn, 1)},
+		},
+		gateway: hostIn(isp, 1),
+		router:  true,
+		ttl:     255,
+		pps:     500,
+		listen:  []uint16{22, 443, 541, 10443},
+		udp:     []uint16{53, 161, 500, 4500, 8013},
+		sessions: []session{
+			{443, netip.AddrPortFrom(hostIn(lan, 50), 54121)},      // someone in the GUI
+			{10443, netip.AddrPortFrom(hostIn(sslvpn, 11), 60312)}, // an SSL VPN user
+		},
 	})
 
-	o.add(fnSysSerial, gosnmp.OctetString, Const(fmt.Sprintf("FGT60FTK2%07d", int(unit(id.Seed+1)*1e7))))
+	o.add(fnSysSerial, gosnmp.OctetString, Const(serial))
 	o.addForNotify(fnGenTrapMsg, gosnmp.OctetString, Const("Memory usage has exceeded the configured threshold."))
 
-	const sys = "1.3.6.1.4.1.12356.101.4.1."
+	const fg = "1.3.6.1.4.1.12356.101."
 	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 30000 + n} }
-	o.add(sys+"1.0", gosnmp.OctetString, Const("v7.2.8,build1639,240313 (GA.M)")) // fgSysVersion
-	o.add(sys+"3.0", gosnmp.Gauge32, Gauge(6, 38, swing(0, 3*time.Minute)))       // fgSysCpuUsage, %
-	o.add(sys+"4.0", gosnmp.Gauge32, Gauge(47, 58, swing(1, 25*time.Minute)))     // fgSysMemUsage, %
-	o.add(sys+"5.0", gosnmp.Gauge32, Const(uint32(1_906_380)))                    // fgSysMemCapacity, KB
-	o.add(sys+"6.0", gosnmp.Gauge32, Gauge(212, 236, swing(2, 6*time.Hour)))      // fgSysDiskUsage, MB
-	o.add(sys+"7.0", gosnmp.Gauge32, Const(uint32(1_907)))                        // fgSysDiskCapacity, MB
-	o.add(sys+"8.0", gosnmp.Gauge32, Gauge(900, 4_200, swing(3, 8*time.Minute)))  // fgSysSesCount
+	cpu := Gauge(6, 38, swing(0, 3*time.Minute))
+	mem := Gauge(47, 58, swing(1, 25*time.Minute))
+	sessions := Gauge(900, 4_200, swing(3, 8*time.Minute))
+	// fgSystemInfo
+	o.add(fg+"4.1.1.0", gosnmp.OctetString, Const("v7.2.8,build1639,240313 (GA.M)")) // fgSysVersion
+	o.add(fg+"4.1.2.0", gosnmp.Integer, Const(1))                                    // fgSysMgmtVdom: root
+	o.add(fg+"4.1.3.0", gosnmp.Gauge32, cpu)                                         // fgSysCpuUsage, %
+	o.add(fg+"4.1.4.0", gosnmp.Gauge32, mem)                                         // fgSysMemUsage, %
+	o.add(fg+"4.1.5.0", gosnmp.Gauge32, Const(uint32(1_906_380)))                    // fgSysMemCapacity, KB
+	o.add(fg+"4.1.6.0", gosnmp.Gauge32, Gauge(212, 236, swing(2, 6*time.Hour)))      // fgSysDiskUsage, MB
+	o.add(fg+"4.1.7.0", gosnmp.Gauge32, Const(uint32(1_907)))                        // fgSysDiskCapacity, MB
+	o.add(fg+"4.1.8.0", gosnmp.Gauge32, sessions)                                    // fgSysSesCount
+	o.add(fg+"4.1.9.0", gosnmp.Gauge32, Gauge(20, 26, swing(4, 25*time.Minute)))     // fgSysLowMemUsage
+	o.add(fg+"4.1.10.0", gosnmp.Gauge32, Const(uint32(1_906_380)))                   // fgSysLowMemCapacity
+	// New sessions a second, averaged over one, ten, thirty and sixty minutes:
+	// the longer the average, the slower it moves.
+	for i, minutes := range []int{1, 10, 30, 60} {
+		rate := Gauge(8, 60, swing(10+uint64(i), time.Duration(minutes+1)*time.Minute))
+		o.add(fmt.Sprintf(fg+"4.1.%d.0", 11+i), gosnmp.Gauge32, rate)
+	}
+	o.add(fg+"4.1.15.0", gosnmp.Gauge32, Gauge(40, 160, swing(5, 8*time.Minute))) // fgSysSes6Count
 	// fgSysUpTime counts hundredths of a second in 64 bits, where sysUpTime
 	// wraps after 497 days.
-	o.add(sys+"20.0", gosnmp.Counter64, Counter64(100, 0, Swing{}))
+	o.add(fg+"4.1.20.0", gosnmp.Counter64, Counter64(100, 0, Swing{}))
+	o.add(fg+"4.1.24.0", gosnmp.Gauge32, Gauge(300, 1_900, swing(3, 8*time.Minute))) // fgSysNpuSesCount
+
+	// fgVirtualDomain: one VDOM, root, in NAT mode, standing alone.
+	o.add(fg+"3.1.1.0", gosnmp.Integer, Const(1))  // fgVdNumber
+	o.add(fg+"3.1.2.0", gosnmp.Integer, Const(10)) // fgVdMaxVdoms
+	vd := func(c int) string { return fmt.Sprintf(fg+"3.2.1.1.%d.1", c) }
+	o.add(vd(1), gosnmp.Integer, Const(1))
+	o.add(vd(2), gosnmp.OctetString, Const("root"))
+	o.add(vd(3), gosnmp.Integer, Const(1)) // nat
+	o.add(vd(4), gosnmp.Integer, Const(3)) // standalone
+	o.add(vd(5), gosnmp.Gauge32, cpu)
+	o.add(vd(6), gosnmp.Gauge32, mem)
+	o.add(vd(7), gosnmp.Gauge32, sessions)
+	o.add(vd(8), gosnmp.Gauge32, Gauge(8, 60, swing(10, 2*time.Minute)))
+	o.add(vd(9), gosnmp.OctetString, Const(fmt.Sprintf("%08x", uint32(mix(id.Seed+81)))))
+
+	// fgFwPolStatsTable, indexed by VDOM and policy: what each policy has let
+	// through.
+	for i, p := range []struct {
+		id  int
+		bps float64
+	}{{1, 600_000}, {2, 2_400_000}, {3, 90_000}, {4, 12_000}} {
+		col := func(c int) string { return fmt.Sprintf(fg+"5.1.2.1.1.%d.1.%d", c, p.id) }
+		n := 40 + uint64(i)*4
+		s := Swing{Depth: 0.6, Period: 9 * time.Minute, Seed: id.Seed + 31000 + n}
+		start := uint64(1e6 + 1e9*unit(id.Seed+31100+n))
+		o.add(col(2), gosnmp.Counter32, Counter(p.bps/800, start/800, s))
+		o.add(col(3), gosnmp.Counter32, Counter(p.bps, start, s))
+		o.add(col(4), gosnmp.OctetString, Const("2024-09-11 06:25:41"))
+		o.add(col(5), gosnmp.Counter64, Counter64(p.bps/800, start/800, s))
+		o.add(col(6), gosnmp.Counter64, Counter64(p.bps, start, s))
+	}
+
+	// fgHaInfo: standalone, so its statistics table has the one member.
+	o.add(fg+"13.1.1.0", gosnmp.Integer, Const(1)) // fgHaSystemMode: standalone
+	o.add(fg+"13.1.2.0", gosnmp.Integer, Const(0))
+	o.add(fg+"13.1.3.0", gosnmp.Integer, Const(128))
+	o.add(fg+"13.1.7.0", gosnmp.OctetString, Const(""))
+	ha := func(c int) string { return fmt.Sprintf(fg+"13.2.1.1.%d.1", c) }
+	o.add(ha(2), gosnmp.OctetString, Const(serial))
+	o.add(ha(11), gosnmp.OctetString, Const(id.Name))
+	o.add(ha(12), gosnmp.Integer, Const(1)) // synchronised
+
+	// fgVpnTunTable: two site-to-site tunnels, indexed by tunnel and phase-2.
+	for i, t := range []struct {
+		phase1, phase2, remote string
+		local, remoteNet       netip.Prefix
+		up                     bool
+		rate                   float64
+	}{
+		{"to-hq", "to-hq-p2", "203.0.113.77", lan, netip.MustParsePrefix("10.0.0.0/16"), true, 180_000},
+		{"to-store-12", "to-store-12-p2", "192.0.2.144", lan, netip.MustParsePrefix("10.12.0.0/24"), false, 0},
+	} {
+		row := i + 1
+		col := func(c int) string { return fmt.Sprintf(fg+"12.2.2.1.%d.%d.1", c, row) }
+		n := 60 + uint64(i)*4
+		s := Swing{Depth: 0.6, Period: 11 * time.Minute, Seed: id.Seed + 32000 + n}
+		status := 1 // down
+		var in, out Reading = Const(uint64(0)), Const(uint64(0))
+		if t.up {
+			status = 2
+			in = Counter64(t.rate, uint64(1e8*unit(id.Seed+32100+n)), s)
+			out = Counter64(t.rate*0.4, uint64(1e8*unit(id.Seed+32101+n)), s)
+		}
+		last := func(p netip.Prefix) string { return hostIn(p, (1<<(32-p.Bits()))-1).String() }
+		o.add(col(2), gosnmp.OctetString, Const(t.phase1))
+		o.add(col(3), gosnmp.OctetString, Const(t.phase2))
+		o.add(col(4), gosnmp.IPAddress, Const(t.remote))
+		o.add(col(5), gosnmp.Integer, Const(500))
+		o.add(col(6), gosnmp.IPAddress, Const(hostIn(isp, 2).String()))
+		o.add(col(7), gosnmp.Integer, Const(500))
+		o.add(col(8), gosnmp.IPAddress, Const(t.local.Masked().Addr().String()))
+		o.add(col(9), gosnmp.IPAddress, Const(last(t.local)))
+		o.add(col(10), gosnmp.Integer, Const(0))
+		o.add(col(11), gosnmp.IPAddress, Const(t.remoteNet.Masked().Addr().String()))
+		o.add(col(12), gosnmp.IPAddress, Const(last(t.remoteNet)))
+		o.add(col(13), gosnmp.Integer, Const(0))
+		o.add(col(14), gosnmp.Integer, Const(0))
+		o.add(col(15), gosnmp.Gauge32, Const(uint32(43200)))
+		o.add(col(16), gosnmp.Gauge32, Const(uint32(0)))
+		o.add(col(17), gosnmp.Gauge32, Const(uint32(43200)))
+		o.add(col(18), gosnmp.Counter64, in)
+		o.add(col(19), gosnmp.Counter64, out)
+		o.add(col(20), gosnmp.Integer, Const(status))
+		o.add(col(21), gosnmp.Integer, Const(1)) // VDOM root
+	}
 	return o
 }

--- a/pkg/simulator/hostres.go
+++ b/pkg/simulator/hostres.go
@@ -1,30 +1,53 @@
 package simulator
 
 import (
+	"cmp"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
 )
 
-// The hrStorageTypes of HOST-RESOURCES-TYPES the models use.
+// The types of HOST-RESOURCES-TYPES the models use.
 const (
+	hrStorageOther         = ".1.3.6.1.2.1.25.2.1.1"
 	hrStorageRam           = ".1.3.6.1.2.1.25.2.1.2"
 	hrStorageVirtualMemory = ".1.3.6.1.2.1.25.2.1.3"
 	hrStorageFixedDisk     = ".1.3.6.1.2.1.25.2.1.4"
+	hrStorageFlashMemory   = ".1.3.6.1.2.1.25.2.1.9"
+
+	hrDeviceProcessor   = ".1.3.6.1.2.1.25.3.1.3"
+	hrDeviceNetwork     = ".1.3.6.1.2.1.25.3.1.4"
+	hrDevicePrinter     = ".1.3.6.1.2.1.25.3.1.5"
+	hrDeviceDiskStorage = ".1.3.6.1.2.1.25.3.1.6"
+
+	hrFSOther     = ".1.3.6.1.2.1.25.3.9.1"
+	hrFSNTFS      = ".1.3.6.1.2.1.25.3.9.9"
+	hrFSLinuxExt2 = ".1.3.6.1.2.1.25.3.9.23"
 )
 
 // hostResources is what HOST-RESOURCES-MIB (RFC 2790) says of a machine.
 type hostResources struct {
 	memoryKiB int
 	// users and processes are the ranges hrSystemNumUsers and
-	// hrSystemProcesses swing in.
+	// hrSystemProcesses swing in. A machine that lists its processes counts
+	// them instead.
 	users, processes [2]float64
 	storage          []storageArea
 	// processors are the hrDeviceIndex of each processor, which an agent
 	// chooses: net-snmp numbers them from 196608, Windows after its disks.
 	processors   []int
 	cpuLo, cpuHi float64
+	// cpu names the processors in hrDeviceTable.
+	cpu string
+	// boot is hrSystemInitialLoadDevice, and bootParams what it started with.
+	boot       int
+	bootParams string
+	devices    []hrDevice
+	fs         []hrFS
+	procs      []process
+	software   []software
 }
 
 type storageArea struct {
@@ -35,15 +58,63 @@ type storageArea struct {
 	period      time.Duration
 }
 
-// addHostResources adds the system scalars, the storage table and the
-// processor table: everything the "Server (HOST-RESOURCES-MIB)" preset polls.
+// hrDevice is a device of hrDeviceTable other than a processor.
+type hrDevice struct {
+	index int
+	kind  string // an hrDeviceType
+	descr string
+	// ifIndex is a network device's interface (hrNetworkTable).
+	ifIndex int
+	// diskKB is a disk's capacity (hrDiskStorageTable), media its
+	// hrDiskStorageMedia: hardDisk(3), ramDisk(8).
+	diskKB, media int
+	removable     bool
+}
+
+// hrFS is a file system of hrFSTable, on the storage area storage.
+type hrFS struct {
+	mount, kind string
+	storage     int
+	bootable    bool
+}
+
+// process is a row of hrSWRunTable, and what it uses (hrSWRunPerfTable).
+type process struct {
+	pid              int
+	name, path, args string
+	// kind is hrSWRunType: operatingSystem(2), deviceDriver(3), application(4).
+	kind  int
+	cpu   float64 // the share of one processor it uses
+	memKB int
+}
+
+// software is a row of hrSWInstalledTable.
+type software struct {
+	name      string
+	installed time.Time
+}
+
+// noDate is the DateAndTime a file system that was never backed up reports.
+var noDate = []byte{0, 0, 1, 1, 0, 0, 0, 0}
+
+// addHostResources adds HOST-RESOURCES-MIB: the system scalars, the storage
+// table, the devices — the processors among them — the file systems, and what
+// is running and installed.
 func addHostResources(o *objects, seed uint64, hr hostResources) {
 	swing := func(n uint64, period time.Duration) Swing {
 		return Swing{Period: period, Seed: seed + 1<<16 + n}
 	}
+	processes := Gauge(hr.processes[0], hr.processes[1], swing(1, 7*time.Minute))
+	if len(hr.procs) > 0 {
+		processes = Const(uint32(len(hr.procs)))
+	}
 	o.add("1.3.6.1.2.1.25.1.1.0", gosnmp.TimeTicks, Uptime())
+	o.add("1.3.6.1.2.1.25.1.2.0", gosnmp.OctetString, DateAndTime())
+	o.add("1.3.6.1.2.1.25.1.3.0", gosnmp.Integer, Const(cmp.Or(hr.boot, 1536)))
+	o.add("1.3.6.1.2.1.25.1.4.0", gosnmp.OctetString, Const(hr.bootParams))
 	o.add("1.3.6.1.2.1.25.1.5.0", gosnmp.Gauge32, Gauge(hr.users[0], hr.users[1], swing(0, 20*time.Minute)))
-	o.add("1.3.6.1.2.1.25.1.6.0", gosnmp.Gauge32, Gauge(hr.processes[0], hr.processes[1], swing(1, 7*time.Minute)))
+	o.add("1.3.6.1.2.1.25.1.6.0", gosnmp.Gauge32, processes)
+	o.add("1.3.6.1.2.1.25.1.7.0", gosnmp.Integer, Const(0)) // no fixed limit
 	o.add("1.3.6.1.2.1.25.2.2.0", gosnmp.Integer, Const(hr.memoryKiB))
 
 	for i, st := range hr.storage {
@@ -55,11 +126,110 @@ func addHostResources(o *objects, seed uint64, hr hostResources) {
 		o.add(col(5), gosnmp.Integer, Const(st.size))
 		o.add(col(6), gosnmp.Integer, IntegerGauge(st.lo*float64(st.size), st.hi*float64(st.size),
 			swing(100+uint64(i), st.period)))
+		o.add(col(7), gosnmp.Counter32, Const(uint32(0)))
 	}
 
+	device := func(index int, kind, descr string) {
+		col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.25.3.2.1.%d.%d", n, index) }
+		o.add(col(1), gosnmp.Integer, Const(index))
+		o.add(col(2), gosnmp.ObjectIdentifier, Const(kind))
+		o.add(col(3), gosnmp.OctetString, Const(descr))
+		o.add(col(4), gosnmp.ObjectIdentifier, Const(".0.0"))
+		o.add(col(5), gosnmp.Integer, Const(2)) // running
+		o.add(col(6), gosnmp.Counter32, Const(uint32(0)))
+	}
 	for i, index := range hr.processors {
+		device(index, hrDeviceProcessor, cmp.Or(hr.cpu, "GenuineIntel: Intel(R) Xeon(R) CPU"))
 		o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.3.1.1.%d", index), gosnmp.ObjectIdentifier, Const(".0.0"))
 		o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.3.1.2.%d", index), gosnmp.Integer,
 			IntegerGauge(hr.cpuLo, hr.cpuHi, swing(200+uint64(i), 90*time.Second)))
+	}
+	for _, d := range hr.devices {
+		device(d.index, d.kind, d.descr)
+		switch d.kind {
+		case hrDeviceNetwork:
+			o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.4.1.1.%d", d.index), gosnmp.Integer, Const(d.ifIndex))
+		case hrDevicePrinter:
+			o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.5.1.1.%d", d.index), gosnmp.Integer, Const(3)) // idle
+			o.add(fmt.Sprintf("1.3.6.1.2.1.25.3.5.1.2.%d", d.index), gosnmp.OctetString, Const([]byte{0x00}))
+		case hrDeviceDiskStorage:
+			removable := 2
+			if d.removable {
+				removable = 1
+			}
+			col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.25.3.6.1.%d.%d", n, d.index) }
+			o.add(col(1), gosnmp.Integer, Const(1)) // readWrite
+			o.add(col(2), gosnmp.Integer, Const(cmp.Or(d.media, 3)))
+			o.add(col(3), gosnmp.Integer, Const(removable))
+			// KBytes is an Integer32: a disk past 2 TB reports the ceiling, as
+			// real agents do.
+			o.add(col(4), gosnmp.Integer, Const(min(d.diskKB, math.MaxInt32)))
+		}
+	}
+
+	for i, fs := range hr.fs {
+		n := i + 1
+		col := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.25.3.8.1.%d.%d", c, n) }
+		bootable := 2
+		if fs.bootable {
+			bootable = 1
+		}
+		o.add(col(1), gosnmp.Integer, Const(n))
+		o.add(col(2), gosnmp.OctetString, Const(fs.mount))
+		o.add(col(3), gosnmp.OctetString, Const(""))
+		o.add(col(4), gosnmp.ObjectIdentifier, Const(fs.kind))
+		o.add(col(5), gosnmp.Integer, Const(1)) // readWrite
+		o.add(col(6), gosnmp.Integer, Const(bootable))
+		o.add(col(7), gosnmp.Integer, Const(fs.storage))
+		o.add(col(8), gosnmp.OctetString, Const(noDate))
+		o.add(col(9), gosnmp.OctetString, Const(noDate))
+	}
+
+	// hrSWRunTable and hrSWRunPerfTable, indexed by the process ID. A process
+	// that uses the processor at all is running, the rest wait (runnable), as
+	// net-snmp reads a sleeping process.
+	if len(hr.procs) > 0 {
+		os := hr.procs[0].pid
+		for _, p := range hr.procs {
+			if p.kind == 2 {
+				os = p.pid
+				break
+			}
+		}
+		o.add("1.3.6.1.2.1.25.4.1.0", gosnmp.Integer, Const(os))
+	}
+	for i, p := range hr.procs {
+		col := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.25.4.2.1.%d.%d", c, p.pid) }
+		perf := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.25.5.1.1.%d.%d", c, p.pid) }
+		status := 2
+		if p.cpu >= 0.05 {
+			status = 1
+		}
+		o.add(col(1), gosnmp.Integer, Const(p.pid))
+		o.add(col(2), gosnmp.OctetString, Const(p.name))
+		o.add(col(3), gosnmp.ObjectIdentifier, Const(".0.0"))
+		o.add(col(4), gosnmp.OctetString, Const(p.path))
+		o.add(col(5), gosnmp.OctetString, Const(p.args))
+		o.add(col(6), gosnmp.Integer, Const(cmp.Or(p.kind, 4)))
+		o.add(col(7), gosnmp.Integer, Const(status))
+		// Centi-seconds of processor since it started, and its memory.
+		n := 300 + uint64(i)
+		o.add(perf(1), gosnmp.Integer, IntegerCounter(p.cpu*100, uint64(100+4e5*p.cpu*unit(seed+n)),
+			Swing{Depth: 0.8, Period: 3 * time.Minute, Seed: seed + n}))
+		o.add(perf(2), gosnmp.Integer, IntegerGauge(float64(p.memKB)*0.97, float64(p.memKB)*1.03, swing(n, 10*time.Minute)))
+	}
+
+	if len(hr.software) > 0 {
+		o.add("1.3.6.1.2.1.25.6.1.0", gosnmp.TimeTicks, Const(uint32(0)))
+		o.add("1.3.6.1.2.1.25.6.2.0", gosnmp.TimeTicks, Const(uint32(0)))
+	}
+	for i, s := range hr.software {
+		n := i + 1
+		col := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.25.6.3.1.%d.%d", c, n) }
+		o.add(col(1), gosnmp.Integer, Const(n))
+		o.add(col(2), gosnmp.OctetString, Const(s.name))
+		o.add(col(3), gosnmp.ObjectIdentifier, Const(".0.0"))
+		o.add(col(4), gosnmp.Integer, Const(4)) // application
+		o.add(col(5), gosnmp.OctetString, Const(dateAndTimeOf(s.installed)))
 	}
 }

--- a/pkg/simulator/idrac.go
+++ b/pkg/simulator/idrac.go
@@ -2,6 +2,7 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -11,9 +12,12 @@ import (
 // dellIDRAC9 is the iDRAC9 of a Dell PowerEdge R750: the controller a server is
 // watched through out of band, whatever its operating system is doing.
 // IDRAC-MIB gives the server's global and storage status, its power state and
-// how long it has been on, its temperatures, fans and power consumption. Its
-// alert is one of the iDRAC's, carrying the eleven objects every iDRAC alert
-// carries — accessible-for-notify, so no request reads them.
+// how long it has been on, its BIOS, its two processors and eight memory
+// modules, its two power supplies, its temperatures, fans and power
+// consumption, and its storage — the RAID controller, four disks and the two
+// virtual disks made of them. Its alert is one of the iDRAC's, carrying the
+// eleven objects every iDRAC alert carries — accessible-for-notify, so no
+// request reads them.
 var dellIDRAC9 = model{
 	ModelInfo:  ModelInfo{ID: "dell-idrac9", Category: "server"},
 	enterprise: 674, // Dell
@@ -59,9 +63,19 @@ func buildDellIDRAC9(id Identity) []Object {
 	fqdn := "r750-" + strings.ToLower(tag) + ".example.com"
 	addSystem(&o, id, "Dell Out-of-band SNMP Agent for Remote Access Controller", ".1.3.6.1.4.1.674.10892.5",
 		"it@example.com", "Server room, rack B3", 72)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "eth0", alias: "iDRAC dedicated port", ifType: ifTypeEthernet, mtu: 1500,
-			speed: 1_000_000_000, mac: deviceMAC(id.Seed, 1), up: true, inRate: 6_000, outRate: 9_000},
+	lan := lanPrefix(id.Seed)
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "eth0", alias: "iDRAC dedicated port", ifType: ifTypeEthernet, mtu: 1500,
+				speed: 1_000_000_000, mac: deviceMAC(id.Seed, 1), up: true, inRate: 6_000, outRate: 9_000},
+		},
+		addrs:    []ifAddr{{ifIndex: 1, prefix: addrIn(lan, 30+int(id.Seed%20)), neighbours: 2}},
+		gateway:  hostIn(lan, 1),
+		pps:      40,
+		listen:   []uint16{22, 80, 443, 5900},
+		udp:      []uint16{161, 623},
+		sessions: []session{{443, netip.AddrPortFrom(hostIn(lan, 50), 55301)}}, // someone in the web interface
 	})
 
 	// racInfoGroup and systemInfoGroup
@@ -80,13 +94,27 @@ func buildDellIDRAC9(id Identity) []Object {
 	o.add(idrac+"2.5.0", gosnmp.Gauge32, SecondsUp()) // systemPowerUpTime: an Unsigned32, seconds
 
 	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 80000 + n} }
-	// A probe table row is indexed by the chassis, then the probe, and says
-	// where the probe is; the status is ok(3) throughout.
-	probe := func(table string, n int, name string, status int, reading Reading, kind int) {
-		col := func(c int) string { return fmt.Sprintf(idrac+"4.%s.1.%d.1.%d", table, c, n) }
+	// A table of systemDetailsGroup is indexed by the chassis, then the item.
+	row := func(table string, n int) func(c int) string {
+		return func(c int) string { return fmt.Sprintf(idrac+"4.%s.1.%d.1.%d", table, c, n) }
+	}
+	chassis := func(col func(int) string, n, status int) {
 		o.add(col(1), gosnmp.Integer, Const(1))
 		o.add(col(2), gosnmp.Integer, Const(n))
 		o.add(col(5), gosnmp.Integer, Const(status))
+	}
+
+	// systemBIOSTable
+	bios := row("300.50", 1)
+	chassis(bios, 1, 3)
+	o.add(bios(7), gosnmp.OctetString, Const("20240513000000.000000+000"))
+	o.add(bios(8), gosnmp.OctetString, Const("1.13.2"))
+	o.add(bios(11), gosnmp.OctetString, Const("Dell Inc."))
+
+	// A probe says where it is and reads a value; the status is ok(3) throughout.
+	probe := func(table string, n int, name string, reading Reading, kind int) {
+		col := row(table, n)
+		chassis(col, n, 3)
 		o.add(col(6), gosnmp.Integer, reading)
 		if kind != 0 {
 			o.add(col(7), gosnmp.Integer, Const(kind))
@@ -103,19 +131,98 @@ func buildDellIDRAC9(id Identity) []Object {
 		{"CPU1 Temp", 480, 620},
 		{"CPU2 Temp", 470, 610},
 	} {
-		probe("700.20", i+1, p.name, 3, IntegerGauge(p.lo, p.hi, swing(uint64(i), 20*time.Minute)), 0)
+		probe("700.20", i+1, p.name, IntegerGauge(p.lo, p.hi, swing(uint64(i), 20*time.Minute)), 0)
 	}
 	// coolingDeviceTable: six fans, in RPM
 	for n := 1; n <= 6; n++ {
-		probe("700.12", n, fmt.Sprintf("System Board Fan%d", n), 3,
-			IntegerGauge(5280, 6960, swing(10+uint64(n), 15*time.Minute)), 0)
+		probe("700.12", n, fmt.Sprintf("System Board Fan%d", n), IntegerGauge(5280, 6960, swing(10+uint64(n), 15*time.Minute)), 0)
 	}
 	// amperageProbeTable: each supply's current in tenths of an amp
 	// (amperageProbeTypeIsPowerSupplyAmps), and what the server draws in watts
-	// (amperageProbeTypeIsSystemWatts).
-	probe("600.30", 1, "PS1 Current 1", 3, IntegerGauge(8, 14, swing(20, 10*time.Minute)), 23)
-	probe("600.30", 2, "PS2 Current 2", 3, IntegerGauge(8, 13, swing(20, 10*time.Minute)), 23)
-	probe("600.30", 3, "System Board Pwr Consumption", 3, IntegerGauge(294, 462, swing(20, 10*time.Minute)), 26)
+	// (amperageProbeTypeIsSystemWatts) — one swing, since they are one load.
+	load := swing(20, 10*time.Minute)
+	probe("600.30", 1, "PS1 Current 1", IntegerGauge(8, 14, load), 23)
+	probe("600.30", 2, "PS2 Current 2", IntegerGauge(8, 13, load), 23)
+	probe("600.30", 3, "System Board Pwr Consumption", IntegerGauge(294, 462, load), 26)
+	// powerSupplyTable: two 1400 W supplies, sharing the load.
+	for n := 1; n <= 2; n++ {
+		col := row("600.12", n)
+		chassis(col, n, 3)
+		o.add(col(6), gosnmp.Integer, Const(14000)) // tenths of a watt
+		o.add(col(8), gosnmp.OctetString, Const(fmt.Sprintf("PS%d Status", n)))
+		o.add(col(9), gosnmp.Integer, Const(240))
+		o.add(col(15), gosnmp.OctetString, Const(fmt.Sprintf("PSU.Slot.%d", n)))
+		o.add(col(16), gosnmp.Integer, IntegerGauge(228, 233, swing(30+uint64(n), 40*time.Minute)))
+	}
+	// processorDeviceTable: two sockets.
+	for n := 1; n <= 2; n++ {
+		col := row("1100.30", n)
+		chassis(col, n, 3)
+		o.add(col(7), gosnmp.Integer, Const(3)) // a central processor
+		o.add(col(8), gosnmp.OctetString, Const("Intel"))
+		o.add(col(11), gosnmp.Gauge32, Const(uint32(4000))) // MHz
+		o.add(col(12), gosnmp.Gauge32, Const(uint32(2000)))
+		o.add(col(17), gosnmp.Gauge32, Const(uint32(28)))
+		o.add(col(19), gosnmp.Gauge32, Const(uint32(56)))
+		o.add(col(23), gosnmp.OctetString, Const("Intel(R) Xeon(R) Gold 6330 CPU @ 2.00GHz"))
+		o.add(col(26), gosnmp.OctetString, Const(fmt.Sprintf("CPU.Socket.%d", n)))
+	}
+	// memoryDeviceTable: eight 32 GiB DDR4 modules.
+	for n := 1; n <= 8; n++ {
+		slot := fmt.Sprintf("%c%d", 'A'+(n-1)/4, (n-1)%4+1)
+		col := row("1100.50", n)
+		chassis(col, n, 3)
+		o.add(col(7), gosnmp.Integer, Const(26)) // DDR4
+		o.add(col(8), gosnmp.OctetString, Const("DIMM.Socket."+slot))
+		o.add(col(14), gosnmp.Gauge32, Const(uint32(33554432))) // KB
+		o.add(col(15), gosnmp.Gauge32, Const(uint32(3200)))     // MT/s
+		o.add(col(21), gosnmp.OctetString, Const("Samsung"))
+		o.add(col(22), gosnmp.OctetString, Const("M393A4K40EB3-CWE"))
+		o.add(col(23), gosnmp.OctetString, Const(fmt.Sprintf("%08X", uint32(mix(id.Seed+500+uint64(n))))))
+		o.add(col(26), gosnmp.OctetString, Const("DIMM.Socket."+slot))
+	}
+
+	// storageDetailsGroup: the PERC controller, four disks, and the two
+	// virtual disks made of them — a mirror for the system, RAID 5 for data.
+	const storage = idrac + "5.1.20."
+	ctl := func(c int) string { return fmt.Sprintf(storage+"130.1.1.%d.1", c) }
+	o.add(ctl(1), gosnmp.Integer, Const(1))
+	o.add(ctl(2), gosnmp.OctetString, Const("PERC H755 Front"))
+	o.add(ctl(8), gosnmp.OctetString, Const("52.26.0-5179"))
+	o.add(ctl(37), gosnmp.Integer, Const(3))
+	o.add(ctl(38), gosnmp.Integer, Const(3))
+	o.add(ctl(78), gosnmp.OctetString, Const("RAID.SL.3-1"))
+	const diskMB = 1144064
+	for n := 1; n <= 4; n++ {
+		col := func(c int) string { return fmt.Sprintf(storage+"130.4.1.%d.%d", c, n) }
+		used := diskMB * 9 / 10
+		o.add(col(1), gosnmp.Integer, Const(n))
+		o.add(col(2), gosnmp.OctetString, Const(fmt.Sprintf("Physical Disk 0:1:%d", n-1)))
+		o.add(col(3), gosnmp.OctetString, Const("SEAGATE"))
+		o.add(col(4), gosnmp.Integer, Const(3)) // online
+		o.add(col(6), gosnmp.OctetString, Const("ST1200MM0099"))
+		o.add(col(7), gosnmp.OctetString, Const(fmt.Sprintf("WFK%05d", int(unit(id.Seed+600+uint64(n))*1e5))))
+		o.add(col(11), gosnmp.Integer, Const(diskMB))
+		o.add(col(17), gosnmp.Integer, Const(used))
+		o.add(col(19), gosnmp.Integer, Const(diskMB-used))
+		o.add(col(24), gosnmp.Integer, Const(3))
+		o.add(col(35), gosnmp.Integer, Const(2)) // a hard disk
+		o.add(col(54), gosnmp.OctetString, Const(fmt.Sprintf("Disk.Bay.%d:Enclosure.Internal.0-1:RAID.SL.3-1", n-1)))
+	}
+	for n, v := range []struct {
+		name   string
+		sizeMB int
+		layout int // r1(3), r5(4)
+	}{{"OS", 228864, 3}, {"DATA", 3203584, 4}} {
+		col := func(c int) string { return fmt.Sprintf(storage+"140.1.1.%d.%d", c, n+1) }
+		o.add(col(1), gosnmp.Integer, Const(n+1))
+		o.add(col(2), gosnmp.OctetString, Const(v.name))
+		o.add(col(4), gosnmp.Integer, Const(2)) // online
+		o.add(col(6), gosnmp.Integer, Const(v.sizeMB))
+		o.add(col(13), gosnmp.Integer, Const(v.layout))
+		o.add(col(20), gosnmp.Integer, Const(3))
+		o.add(col(35), gosnmp.OctetString, Const(fmt.Sprintf("Disk.Virtual.%d:RAID.SL.3-1", n)))
+	}
 
 	// alertVariablesGroup: what alertTemperatureProbeWarning says.
 	for i, v := range []struct {

--- a/pkg/simulator/ifaces.go
+++ b/pkg/simulator/ifaces.go
@@ -13,6 +13,7 @@ import (
 const (
 	ifTypeOther            = 1
 	ifTypeEthernet         = 6
+	ifTypePPP              = 23
 	ifTypeSoftwareLoopback = 24
 	ifTypePropVirtual      = 53
 	ifTypeIEEE80211        = 71
@@ -34,8 +35,23 @@ type iface struct {
 	errorRate          float64 // input errors per second, while up
 }
 
-// addInterfaces adds IF-MIB's ifNumber, ifTable and ifXTable. An interface that
-// is down keeps the counts it made while it was up, and adds nothing to them.
+// ifName is the interface's short name: its description when it has none of
+// its own.
+func (f iface) ifName() string {
+	if f.name != "" {
+		return f.name
+	}
+	return f.descr
+}
+
+// addInterfaces adds IF-MIB whole: ifNumber, every column of ifTable and of
+// ifXTable, ifStackTable and the last-change scalars. An interface that is down
+// keeps the counts it made while it was up, and adds nothing to them.
+//
+// A 32-bit counter and its 64-bit twin are built from the same arguments, so
+// they agree — ifInUcastPkts is ifHCInUcastPkts modulo 2^32 — and the packets
+// follow the octets: about 900 octets a packet in, 700 out, a few in a hundred
+// multicast or broadcast.
 func addInterfaces(o *objects, seed uint64, ifs []iface) {
 	swing := func(n uint64, depth float64, period time.Duration) Swing {
 		return Swing{Depth: depth, Period: period, Seed: seed + n}
@@ -45,6 +61,7 @@ func addInterfaces(o *objects, seed uint64, ifs []iface) {
 	start := func(n uint64, base, spread float64) uint64 {
 		return uint64(base + spread*unit(seed+1000+n))
 	}
+	zero := Const(uint32(0))
 	o.add("1.3.6.1.2.1.2.1.0", gosnmp.Integer, Const(len(ifs)))
 	for _, f := range ifs {
 		col := func(n int) string { return fmt.Sprintf("1.3.6.1.2.1.2.2.1.%d.%d", n, f.index) }
@@ -58,16 +75,26 @@ func addInterfaces(o *objects, seed uint64, ifs []iface) {
 		if f.up && !f.adminDown {
 			oper, in, out, errs = 1, f.inRate, f.outRate, f.errorRate
 		}
-		name := f.name
-		if name == "" {
-			name = f.descr
-		}
-		inOctets := func() (float64, uint64, Swing) {
+		inPkts, outPkts := in/900, out/700
+		type counts func() (float64, uint64, Swing)
+		inOctets := counts(func() (float64, uint64, Swing) {
 			return in, start(n, 3.0e9, 1.0e9), swing(n, 0.6, 5*time.Minute)
-		}
-		outOctets := func() (float64, uint64, Swing) {
+		})
+		outOctets := counts(func() (float64, uint64, Swing) {
 			return out, start(n+1, 1.0e9, 2.0e9), swing(n+1, 0.5, 7*time.Minute)
+		})
+		packets := func(rate float64, k uint64, base, spread float64, towards uint64, depth float64, period time.Duration) counts {
+			return func() (float64, uint64, Swing) {
+				return rate, start(n+k, base, spread), swing(n+towards, depth, period)
+			}
 		}
+		inUcast := packets(inPkts, 2, 1e6, 1e7, 0, 0.6, 5*time.Minute)
+		outUcast := packets(outPkts, 4, 1e6, 1e7, 1, 0.5, 7*time.Minute)
+		inMcast := packets(inPkts*0.02, 5, 1e4, 1e5, 0, 0.6, 5*time.Minute)
+		inBcast := packets(inPkts*0.01, 6, 1e4, 1e5, 0, 0.6, 5*time.Minute)
+		outMcast := packets(outPkts*0.005, 7, 1e4, 1e5, 1, 0.5, 7*time.Minute)
+		outBcast := packets(outPkts*0.002, 8, 1e4, 1e5, 1, 0.5, 7*time.Minute)
+		physical := f.ifType == ifTypeEthernet || f.ifType == ifTypeIEEE80211
 
 		o.add(col(1), gosnmp.Integer, Const(f.index))
 		o.add(col(2), gosnmp.OctetString, Const(f.descr))
@@ -78,22 +105,52 @@ func addInterfaces(o *objects, seed uint64, ifs []iface) {
 		o.add(col(6), gosnmp.OctetString, Const([]byte(f.mac)))
 		o.add(col(7), gosnmp.Integer, Const(admin))
 		o.add(col(8), gosnmp.Integer, Const(oper))
-		o.add(col(9), gosnmp.TimeTicks, Const(uint32(0)))
+		o.add(col(9), gosnmp.TimeTicks, zero)
 		o.add(col(10), gosnmp.Counter32, Counter(inOctets()))
-		o.add(col(11), gosnmp.Counter32, Counter(in/900, start(n+2, 1e6, 1e7), swing(n, 0.6, 5*time.Minute)))
-		o.add(col(13), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(11), gosnmp.Counter32, Counter(inUcast()))
+		o.add(col(12), gosnmp.Counter32, Counter(inPkts*0.03, start(n+9, 2e4, 2e5), swing(n, 0.6, 5*time.Minute)))
+		o.add(col(13), gosnmp.Counter32, zero)
 		o.add(col(14), gosnmp.Counter32, Counter(errs, start(n+3, 0, 40), swing(n+3, 0.9, 11*time.Minute)))
+		o.add(col(15), gosnmp.Counter32, Counter(inPkts*5e-4, start(n+10, 0, 1000), swing(n+3, 0.9, 11*time.Minute)))
 		o.add(col(16), gosnmp.Counter32, Counter(outOctets()))
-		o.add(col(17), gosnmp.Counter32, Counter(out/700, start(n+4, 1e6, 1e7), swing(n+1, 0.5, 7*time.Minute)))
-		o.add(col(19), gosnmp.Counter32, Const(uint32(0)))
-		o.add(col(20), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(17), gosnmp.Counter32, Counter(outUcast()))
+		o.add(col(18), gosnmp.Counter32, Counter(outPkts*0.007, start(n+11, 2e4, 2e5), swing(n+1, 0.5, 7*time.Minute)))
+		o.add(col(19), gosnmp.Counter32, zero)
+		o.add(col(20), gosnmp.Counter32, zero)
+		o.add(col(21), gosnmp.Gauge32, zero)
+		o.add(col(22), gosnmp.ObjectIdentifier, Const(".0.0"))
 
-		o.add(ext(1), gosnmp.OctetString, Const(name))
+		connector := 2
+		if physical {
+			connector = 1
+		}
+		o.add(ext(1), gosnmp.OctetString, Const(f.ifName()))
+		o.add(ext(2), gosnmp.Counter32, Counter(inMcast()))
+		o.add(ext(3), gosnmp.Counter32, Counter(inBcast()))
+		o.add(ext(4), gosnmp.Counter32, Counter(outMcast()))
+		o.add(ext(5), gosnmp.Counter32, Counter(outBcast()))
 		o.add(ext(6), gosnmp.Counter64, Counter64(inOctets()))
+		o.add(ext(7), gosnmp.Counter64, Counter64(inUcast()))
+		o.add(ext(8), gosnmp.Counter64, Counter64(inMcast()))
+		o.add(ext(9), gosnmp.Counter64, Counter64(inBcast()))
 		o.add(ext(10), gosnmp.Counter64, Counter64(outOctets()))
+		o.add(ext(11), gosnmp.Counter64, Counter64(outUcast()))
+		o.add(ext(12), gosnmp.Counter64, Counter64(outMcast()))
+		o.add(ext(13), gosnmp.Counter64, Counter64(outBcast()))
+		o.add(ext(14), gosnmp.Integer, Const(1)) // linkUp and linkDown enabled
 		o.add(ext(15), gosnmp.Gauge32, Const(uint32(min(f.speed/1_000_000, math.MaxUint32))))
+		o.add(ext(16), gosnmp.Integer, Const(2)) // not promiscuous
+		o.add(ext(17), gosnmp.Integer, Const(connector))
 		o.add(ext(18), gosnmp.OctetString, Const(f.alias))
+		o.add(ext(19), gosnmp.TimeTicks, zero)
+
+		// ifStackTable: every interface directly on the wire, with nothing
+		// stacked on it.
+		o.add(fmt.Sprintf("1.3.6.1.2.1.31.1.2.1.3.0.%d", f.index), gosnmp.Integer, Const(1))
+		o.add(fmt.Sprintf("1.3.6.1.2.1.31.1.2.1.3.%d.0", f.index), gosnmp.Integer, Const(1))
 	}
+	o.add("1.3.6.1.2.1.31.1.5.0", gosnmp.TimeTicks, zero) // ifTableLastChange
+	o.add("1.3.6.1.2.1.31.1.6.0", gosnmp.TimeTicks, zero) // ifStackLastChange
 }
 
 // deviceMAC is a MAC address for a device's n-th port, drawn from its seed:

--- a/pkg/simulator/linuxserver.go
+++ b/pkg/simulator/linuxserver.go
@@ -2,17 +2,21 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 )
 
-// linuxServer is an Ubuntu host running net-snmp: the system group, three
-// interfaces — the loopback, one busy, one cabled and down, which is what an
-// interface wall looks like on a real server — and the host resources.
+// linuxServer is an Ubuntu 24.04 host running net-snmp, as a walk of one finds
+// it: the system group and sysORTable; three interfaces — the loopback, one
+// busy, one cabled and down, which is what an interface wall looks like on a
+// real server; its address, ARP cache, routes and sockets; its devices, file
+// systems, the processes running — kernel threads included, as net-snmp lists
+// them — and the packages installed; and UCD-SNMP-MIB's memory, load and disks.
 //
 // It answers everything the bundled "Interfaces" and "Host resources" presets
-// poll, and TestEveryModelFeedsItsPresets holds it to that: binding a preset
-// to a simulated server and getting empty widgets would be a demonstration of
-// the wrong thing.
+// poll, and TestEveryModelFeedsItsPresets holds it to that: binding a preset to
+// a simulated server and getting empty widgets would be a demonstration of the
+// wrong thing.
 var linuxServer = model{
 	ModelInfo:  ModelInfo{ID: "linux-server", Category: "server"},
 	enterprise: 8072, // net-snmp
@@ -31,28 +35,186 @@ func buildLinuxServer(id Identity) []Object {
 	var o objects
 	addSystem(&o, id, fmt.Sprintf("Linux %s 6.8.0-45-generic #45-Ubuntu SMP PREEMPT_DYNAMIC x86_64", id.Name),
 		".1.3.6.1.4.1.8072.3.2.10", "root@"+id.Name, "Server room, rack A1", 72)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
-			up: true, inRate: 20_000, outRate: 20_000},
-		{index: 2, descr: "eth0", alias: "uplink", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
-			mac: deviceMAC(id.Seed, 1), up: true, inRate: 1_250_000, outRate: 310_000, errorRate: 0.004},
-		{index: 3, descr: "eth1", alias: "spare", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
-			mac: deviceMAC(id.Seed, 2)},
+	lan := lanPrefix(id.Seed)
+	peer := func(n int, port uint16) netip.AddrPort { return netip.AddrPortFrom(hostIn(lan, n), port) }
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
+				up: true, inRate: 20_000, outRate: 20_000},
+			{index: 2, descr: "eth0", alias: "uplink", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+				mac: deviceMAC(id.Seed, 1), up: true, inRate: 1_250_000, outRate: 310_000, errorRate: 0.004},
+			{index: 3, descr: "eth1", alias: "spare", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+				mac: deviceMAC(id.Seed, 2)},
+		},
+		addrs:   []ifAddr{{ifIndex: 2, prefix: addrIn(lan, 10+int(id.Seed%40)), neighbours: 6}},
+		gateway: hostIn(lan, 1),
+		pps:     1400,
+		listen:  []uint16{22, 80, 443, 5432, 9100},
+		udp:     []uint16{123, 161},
+		sessions: []session{
+			{22, peer(50, 51844)},   // someone logged in
+			{5432, peer(21, 43210)}, // the application server
+			{5432, peer(21, 43212)},
+			{443, peer(77, 55012)},
+		},
+		modules: []sysOR{moduleHostResources},
 	})
+
+	const mem, swap = 8388608, 2097152 // KiB: 8 GiB, and 2 GiB of swap
 	addHostResources(&o, id.Seed, hostResources{
-		memoryKiB: 8388608, // 8 GiB
+		memoryKiB: mem,
 		users:     [2]float64{1, 3},
-		processes: [2]float64{180, 260},
 		storage: []storageArea{
-			{1, hrStorageRam, "Physical memory", 1024, 8388608, 0.55, 0.75, 4 * time.Minute},
-			{3, hrStorageVirtualMemory, "Virtual memory", 1024, 10485760, 0.48, 0.62, 5 * time.Minute},
+			{1, hrStorageRam, "Physical memory", 1024, mem, 0.55, 0.75, 4 * time.Minute},
+			{3, hrStorageVirtualMemory, "Virtual memory", 1024, mem + swap, 0.48, 0.62, 5 * time.Minute},
+			{6, hrStorageOther, "Memory buffers", 1024, mem, 0.02, 0.03, 30 * time.Minute},
+			{7, hrStorageOther, "Cached memory", 1024, mem, 0.18, 0.24, 25 * time.Minute},
+			{8, hrStorageOther, "Shared memory", 1024, mem, 0.01, 0.015, 30 * time.Minute},
+			{10, hrStorageVirtualMemory, "Swap space", 1024, swap, 0, 0.02, time.Hour},
 			{31, hrStorageFixedDisk, "/", 4096, 25600000, 0.41, 0.43, 6 * time.Hour},
+			{32, hrStorageFixedDisk, "/boot", 4096, 499712, 0.18, 0.19, 24 * time.Hour},
+			{35, hrStorageFixedDisk, "/run", 4096, 204800, 0.01, 0.02, time.Hour},
 			{36, hrStorageFixedDisk, "/home", 4096, 51200000, 0.63, 0.64, 9 * time.Hour},
 		},
 		// One row per CPU, indexed as net-snmp indexes hrDeviceTable.
 		processors: []int{196608, 196609},
 		cpuLo:      4,
 		cpuHi:      55,
+		cpu:        "GenuineIntel: Intel(R) Xeon(R) Silver 4314 CPU @ 2.40GHz",
+		boot:       393216,
+		bootParams: "BOOT_IMAGE=/vmlinuz-6.8.0-45-generic root=/dev/mapper/ubuntu--vg-ubuntu--lv ro",
+		devices: []hrDevice{
+			{index: 262145, kind: hrDeviceNetwork, descr: "network interface lo", ifIndex: 1},
+			{index: 262146, kind: hrDeviceNetwork, descr: "network interface eth0", ifIndex: 2},
+			{index: 262147, kind: hrDeviceNetwork, descr: "network interface eth1", ifIndex: 3},
+			{index: 393216, kind: hrDeviceDiskStorage, descr: "SCSI disk (/dev/sda)", diskKB: 104857600},
+			{index: 393232, kind: hrDeviceDiskStorage, descr: "SCSI disk (/dev/sdb)", diskKB: 209715200},
+		},
+		fs: []hrFS{
+			{"/", hrFSLinuxExt2, 31, true},
+			{"/boot", hrFSLinuxExt2, 32, false},
+			{"/run", hrFSOther, 35, false},
+			{"/home", hrFSLinuxExt2, 36, false},
+		},
+		procs:    linuxProcesses(2),
+		software: ubuntuPackages(),
+	})
+	addUCD(&o, id.Seed, ucdInfo{
+		memKB: mem, swapKB: swap, memUsed: [2]float64{0.3, 0.45}, cpus: 2,
+		load: [2]float64{0.15, 1.4}, user: [2]float64{3, 38}, system: [2]float64{1, 11},
+		disks: []ucdDisk{
+			{"/", "/dev/mapper/ubuntu--vg-ubuntu--lv", 102400000, [2]float64{0.41, 0.43}},
+			{"/boot", "/dev/sda2", 1998848, [2]float64{0.18, 0.19}},
+			{"/home", "/dev/sdb1", 204800000, [2]float64{0.63, 0.64}},
+		},
 	})
 	return o
+}
+
+// linuxProcesses is what a Linux server with cpus processors runs: the kernel's
+// threads, as net-snmp lists them, then the services a web and database host
+// has.
+func linuxProcesses(cpus int) []process {
+	procs := []process{{pid: 1, name: "systemd", path: "/sbin/init", args: "splash", kind: 4, cpu: 0.001, memKB: 12400}}
+	kernel := []string{"kthreadd", "pool_workqueue_release", "kworker/R-rcu_g", "kworker/R-rcu_p",
+		"kworker/R-slub_", "kworker/R-netns", "kworker/0:0H-events_highpri", "kworker/R-mm_pe",
+		"rcu_tasks_kthread", "rcu_tasks_rude_kthread", "rcu_tasks_trace_kthread", "rcu_preempt"}
+	for c := 0; c < cpus; c++ {
+		kernel = append(kernel, fmt.Sprintf("ksoftirqd/%d", c), fmt.Sprintf("migration/%d", c),
+			fmt.Sprintf("idle_inject/%d", c), fmt.Sprintf("cpuhp/%d", c))
+	}
+	kernel = append(kernel, "kdevtmpfs", "kworker/R-inet_", "kauditd", "khungtaskd", "oom_reaper",
+		"kworker/R-write", "kcompactd0", "ksmd", "khugepaged", "kworker/R-kinte", "kworker/R-kbloc",
+		"kworker/R-blkcg", "irq/9-acpi", "kworker/R-tpm_d", "kworker/R-ata_s", "kworker/R-md",
+		"kworker/R-md_bi", "kworker/R-edac-", "kworker/R-devfr", "watchdogd", "kswapd0",
+		"ecryptfs-kthread", "kworker/R-kthro", "kworker/R-acpi_", "scsi_eh_0", "kworker/R-scsi_",
+		"scsi_eh_1", "kworker/R-mld", "kworker/R-ipv6_", "kworker/R-kstrp", "kworker/R-crypt",
+		"jbd2/dm-0-8", "kworker/R-ext4-", "jbd2/sda2-8", "jbd2/sdb1-8", "kworker/0:1-events",
+		"kworker/1:2-mm_percpu_wq", "kworker/u4:3-events_unbound", "psimon")
+	for i, name := range kernel {
+		procs = append(procs, process{pid: 2 + i, name: name, kind: 2})
+	}
+	type svc struct {
+		name, path, args string
+		cpu              float64
+		memKB            int
+	}
+	pid := 380
+	for _, s := range []svc{
+		{"systemd-journald", "/usr/lib/systemd/systemd-journald", "", 0.002, 61200},
+		{"multipathd", "/sbin/multipathd", "-d -s", 0.001, 27100},
+		{"systemd-udevd", "/usr/lib/systemd/systemd-udevd", "", 0.0005, 7400},
+		{"systemd-networkd", "/usr/lib/systemd/systemd-networkd", "", 0.0005, 8800},
+		{"systemd-resolved", "/usr/lib/systemd/systemd-resolved", "", 0.001, 12800},
+		{"systemd-timesyncd", "/usr/lib/systemd/systemd-timesyncd", "", 0, 7200},
+		{"cron", "/usr/sbin/cron", "-f -P", 0, 2700},
+		{"dbus-daemon", "@dbus-daemon", "--system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only", 0.0005, 5100},
+		{"networkd-dispatcher", "/usr/bin/python3", "/usr/bin/networkd-dispatcher --run-startup-triggers", 0, 20400},
+		{"rsyslogd", "/usr/sbin/rsyslogd", "-n -iNONE", 0.001, 6300},
+		{"snapd", "/usr/lib/snapd/snapd", "", 0.002, 31700},
+		{"systemd-logind", "/usr/lib/systemd/systemd-logind", "", 0, 7700},
+		{"udisksd", "/usr/libexec/udisks2/udisksd", "", 0.0005, 13200},
+		{"polkitd", "/usr/lib/polkit-1/polkitd", "--no-debug", 0, 10100},
+		{"agetty", "/sbin/agetty", "-o -p -- \\u --noclear - linux", 0, 1900},
+		{"unattended-upgr", "/usr/bin/python3", "/usr/share/unattended-upgrades/unattended-upgrade-shutdown --wait-for-signal", 0, 23900},
+		{"snmpd", "/usr/sbin/snmpd", "-LOw -u Debian-snmp -g Debian-snmp -I -smux mteTrigger mteTriggerConf -f -p /run/snmpd.pid", 0.004, 11300},
+		{"sshd", "sshd: /usr/sbin/sshd -D [listener] 0 of 10-100 startups", "", 0, 9100},
+		{"chronyd", "/usr/sbin/chronyd", "-F 1", 0, 3400},
+		{"node_exporter", "/usr/bin/prometheus-node-exporter", "", 0.006, 21800},
+		{"nginx", "nginx: master process /usr/sbin/nginx", "-g daemon on; master_process on;", 0, 1600},
+		{"nginx", "nginx: worker process", "", 0.02, 5300},
+		{"nginx", "nginx: worker process", "", 0.02, 5100},
+		{"postgres", "/usr/lib/postgresql/16/bin/postgres", "-D /var/lib/postgresql/16/main -c config_file=/etc/postgresql/16/main/postgresql.conf", 0.002, 31200},
+		{"postgres", "postgres: 16/main: checkpointer", "", 0.001, 142000},
+		{"postgres", "postgres: 16/main: background writer", "", 0.001, 61000},
+		{"postgres", "postgres: 16/main: walwriter", "", 0.001, 21400},
+		{"postgres", "postgres: 16/main: autovacuum launcher", "", 0, 11800},
+		{"postgres", "postgres: 16/main: logical replication launcher", "", 0, 10200},
+		{"postgres", "postgres: 16/main: app appdb client idle", "", 0.06, 188000},
+		{"postgres", "postgres: 16/main: app appdb client idle", "", 0.05, 176000},
+		{"sshd", "sshd: ops [priv]", "", 0, 11200},
+		{"sshd", "sshd: ops@pts/0", "", 0.001, 7300},
+		{"bash", "-bash", "", 0, 5200},
+		{"systemd", "/usr/lib/systemd/systemd", "--user", 0, 10900},
+		{"(sd-pam)", "(sd-pam)", "", 0, 4100},
+	} {
+		procs = append(procs, process{pid: pid, name: s.name, path: s.path, args: s.args, kind: 4, cpu: s.cpu, memKB: s.memKB})
+		pid += 7 + pid%11
+	}
+	return procs
+}
+
+// ubuntuPackages are some of what dpkg says an Ubuntu 24.04 server has, named
+// as net-snmp names them, and when they were installed: most with the system,
+// the rest with the last updates.
+func ubuntuPackages() []software {
+	installed := time.Date(2024, 4, 25, 14, 12, 7, 0, time.UTC)
+	updated := time.Date(2024, 9, 3, 6, 25, 41, 0, time.UTC)
+	var out []software
+	for i, name := range []string{
+		"adduser-3.137ubuntu1", "apt-2.7.14build2", "base-files-13ubuntu10.1", "bash-5.2.21-2ubuntu4",
+		"bsdutils-1:2.39.3-9ubuntu6.1", "ca-certificates-20240203", "chrony-4.5-1ubuntu4.1",
+		"coreutils-9.4-3ubuntu6", "cron-3.0pl1-184ubuntu2", "curl-8.5.0-2ubuntu10.4",
+		"dbus-1.14.10-4ubuntu4.1", "dpkg-1.22.6ubuntu6.1", "e2fsprogs-1.47.0-2.4~exp1ubuntu4.1",
+		"gzip-1.12-1ubuntu3", "iproute2-6.1.0-1ubuntu6", "iputils-ping-3:20240117-1build1",
+		"libc6-2.39-0ubuntu8.3", "libsnmp40t64-5.9.4+dfsg-1.1ubuntu3", "libssl3t64-3.0.13-0ubuntu3.4",
+		"linux-image-6.8.0-45-generic-6.8.0-45.45", "login-1:4.13+dfsg1-4ubuntu3.2",
+		"logrotate-3.21.0-2build1", "multipath-tools-0.9.4-5ubuntu8", "nginx-1.24.0-2ubuntu7.1",
+		"openssh-server-1:9.6p1-3ubuntu13.5", "openssl-3.0.13-0ubuntu3.4", "passwd-1:4.13+dfsg1-4ubuntu3.2",
+		"perl-5.38.2-3.2build2", "postgresql-16-16.4-0ubuntu0.24.04.2", "procps-2:4.0.4-4ubuntu3.2",
+		"prometheus-node-exporter-1.7.0-1ubuntu0.2", "python3-3.12.3-0ubuntu2", "rsyslog-8.2312.0-3ubuntu9",
+		"snapd-2.63+24.04", "snmpd-5.9.4+dfsg-1.1ubuntu3", "sudo-1.9.15p5-3ubuntu5",
+		"systemd-255.4-1ubuntu8.4", "tar-1.35+dfsg-3build1", "tzdata-2024a-3ubuntu1.1",
+		"ubuntu-minimal-1.539.2", "ufw-0.36.2-6", "unattended-upgrades-2.9.1+nmu4ubuntu1",
+		"util-linux-2.39.3-9ubuntu6.1", "vim-2:9.1.0016-1ubuntu7.2", "wget-1.21.4-1ubuntu4.1",
+		"zlib1g-1:1.3.dfsg-3.1ubuntu2.1",
+	} {
+		when := installed.Add(time.Duration(i) * 11 * time.Second)
+		if i%5 == 3 {
+			when = updated.Add(time.Duration(i) * 7 * time.Second)
+		}
+		out = append(out, software{name: name, installed: when})
+	}
+	return out
 }

--- a/pkg/simulator/mikrotik.go
+++ b/pkg/simulator/mikrotik.go
@@ -2,17 +2,19 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
 )
 
-// mikrotikRB4011 is a MikroTik RB4011 on RouterOS 7: ten gigabit ports, the
-// first the uplink and the last four unused; an SFP+ cage with nothing in it;
-// the bridge the LAN ports are in. MIKROTIK-MIB's health group gives the board's
-// voltage, temperatures, power and current, and RouterOS answers
-// HOST-RESOURCES-MIB for its memory, its flash and its four cores — so it feeds
-// the "Server" preset as well as the interface ones.
+// mikrotikRB4011 is a MikroTik RB4011 on RouterOS 7, set up as a small office's
+// router: ether1 to the provider, the LAN ports in a bridge on RouterOS's own
+// 192.168.88.0/24, an SFP+ cage with nothing in it. It routes, NATs and serves
+// DHCP and DNS, which its sockets show; MIKROTIK-MIB gives the board's health
+// both ways RouterOS does (the old scalars and the gauge table) and the
+// neighbours MNDP and LLDP found; HOST-RESOURCES-MIB gives its memory, flash and
+// four cores — enough for the "Server" preset as well as the interface ones.
 var mikrotikRB4011 = model{
 	ModelInfo:  ModelInfo{ID: "mikrotik-rb4011", Category: "network"},
 	enterprise: 14988, // MikroTik
@@ -28,8 +30,8 @@ var mikrotikRB4011 = model{
 func buildMikrotikRB4011(id Identity) []Object {
 	var o objects
 	const version = "7.14.3"
-	addSystem(&o, id, "RouterOS RB4011iGS+", ".1.3.6.1.4.1.14988.1", "noc@example.com",
-		"Branch office, network room", 78)
+	descr := "RouterOS RB4011iGS+"
+	addSystem(&o, id, descr, ".1.3.6.1.4.1.14988.1", "noc@example.com", "Branch office, network room", 78)
 	ifs := make([]iface, 0, 12)
 	for p := 1; p <= 10; p++ {
 		f := iface{index: p, descr: fmt.Sprintf("ether%d", p), ifType: ifTypeEthernet, mtu: 1500,
@@ -47,26 +49,90 @@ func buildMikrotikRB4011(id Identity) []Object {
 	ifs = append(ifs,
 		iface{index: 11, descr: "sfp-sfpplus1", ifType: ifTypeEthernet, mtu: 1500, speed: 10_000_000_000,
 			mac: deviceMAC(id.Seed, 11)},
-		// The bridge carries the router's own address, and its base MAC — the
+		// The bridge carries the router's LAN address, and its base MAC — the
 		// one its engine ID carries too.
 		iface{index: 12, descr: "bridge", alias: "LAN", ifType: ifTypeBridge, mtu: 1500,
 			mac: deviceMAC(id.Seed, 0), up: true, inRate: 1_800_000, outRate: 5_000_000},
 	)
-	addInterfaces(&o, id.Seed, ifs)
+	wan := netip.MustParsePrefix("198.51.100.0/29")
+	lan := netip.MustParsePrefix("192.168.88.0/24")
+	switchMAC, apMAC := peerMAC(id.Seed, 901), peerMAC(id.Seed, 902)
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs:  ifs,
+		addrs: []ifAddr{
+			{ifIndex: 12, prefix: addrIn(lan, 1), neighbours: 14},
+			{ifIndex: 1, prefix: addrIn(wan, 2)},
+		},
+		gateway: hostIn(wan, 1),
+		router:  true,
+		routes: []route{
+			{dest: netip.MustParsePrefix("10.10.0.0/16"), nextHop: hostIn(lan, 2), ifIndex: 12, proto: protoStatic, metric: 1},
+		},
+		pps:      600,
+		listen:   []uint16{22, 53, 80, 443, 2000, 8291, 8728, 8729},
+		udp:      []uint16{53, 67, 123, 161, 5678, 20561},
+		sessions: []session{{8291, netip.AddrPortFrom(hostIn(lan, 254), 50917)}}, // someone in Winbox
+		lldp: &lldpInfo{name: id.Name, descr: descr, caps: capRouter | capBridge, neighbours: []neighbour{
+			{ifIndex: 2, name: "sw-office", descr: catalystDescr, port: "Gi0/24", portDescr: "GigabitEthernet0/24",
+				chassis: switchMAC, caps: capBridge},
+			{ifIndex: 3, name: "ap-openspace", descr: "U6-Pro 6.6.77.15402", port: "eth0", portDescr: "eth0",
+				chassis: apMAC, caps: capWLAN | capBridge},
+		}},
+	})
 
 	// mtxrHealth, in the units RouterOS reports: tenths of a volt, of a degree
-	// and of a watt, and milliamps.
-	const health = "1.3.6.1.4.1.14988.1.1.3."
+	// and of a watt, and milliamps. The gauge table says the same in its own
+	// units, from the same swings.
+	const mtxr = "1.3.6.1.4.1.14988.1.1."
 	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 40000 + n} }
-	o.add(health+"8.0", gosnmp.Integer, IntegerGauge(238, 242, swing(0, 30*time.Minute)))  // mtxrHlVoltage
-	o.add(health+"10.0", gosnmp.Integer, IntegerGauge(390, 440, swing(1, 50*time.Minute))) // mtxrHlTemperature
-	o.add(health+"11.0", gosnmp.Integer, IntegerGauge(470, 560, swing(2, 12*time.Minute))) // mtxrHlProcessorTemperature
+	o.add(mtxr+"3.8.0", gosnmp.Integer, IntegerGauge(238, 242, swing(0, 30*time.Minute)))  // mtxrHlVoltage
+	o.add(mtxr+"3.10.0", gosnmp.Integer, IntegerGauge(390, 440, swing(1, 50*time.Minute))) // mtxrHlTemperature
+	o.add(mtxr+"3.11.0", gosnmp.Integer, IntegerGauge(470, 560, swing(2, 12*time.Minute))) // mtxrHlProcessorTemperature
 	// The current follows the power: one swing for both.
-	o.add(health+"12.0", gosnmp.Integer, IntegerGauge(142, 188, swing(3, 9*time.Minute))) // mtxrHlPower
-	o.add(health+"13.0", gosnmp.Integer, IntegerGauge(590, 780, swing(3, 9*time.Minute))) // mtxrHlCurrent
-	o.add("1.3.6.1.4.1.14988.1.1.4.4.0", gosnmp.OctetString, Const(version))              // mtxrLicVersion
-	o.add("1.3.6.1.4.1.14988.1.1.7.3.0", gosnmp.OctetString, Const(fmt.Sprintf("%012X", mix(id.Seed+3)&0xFFFFFFFFFFFF)))
-	o.add("1.3.6.1.4.1.14988.1.1.7.4.0", gosnmp.OctetString, Const(version)) // mtxrFirmwareVersion
+	o.add(mtxr+"3.12.0", gosnmp.Integer, IntegerGauge(142, 188, swing(3, 9*time.Minute))) // mtxrHlPower
+	o.add(mtxr+"3.13.0", gosnmp.Integer, IntegerGauge(590, 780, swing(3, 9*time.Minute))) // mtxrHlCurrent
+	for i, g := range []struct {
+		name   string
+		lo, hi float64
+		unit   int // celsius(1), dV(3), dA(4), dW(5)
+		swing  Swing
+	}{
+		{"voltage", 238, 242, 3, swing(0, 30*time.Minute)},
+		{"temperature", 39, 44, 1, swing(1, 50*time.Minute)},
+		{"cpu-temperature", 47, 56, 1, swing(2, 12*time.Minute)},
+		{"power-consumption", 142, 188, 5, swing(3, 9*time.Minute)},
+		{"current", 6, 8, 4, swing(3, 9*time.Minute)},
+	} {
+		n := i + 1
+		col := func(c int) string { return fmt.Sprintf(mtxr+"3.100.1.%d.%d", c, n) }
+		o.add(col(2), gosnmp.OctetString, Const(g.name))
+		o.add(col(3), gosnmp.Integer, IntegerGauge(g.lo, g.hi, g.swing))
+		o.add(col(4), gosnmp.Integer, Const(g.unit))
+	}
+	o.add(mtxr+"4.4.0", gosnmp.OctetString, Const(version)) // mtxrLicVersion
+	o.add(mtxr+"7.3.0", gosnmp.OctetString, Const(fmt.Sprintf("%012X", mix(id.Seed+3)&0xFFFFFFFFFFFF)))
+	o.add(mtxr+"7.4.0", gosnmp.OctetString, Const(version)) // mtxrFirmwareVersion
+	// mtxrNeighborTable: what MNDP and LLDP found on the LAN ports.
+	for i, n := range []struct {
+		ip                          netip.Addr
+		mac                         []byte
+		version, platform, identity string
+		ifIndex                     int
+	}{
+		{hostIn(lan, 2), switchMAC, "15.0(2)SE11", "Cisco WS-C2960-24TT-L", "sw-office", 2},
+		{hostIn(lan, 3), apMAC, "6.6.77.15402", "U6-Pro", "ap-openspace", 3},
+	} {
+		row := i + 1
+		col := func(c int) string { return fmt.Sprintf(mtxr+"11.1.1.%d.%d", c, row) }
+		o.add(col(2), gosnmp.IPAddress, Const(n.ip.String()))
+		o.add(col(3), gosnmp.OctetString, Const(n.mac))
+		o.add(col(4), gosnmp.OctetString, Const(n.version))
+		o.add(col(5), gosnmp.OctetString, Const(n.platform))
+		o.add(col(6), gosnmp.OctetString, Const(n.identity))
+		o.add(col(7), gosnmp.OctetString, Const(""))
+		o.add(col(8), gosnmp.Integer, Const(n.ifIndex))
+	}
 
 	addHostResources(&o, id.Seed, hostResources{
 		memoryKiB: 1048576, // 1 GiB
@@ -79,6 +145,7 @@ func buildMikrotikRB4011(id Identity) []Object {
 		processors: []int{1, 2, 3, 4},
 		cpuLo:      1,
 		cpuHi:      24,
+		cpu:        "AL21400 Cortex-A15",
 	})
 	return o
 }

--- a/pkg/simulator/model_test.go
+++ b/pkg/simulator/model_test.go
@@ -144,20 +144,21 @@ func TestEveryModelServesAWalk(t *testing.T) {
 	for _, m := range models {
 		t.Run(m.ID, func(t *testing.T) {
 			objects := m.build(Identity{Name: "dev-01", Seed: 7})
-			readable := 0
-			for _, o := range objects {
-				if !o.NotifyOnly {
-					readable++
-				}
-			}
 			a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public", Objects: objects})
+			// Everything a request may read: the model's objects less those only a
+			// notification carries, and the agent's own.
+			readable := len(a.tree.entries)
 			g := connect(t, manager(a, gosnmp.Version2c, "public"))
 			n := 0
-			if err := g.BulkWalk(".1.3.6.1", func(gosnmp.SnmpPDU) error {
-				n++
-				return nil
-			}); err != nil {
-				t.Fatal(err)
+			// Both subtrees a device answers in: LLDP-MIB lives under
+			// iso.std.iso8802, outside .1.3.6.1, as it does on a real device.
+			for _, root := range []string{".1.0.8802", ".1.3.6.1"} {
+				if err := g.BulkWalk(root, func(gosnmp.SnmpPDU) error {
+					n++
+					return nil
+				}); err != nil {
+					t.Fatal(err)
+				}
 			}
 			if n != readable {
 				t.Errorf("walked %d objects of %d", n, readable)

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -458,6 +458,9 @@ func (nt *notifier) run(o *outbound) {
 				return
 			}
 			o.record(err)
+			if err == nil {
+				nt.a.stats.outTraps.Add(1)
+			}
 			if j.done != nil {
 				j.done <- o.delivery(err)
 			}
@@ -511,7 +514,7 @@ func (nt *notifier) pick(name string) (Notification, bool) {
 // deliver sends n to o now and, for an INFORM, waits for the acknowledgement.
 func (nt *notifier) deliver(o *outbound, n Notification) error {
 	a := nt.a
-	c := clock{started: a.started, now: time.Now()}
+	c := clock{started: a.started, now: time.Now(), stats: &a.stats}
 	g := &gosnmp.GoSNMP{
 		Target:    o.dial,
 		Port:      uint16(o.Port),

--- a/pkg/simulator/pdu.go
+++ b/pkg/simulator/pdu.go
@@ -21,8 +21,33 @@ type answer struct {
 }
 
 // process answers one request PDU from the tree: RFC 3416 4.2, and RFC 1157 4.1
-// for SNMPv1, whose errors are different.
+// for SNMPv1, whose errors are different. It counts what SNMPv2-MIB's snmp
+// group counts — the request on arrival, as net-snmp does, so that a GET of
+// snmpInGetRequests counts itself.
 func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock) answer {
+	st := &a.stats
+	switch req.PDUType {
+	case gosnmp.GetRequest:
+		st.inGets.Add(1)
+	case gosnmp.GetNextRequest, gosnmp.GetBulkRequest:
+		// The MIB has no counter of its own for GETBULK; net-snmp counts one
+		// as a GETNEXT.
+		st.inGetNexts.Add(1)
+	case gosnmp.SetRequest:
+		st.inSets.Add(1)
+	}
+	ans := a.dispatch(ver, req, c)
+	if ans.status == gosnmp.NoError && req.PDUType != gosnmp.SetRequest {
+		st.inTotalReqVars.Add(uint32(len(ans.vars)))
+	}
+	if ans.status == gosnmp.NoSuchName {
+		st.outNoSuchNames.Add(1)
+	}
+	st.outGetResponses.Add(1)
+	return ans
+}
+
+func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock) answer {
 	v1 := ver == gosnmp.Version1
 	switch req.PDUType {
 	case gosnmp.GetRequest:

--- a/pkg/simulator/printer.go
+++ b/pkg/simulator/printer.go
@@ -8,9 +8,11 @@ import (
 )
 
 // hpLaserJet is an HP LaserJet on its Jetdirect card, answering the Printer MIB
-// (RFC 3805): its page count, a black cartridge running low and the alert that
-// says so, and the printer's status in the host resources, as printers report
-// it.
+// (RFC 3805) as a walk of one finds it: the general group, the front door, two
+// paper trays and the output bin, the marker and the pages it has printed, the
+// black cartridge running low and the alert that says so, the languages it
+// reads, the console's message; the printer as a device in the host resources,
+// and a Jetdirect's sockets — raw printing, LPD, IPP, the web interface.
 var hpLaserJet = model{
 	ModelInfo:  ModelInfo{ID: "hp-laserjet", Category: "printing"},
 	enterprise: 11, // HP
@@ -35,30 +37,85 @@ func buildHPLaserJet(id Identity) []Object {
 	addSystem(&o, id, "HP ETHERNET MULTI-ENVIRONMENT,ROM none,JETDIRECT,JD153,EEPROM JSI23900051,CIDATE 06/17/2019",
 		".1.3.6.1.4.1.11.2.3.9.1", // hpNetPrinter
 		"helpdesk@example.com", "Floor 1, copy room", 72)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "HP ETHERNET MULTI-ENVIRONMENT", ifType: ifTypeEthernet, mtu: 1500,
-			speed: 1_000_000_000, mac: deviceMAC(id.Seed, 1), up: true, inRate: 1_500, outRate: 900},
+	lan := lanPrefix(id.Seed)
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "HP ETHERNET MULTI-ENVIRONMENT", ifType: ifTypeEthernet, mtu: 1500,
+				speed: 1_000_000_000, mac: deviceMAC(id.Seed, 1), up: true, inRate: 1_500, outRate: 900},
+		},
+		addrs:   []ifAddr{{ifIndex: 1, prefix: addrIn(lan, 200+int(id.Seed%20))}},
+		gateway: hostIn(lan, 1),
+		pps:     12,
+		listen:  []uint16{80, 443, 515, 631, 9100},
+		udp:     []uint16{161, 427, 5353},
+		modules: []sysOR{moduleHostResources},
 	})
 
-	// Host resources: the printer as a device, and its status.
-	o.add("1.3.6.1.2.1.25.1.1.0", gosnmp.TimeTicks, Uptime())
-	o.add("1.3.6.1.2.1.25.2.2.0", gosnmp.Integer, Const(524288)) // 512 MiB
-	device := func(c int) string { return fmt.Sprintf("1.3.6.1.2.1.25.3.2.1.%d.1", c) }
-	o.add(device(1), gosnmp.Integer, Const(1))
-	o.add(device(2), gosnmp.ObjectIdentifier, Const(".1.3.6.1.2.1.25.3.1.5")) // hrDevicePrinter
-	o.add(device(3), gosnmp.OctetString, Const("HP LaserJet Pro M404dn"))
-	o.add(device(5), gosnmp.Integer, Const(2))                                 // hrDeviceStatus: running
-	o.add("1.3.6.1.2.1.25.3.5.1.1.1", gosnmp.Integer, Const(3))                // hrPrinterStatus: idle
-	o.add("1.3.6.1.2.1.25.3.5.1.2.1", gosnmp.OctetString, Const([]byte{0x00})) // no error detected
+	// Host resources: the printer as a device, its memory, and nothing running
+	// that a printer would say.
+	const model = "HP LaserJet Pro M404dn"
+	addHostResources(&o, id.Seed, hostResources{
+		memoryKiB: 524288, // 512 MiB
+		storage: []storageArea{
+			{1, hrStorageRam, "RAM", 1024, 524288, 0.38, 0.44, 30 * time.Minute},
+			{2, hrStorageFlashMemory, "Flash", 1024, 4194304, 0.21, 0.21, 24 * time.Hour},
+		},
+		devices: []hrDevice{{index: 1, kind: hrDevicePrinter, descr: model}},
+		boot:    1,
+	})
 
 	const prt = "1.3.6.1.2.1.43."
-	o.add(prt+"5.1.1.16.1", gosnmp.OctetString, Const("HP LaserJet Pro M404dn"))
+	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 40000 + n} }
+	// prtGeneralTable
+	o.add(prt+"5.1.1.1.1", gosnmp.Counter32, Const(uint32(3)))
+	o.add(prt+"5.1.1.2.1", gosnmp.Integer, Const(1))
+	o.add(prt+"5.1.1.4.1", gosnmp.OctetString, Const(""))
+	o.add(prt+"5.1.1.5.1", gosnmp.OctetString, Const(""))
+	o.add(prt+"5.1.1.16.1", gosnmp.OctetString, Const(model))
 	o.add(prt+"5.1.1.17.1", gosnmp.OctetString, Const(fmt.Sprintf("PHB%07d", int(unit(id.Seed+41)*1e7))))
-	// The marker, and the pages it has printed: about fourteen an hour.
+	// prtCoverTable: the front door, closed.
+	o.add(prt+"6.1.1.2.1.1", gosnmp.OctetString, Const("Front Door"))
+	o.add(prt+"6.1.1.3.1.1", gosnmp.Integer, Const(4)) // coverClosed
+	// prtInputTable: the manual feed and the cassette, A4 in micrometres.
+	for n, t := range []struct {
+		name      string
+		kind, max int
+		level     [2]float64
+	}{
+		{"Tray 1", 4, 100, [2]float64{0, 0}},    // sheetFeedManual, empty
+		{"Tray 2", 3, 250, [2]float64{60, 230}}, // sheetFeedAutoRemovableTray
+	} {
+		col := func(c int) string { return fmt.Sprintf(prt+"8.2.1.%d.1.%d", c, n+1) }
+		o.add(col(2), gosnmp.Integer, Const(t.kind))
+		o.add(col(3), gosnmp.Integer, Const(4)) // micrometers
+		o.add(col(4), gosnmp.Integer, Const(297000))
+		o.add(col(5), gosnmp.Integer, Const(210000))
+		o.add(col(8), gosnmp.Integer, Const(8)) // sheets
+		o.add(col(9), gosnmp.Integer, Const(t.max))
+		o.add(col(10), gosnmp.Integer, IntegerGauge(t.level[0], t.level[1], swing(10+uint64(n), 3*time.Hour)))
+		o.add(col(11), gosnmp.Integer, Const(0)) // available and idle
+		o.add(col(12), gosnmp.OctetString, Const("A4"))
+		o.add(col(13), gosnmp.OctetString, Const(t.name))
+		o.add(col(15), gosnmp.OctetString, Const(""))
+		o.add(col(18), gosnmp.OctetString, Const(t.name))
+	}
+	// prtOutputTable: the face-down bin.
+	out := func(c int) string { return fmt.Sprintf(prt+"9.2.1.%d.1.1", c) }
+	o.add(out(2), gosnmp.Integer, Const(4)) // unRemovableBin
+	o.add(out(3), gosnmp.Integer, Const(8)) // sheets
+	o.add(out(4), gosnmp.Integer, Const(150))
+	o.add(out(5), gosnmp.Integer, IntegerGauge(90, 150, swing(20, 2*time.Hour)))
+	o.add(out(6), gosnmp.Integer, Const(0))
+	o.add(out(7), gosnmp.OctetString, Const("Face Down Bin"))
+	// The marker, and the pages it has printed: about fourteen an hour, and
+	// fewer since it was last switched on.
+	pages := Swing{Depth: 0.9, Period: 2 * time.Hour, Seed: id.Seed + 40000}
 	o.add(prt+"10.2.1.2.1.1", gosnmp.Integer, Const(4)) // electrophotographicLaser
 	o.add(prt+"10.2.1.3.1.1", gosnmp.Integer, Const(7)) // counted in impressions
-	o.add(prt+"10.2.1.4.1.1", gosnmp.Counter32, Counter(0.004, uint64(18_000+40_000*unit(id.Seed+42)),
-		Swing{Depth: 0.9, Period: 2 * time.Hour, Seed: id.Seed + 40000}))
+	o.add(prt+"10.2.1.4.1.1", gosnmp.Counter32, Counter(0.004, uint64(18_000+40_000*unit(id.Seed+42)), pages))
+	o.add(prt+"10.2.1.5.1.1", gosnmp.Counter32, Counter(0.004, 0, pages))
+	o.add(prt+"10.2.1.6.1.1", gosnmp.Integer, Const(1))  // one colorant
 	o.add(prt+"10.2.1.15.1.1", gosnmp.Integer, Const(0)) // prtMarkerStatus: available and idle
 	// The black cartridge, at 17 to 18 percent.
 	supply := func(c int) string { return fmt.Sprintf(prt+"11.1.1.%d.1.1", c) }
@@ -71,6 +128,28 @@ func buildHPLaserJet(id Identity) []Object {
 	o.add(supply(7), gosnmp.Integer, Const(19)) // in percent
 	o.add(supply(8), gosnmp.Integer, Const(100))
 	o.add(supply(9), gosnmp.Integer, IntegerGauge(17, 18, Swing{Period: 6 * time.Hour, Seed: id.Seed + 40001}))
+	// prtMarkerColorantTable: black, which the marker uses.
+	o.add(prt+"12.1.1.3.1.1", gosnmp.Integer, Const(3)) // process
+	o.add(prt+"12.1.1.4.1.1", gosnmp.OctetString, Const("black"))
+	// prtInterpreterTable: the languages the printer reads.
+	for n, l := range []struct {
+		family         int
+		version, descr string
+	}{
+		{5, "", "PJL"},
+		{3, "6", "PCL 6"},
+		{47, "3.0", "PCL XL"},
+		{6, "3", "PostScript 3 emulation"},
+		{54, "1.7", "PDF"},
+	} {
+		col := func(c int) string { return fmt.Sprintf(prt+"15.1.1.%d.1.%d", c, n+1) }
+		o.add(col(2), gosnmp.Integer, Const(l.family))
+		o.add(col(3), gosnmp.OctetString, Const(""))
+		o.add(col(4), gosnmp.OctetString, Const(l.version))
+		o.add(col(5), gosnmp.OctetString, Const(l.descr))
+	}
+	// prtConsoleDisplayBufferTable: what the panel says.
+	o.add(prt+"16.5.1.2.1.1", gosnmp.OctetString, Const("Ready"))
 	// The alert the cartridge raised, which printerV2Alert carries.
 	alert := func(c int) string { return fmt.Sprintf(prt+"18.1.1.%d.1.1", c) }
 	o.add(alert(1), gosnmp.Integer, Const(1))

--- a/pkg/simulator/probe.go
+++ b/pkg/simulator/probe.go
@@ -10,7 +10,8 @@ import (
 // environmentProbe is a temperature and humidity probe answering the standard
 // ENTITY-SENSOR-MIB (RFC 3433) rather than a vendor's: two sensors in
 // ENTITY-MIB's physical table, and their readings, as a server room's cold aisle
-// reads. The MIB defines no notification, and the probe sends only the generic
+// reads — beside the address, routes and sockets of the small embedded agent it
+// is. The MIB defines no notification, and the probe sends only the generic
 // ones.
 var environmentProbe = model{
 	ModelInfo:  ModelInfo{ID: "environment-probe", Category: "environment"},
@@ -22,27 +23,26 @@ func buildEnvironmentProbe(id Identity) []Object {
 	var o objects
 	addSystem(&o, id, "Environment monitor, 2 sensors (temperature, humidity), firmware 2.4.1",
 		".1.3.6.1.4.1.8072.3.2.10", "facilities@example.com", "Server room, cold aisle", 72)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
-			mac: deviceMAC(id.Seed, 1), up: true, inRate: 300, outRate: 500},
+	lan := lanPrefix(id.Seed)
+	serial := fmt.Sprintf("EM2-%06d", int(unit(id.Seed+51)*1e6))
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
+				mac: deviceMAC(id.Seed, 1), up: true, inRate: 300, outRate: 500},
+		},
+		addrs:   []ifAddr{{ifIndex: 1, prefix: addrIn(lan, 240+int(id.Seed%10))}},
+		gateway: hostIn(lan, 1),
+		pps:     6,
+		listen:  []uint16{80},
+		// ENTITY-MIB's physical table: the probe, and the two sensors in it.
+		entity: []physical{
+			{index: 1, class: classChassis, relPos: -1, descr: "Environment monitor", name: "chassis",
+				model: "EM-2", serial: serial, hwRev: "B", fwRev: "2.4.1", swRev: "2.4.1", fru: false},
+			{index: 2, container: 1, relPos: 1, class: classSensor, descr: "Temperature sensor", name: "temperature"},
+			{index: 3, container: 1, relPos: 2, class: classSensor, descr: "Humidity sensor", name: "humidity"},
+		},
 	})
-
-	// ENTITY-MIB's physical table: the probe, and the two sensors in it.
-	const physical = "1.3.6.1.2.1.47.1.1.1.1."
-	for _, e := range []struct {
-		index            int
-		descr, name      string
-		class, container int
-	}{
-		{1, "Environment monitor", "chassis", 3, 0}, // chassis
-		{2, "Temperature sensor", "temperature", 8, 1},
-		{3, "Humidity sensor", "humidity", 8, 1}, // sensor
-	} {
-		o.add(fmt.Sprintf(physical+"2.%d", e.index), gosnmp.OctetString, Const(e.descr))
-		o.add(fmt.Sprintf(physical+"4.%d", e.index), gosnmp.Integer, Const(e.container))
-		o.add(fmt.Sprintf(physical+"5.%d", e.index), gosnmp.Integer, Const(e.class))
-		o.add(fmt.Sprintf(physical+"7.%d", e.index), gosnmp.OctetString, Const(e.name))
-	}
 
 	// ENTITY-SENSOR-MIB: the readings, in tenths.
 	const sensor = "1.3.6.1.2.1.99.1.1.1."

--- a/pkg/simulator/rackpdu.go
+++ b/pkg/simulator/rackpdu.go
@@ -9,9 +9,10 @@ import (
 
 // apcRackPDU is an APC AP7921B switched rack PDU: eight outlets on one 16 A
 // phase, the last of them switched off. PowerNet-MIB's rPDU group gives the
-// phase load, the power the PDU draws and each outlet's name and state. Its
-// notifications are PowerNet's SNMPv1 traps under apc, as RFC 3584 translates
-// them: enterprises.318.0.<specific-trap>.
+// phase load, the power the PDU draws and each outlet's name and state, beside
+// the small agent's address and sockets. Its notifications are PowerNet's
+// SNMPv1 traps under apc, as RFC 3584 translates them:
+// enterprises.318.0.<specific-trap>.
 var apcRackPDU = model{
 	ModelInfo:  ModelInfo{ID: "apc-rack-pdu", Category: "power"},
 	enterprise: 318, // APC
@@ -49,9 +50,18 @@ func buildAPCRackPDU(id Identity) []Object {
 		"(Embedded PowerNet SNMP Agent SW v2.2 compatible)",
 		".1.3.6.1.4.1.318.1.3.4.5", // masterSwitchrPDU
 		"facilities@example.com", "Rack A2, rear", 72)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
-			mac: deviceMAC(id.Seed, 1), up: true, inRate: 300, outRate: 600},
+	lan := lanPrefix(id.Seed)
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
+				mac: deviceMAC(id.Seed, 1), up: true, inRate: 300, outRate: 600},
+		},
+		addrs:   []ifAddr{{ifIndex: 1, prefix: addrIn(lan, 220+int(id.Seed%10))}},
+		gateway: hostIn(lan, 1),
+		pps:     6,
+		listen:  []uint16{21, 22, 80, 443},
+		udp:     []uint16{161},
 	})
 
 	// The load and the power drawn move together: 230 V times 4.2 to 6.8 A.

--- a/pkg/simulator/sample_test.go
+++ b/pkg/simulator/sample_test.go
@@ -3,6 +3,7 @@ package simulator
 import (
 	"fmt"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -45,6 +46,40 @@ var engineOrder = []string{
 	".1.3.6.1.6.3.10.2.1.2.0",
 	".1.3.6.1.6.3.10.2.1.3.0",
 	".1.3.6.1.6.3.10.2.1.4.0",
+}
+
+// snmpOrder is SNMPv2-MIB's snmp group, which every agent adds to what it
+// serves, in the order it is walked — .11.10 after .11.9, where text would put
+// it after .11.1. Arcs 7 and 23 were never assigned.
+var snmpOrder = []string{
+	".1.3.6.1.2.1.11.1.0", ".1.3.6.1.2.1.11.2.0", ".1.3.6.1.2.1.11.3.0", ".1.3.6.1.2.1.11.4.0",
+	".1.3.6.1.2.1.11.5.0", ".1.3.6.1.2.1.11.6.0", ".1.3.6.1.2.1.11.8.0", ".1.3.6.1.2.1.11.9.0",
+	".1.3.6.1.2.1.11.10.0", ".1.3.6.1.2.1.11.11.0", ".1.3.6.1.2.1.11.12.0", ".1.3.6.1.2.1.11.13.0",
+	".1.3.6.1.2.1.11.14.0", ".1.3.6.1.2.1.11.15.0", ".1.3.6.1.2.1.11.16.0", ".1.3.6.1.2.1.11.17.0",
+	".1.3.6.1.2.1.11.18.0", ".1.3.6.1.2.1.11.19.0", ".1.3.6.1.2.1.11.20.0", ".1.3.6.1.2.1.11.21.0",
+	".1.3.6.1.2.1.11.22.0", ".1.3.6.1.2.1.11.24.0", ".1.3.6.1.2.1.11.25.0", ".1.3.6.1.2.1.11.26.0",
+	".1.3.6.1.2.1.11.27.0", ".1.3.6.1.2.1.11.28.0", ".1.3.6.1.2.1.11.29.0", ".1.3.6.1.2.1.11.30.0",
+	".1.3.6.1.2.1.11.31.0", ".1.3.6.1.2.1.11.32.0",
+}
+
+// v3StatsOrder are the counters a v3 agent adds after its engine: SNMP-MPD-MIB's,
+// SNMP-TARGET-MIB's two about contexts, and the USM's.
+var v3StatsOrder = []string{
+	".1.3.6.1.6.3.11.2.1.1.0", ".1.3.6.1.6.3.11.2.1.2.0", ".1.3.6.1.6.3.11.2.1.3.0",
+	".1.3.6.1.6.3.12.1.4.0", ".1.3.6.1.6.3.12.1.5.0",
+	".1.3.6.1.6.3.15.1.1.1.0", ".1.3.6.1.6.3.15.1.1.2.0", ".1.3.6.1.6.3.15.1.1.3.0",
+	".1.3.6.1.6.3.15.1.1.4.0", ".1.3.6.1.6.3.15.1.1.5.0", ".1.3.6.1.6.3.15.1.1.6.0",
+}
+
+// walkOrder is how an agent serving sampleObjects is walked: the snmp group
+// between ifTable and ifXTable, and for v3 the engine and its statistics after
+// everything under mib-2.
+func walkOrder(v3 bool) []string {
+	out := slices.Concat(sampleOrder[:11], snmpOrder, sampleOrder[11:])
+	if v3 {
+		out = slices.Concat(out, engineOrder, v3StatsOrder)
+	}
+	return out
 }
 
 // sampleObjects is a small device, declared interface by interface rather than

--- a/pkg/simulator/snmplens_test.go
+++ b/pkg/simulator/snmplens_test.go
@@ -62,8 +62,8 @@ func TestSnmpLensReadsTheSimulator(t *testing.T) {
 		for j, r := range rows {
 			got[j] = r.Oid
 		}
-		// The device answers v3, so its engine group is there too.
-		if want := slices.Concat(sampleOrder, engineOrder); !slices.Equal(got, want) {
+		// The device answers v3, so its engine group and statistics are there too.
+		if want := walkOrder(true); !slices.Equal(got, want) {
 			t.Errorf("walked\n%v\nwant\n%v", got, want)
 		}
 	})

--- a/pkg/simulator/stack.go
+++ b/pkg/simulator/stack.go
@@ -1,0 +1,551 @@
+package simulator
+
+import (
+	"cmp"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"net"
+	"net/netip"
+	"slices"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A device's standard MIBs — IF-MIB, IP-MIB, IP-FORWARD-MIB, TCP-MIB, UDP-MIB,
+// EtherLike-MIB, and ENTITY-MIB's account of its hardware, BRIDGE-MIB and
+// LLDP-MIB when it is a switch — built from one description of the device so
+// that they agree with each other: an address sits on an interface the device
+// has, a route leaves through one, a TCP session runs to an address it can
+// reach, a bridge port is an interface, a neighbour is heard where a cable is.
+type stack struct {
+	seed uint64
+	ifs  []iface
+	// addrs are the device's IPv4 addresses. A loopback interface carries
+	// 127.0.0.1 as well, as a host's does.
+	addrs []ifAddr
+	// gateway is the next hop of the default route, or the zero address.
+	gateway netip.Addr
+	// router forwards (ipForwarding), and routes are what it has learnt.
+	router bool
+	routes []route
+	// ttl is ipDefaultTTL, 64 when not given.
+	ttl int
+	// pps is how many packets a second the device's own IP stack sends and
+	// receives — not what it forwards — which moves every protocol counter.
+	pps float64
+	// listen and udp are the ports the device listens on; sessions are the
+	// TCP connections established to it.
+	listen   []uint16
+	udp      []uint16
+	sessions []session
+	entity   []physical
+	bridge   *bridgeInfo
+	lldp     *lldpInfo
+	// modules are the MIB modules sysORTable lists besides the standard ones.
+	modules []sysOR
+}
+
+// ifAddr is one of the device's addresses, on an interface.
+type ifAddr struct {
+	ifIndex int
+	prefix  netip.Prefix
+	// neighbours is how many other hosts of the subnet the ARP cache holds,
+	// the gateway aside.
+	neighbours int
+}
+
+// route is one the device knows beyond its own subnets and its default route.
+type route struct {
+	dest    netip.Prefix
+	nextHop netip.Addr
+	ifIndex int
+	proto   int // ipCidrRouteProto
+	metric  int
+	as      int // the next hop's AS, for a route BGP learnt
+}
+
+// The ipCidrRouteProto values the models use.
+const (
+	protoLocal  = 2
+	protoStatic = 3 // netmgmt
+	protoOSPF   = 13
+	protoBGP    = 14
+)
+
+// session is a TCP connection established to the device's first address, on
+// its port local, from peer.
+type session struct {
+	local uint16
+	peer  netip.AddrPort
+}
+
+// sysOR is a MIB module the agent says it implements: a row of sysORTable.
+type sysOR struct{ oid, descr string }
+
+// standardModules are the modules every agent here lists, described as
+// net-snmp describes them.
+var standardModules = []sysOR{
+	{".1.3.6.1.6.3.11.3.1.1", "The MIB for Message Processing and Dispatching."},
+	{".1.3.6.1.6.3.15.2.1.1", "The management information definitions for the SNMP User-based Security Model."},
+	{".1.3.6.1.6.3.10.3.1.1", "The SNMP Management Architecture MIB."},
+	{".1.3.6.1.6.3.1", "The MIB module for SNMPv2 entities"},
+	{".1.3.6.1.2.1.31", "The MIB module to describe generic objects for network interface sub-layers"},
+	{".1.3.6.1.2.1.49", "The MIB module for managing TCP implementations"},
+	{".1.3.6.1.2.1.4", "The MIB module for managing IP and ICMP implementations"},
+	{".1.3.6.1.2.1.50", "The MIB module for managing UDP implementations"},
+}
+
+// The other modules a model may list.
+var (
+	moduleHostResources = sysOR{".1.3.6.1.2.1.25.7.1", "The MIB module for managing host systems."}
+	moduleEntity        = sysOR{".1.3.6.1.2.1.47", "The MIB module for representing multiple logical entities supported by a single SNMP agent."}
+	moduleBridge        = sysOR{".1.3.6.1.2.1.17", "The Bridge MIB module for managing devices that support IEEE 802.1D."}
+	moduleLLDP          = sysOR{".1.0.8802.1.1.2", "Management Information Base module for LLDP configuration, statistics, local system data and remote systems data components."}
+)
+
+// lanPrefix is a private /24 drawn from seed: the network a device sits on.
+func lanPrefix(seed uint64) netip.Prefix {
+	h := mix(seed + 70001)
+	return netip.PrefixFrom(netip.AddrFrom4([4]byte{10, byte(16 + h%224), byte(h >> 8), 0}), 24)
+}
+
+// hostIn is the address numbered n in p.
+func hostIn(p netip.Prefix, n int) netip.Addr {
+	b := p.Masked().Addr().As4()
+	binary.BigEndian.PutUint32(b[:], binary.BigEndian.Uint32(b[:])+uint32(n))
+	return netip.AddrFrom4(b)
+}
+
+// addrIn is the address numbered n in p, with p's length.
+func addrIn(p netip.Prefix, n int) netip.Prefix { return netip.PrefixFrom(hostIn(p, n), p.Bits()) }
+
+// maskOf writes a prefix length as a dotted netmask.
+func maskOf(bits int) string { return net.IP(net.CIDRMask(bits, 32)).String() }
+
+// peerMAC is the MAC of another station, drawn apart from the device's own.
+func peerMAC(seed, n uint64) net.HardwareAddr { return deviceMAC(seed^0x5eedc0ffee, n) }
+
+// counter is one of the stack's protocol counters: a share of its packet rate,
+// from a start drawn from the seed. counter64 with the same arguments is the
+// same count in 64 bits, as tcpHCInSegs is tcpInSegs.
+func (s stack) counter(n uint64, share float64) Reading {
+	return Counter(s.pps*share, s.start(n), s.swing(n))
+}
+
+func (s stack) counter64(n uint64, share float64) Reading {
+	return Counter64(s.pps*share, s.start(n), s.swing(n))
+}
+
+func (s stack) start(n uint64) uint64 { return uint64(1e5 + 9e6*unit(s.seed+3100+n)) }
+
+func (s stack) swing(n uint64) Swing {
+	return Swing{Depth: 0.4, Period: 7 * time.Minute, Seed: s.seed + 3000 + n}
+}
+
+// ownAddrs are the device's addresses, 127.0.0.1 on its loopback included.
+func (s stack) ownAddrs() []ifAddr {
+	out := slices.Clone(s.addrs)
+	for _, f := range s.ifs {
+		if f.ifType == ifTypeSoftwareLoopback {
+			out = append(out, ifAddr{ifIndex: f.index, prefix: netip.MustParsePrefix("127.0.0.1/8")})
+			break
+		}
+	}
+	return out
+}
+
+// primary is the address the device is managed at, which sessions run to.
+func (s stack) primary() netip.Addr {
+	if len(s.addrs) > 0 {
+		return s.addrs[0].prefix.Addr()
+	}
+	return netip.IPv4Unspecified()
+}
+
+// ifIndexFor is the interface an address is reached through: the one whose
+// subnet holds it.
+func (s stack) ifIndexFor(a netip.Addr) int {
+	for _, own := range s.addrs {
+		if own.prefix.Masked().Contains(a) {
+			return own.ifIndex
+		}
+	}
+	return 0
+}
+
+// addStack adds the standard MIBs s describes.
+func addStack(o *objects, s stack) {
+	addInterfaces(o, s.seed, s.ifs)
+	addIP(o, s)
+	addICMP(o, s.seed)
+	addTCP(o, s)
+	addUDP(o, s)
+	addEtherLike(o, s.seed, s.ifs)
+	modules := slices.Concat(standardModules, s.modules)
+	if len(s.entity) > 0 {
+		addEntity(o, s.entity)
+		modules = append(modules, moduleEntity)
+	}
+	if s.bridge != nil {
+		addBridge(o, s, *s.bridge)
+		modules = append(modules, moduleBridge)
+	}
+	if s.lldp != nil {
+		addLLDP(o, s, *s.lldp)
+		modules = append(modules, moduleLLDP)
+	}
+	addSysOR(o, modules)
+}
+
+// addSysOR adds sysORTable, every module there since the agent started.
+func addSysOR(o *objects, modules []sysOR) {
+	const or = "1.3.6.1.2.1.1."
+	o.add(or+"8.0", gosnmp.TimeTicks, Const(uint32(0))) // sysORLastChange
+	for i, m := range modules {
+		n := i + 1
+		o.add(fmt.Sprintf(or+"9.1.2.%d", n), gosnmp.ObjectIdentifier, Const(m.oid))
+		o.add(fmt.Sprintf(or+"9.1.3.%d", n), gosnmp.OctetString, Const(m.descr))
+		o.add(fmt.Sprintf(or+"9.1.4.%d", n), gosnmp.TimeTicks, Const(uint32(0)))
+	}
+}
+
+// addIP adds IP-MIB — the ip group, the addresses in both of its tables, the
+// ARP cache — and IP-FORWARD-MIB's routes.
+func addIP(o *objects, s stack) {
+	const ip = "1.3.6.1.2.1.4."
+	zero := Const(uint32(0))
+	forwarding, forwarded := 2, 0.0
+	if s.router {
+		// A router forwards far more than it receives itself.
+		forwarding, forwarded = 1, 12
+	}
+	o.add(ip+"1.0", gosnmp.Integer, Const(forwarding))
+	o.add(ip+"2.0", gosnmp.Integer, Const(cmp.Or(s.ttl, 64)))
+	// Counters that share a number share a start, so that one never passes the
+	// other: ipInDelivers stays under ipInReceives.
+	o.add(ip+"3.0", gosnmp.Counter32, s.counter(1, 1))         // ipInReceives
+	o.add(ip+"4.0", gosnmp.Counter32, s.counter(2, 1e-5))      // ipInHdrErrors
+	o.add(ip+"5.0", gosnmp.Counter32, s.counter(3, 1e-4))      // ipInAddrErrors
+	o.add(ip+"6.0", gosnmp.Counter32, s.counter(4, forwarded)) // ipForwDatagrams
+	o.add(ip+"7.0", gosnmp.Counter32, zero)                    // ipInUnknownProtos
+	o.add(ip+"8.0", gosnmp.Counter32, s.counter(6, 2e-4))      // ipInDiscards
+	o.add(ip+"9.0", gosnmp.Counter32, s.counter(1, 0.99))      // ipInDelivers
+	o.add(ip+"10.0", gosnmp.Counter32, s.counter(8, 0.97))     // ipOutRequests
+	o.add(ip+"11.0", gosnmp.Counter32, s.counter(9, 1e-4))     // ipOutDiscards
+	o.add(ip+"12.0", gosnmp.Counter32, s.counter(10, 1e-5))    // ipOutNoRoutes
+	o.add(ip+"13.0", gosnmp.Integer, Const(30))                // ipReasmTimeout, seconds
+	o.add(ip+"14.0", gosnmp.Counter32, s.counter(12, 1e-4))    // ipReasmReqds
+	o.add(ip+"15.0", gosnmp.Counter32, s.counter(12, 5e-5))    // ipReasmOKs
+	o.add(ip+"16.0", gosnmp.Counter32, zero)                   // ipReasmFails
+	o.add(ip+"17.0", gosnmp.Counter32, s.counter(15, 1e-4))    // ipFragOKs
+	o.add(ip+"18.0", gosnmp.Counter32, zero)                   // ipFragFails
+	o.add(ip+"19.0", gosnmp.Counter32, s.counter(15, 2e-4))    // ipFragCreates
+	o.add(ip+"23.0", gosnmp.Counter32, zero)                   // ipRoutingDiscards
+
+	prefixes := map[string]bool{}
+	for _, a := range s.ownAddrs() {
+		addr := a.prefix.Addr().String()
+		// ipAddrTable, indexed by the address.
+		col := func(c int) string { return fmt.Sprintf(ip+"20.1.%d.%s", c, addr) }
+		o.add(col(1), gosnmp.IPAddress, Const(addr))
+		o.add(col(2), gosnmp.Integer, Const(a.ifIndex))
+		o.add(col(3), gosnmp.IPAddress, Const(maskOf(a.prefix.Bits())))
+		o.add(col(4), gosnmp.Integer, Const(1))
+		o.add(col(5), gosnmp.Integer, Const(65535))
+
+		// ipAddressPrefixTable, which ipAddressTable points at: indexed by the
+		// interface, the address type, the prefix as an InetAddress — its
+		// length first — and the prefix length.
+		subnet := a.prefix.Masked()
+		pfx := fmt.Sprintf("%d.1.4.%s.%d", a.ifIndex, subnet.Addr(), subnet.Bits())
+		if !prefixes[pfx] {
+			prefixes[pfx] = true
+			pcol := func(c int) string { return fmt.Sprintf(ip+"32.1.%d.%s", c, pfx) }
+			o.add(pcol(5), gosnmp.Integer, Const(2)) // origin: manual
+			o.add(pcol(6), gosnmp.Integer, Const(1)) // on link: true
+			o.add(pcol(7), gosnmp.Integer, Const(2)) // autonomous: false
+			o.add(pcol(8), gosnmp.Gauge32, Const(uint32(math.MaxUint32)))
+			o.add(pcol(9), gosnmp.Gauge32, Const(uint32(math.MaxUint32)))
+		}
+		// ipAddressTable, indexed by the type and the address, its length first.
+		acol := func(c int) string { return fmt.Sprintf(ip+"34.1.%d.1.4.%s", c, addr) }
+		o.add(acol(3), gosnmp.Integer, Const(a.ifIndex))
+		o.add(acol(4), gosnmp.Integer, Const(1)) // unicast
+		o.add(acol(5), gosnmp.ObjectIdentifier, Const(".1.3.6.1.2.1.4.32.1.5."+pfx))
+		o.add(acol(6), gosnmp.Integer, Const(2)) // origin: manual
+		o.add(acol(7), gosnmp.Integer, Const(1)) // status: preferred
+		o.add(acol(8), gosnmp.TimeTicks, Const(uint32(0)))
+		o.add(acol(9), gosnmp.TimeTicks, Const(uint32(0)))
+		o.add(acol(10), gosnmp.Integer, Const(1)) // active
+		o.add(acol(11), gosnmp.Integer, Const(2)) // volatile
+	}
+
+	// ipNetToMediaTable: the ARP cache, indexed by interface and address.
+	for _, n := range s.neighbours() {
+		inst := fmt.Sprintf("%d.%s", n.ifIndex, n.addr)
+		col := func(c int) string { return fmt.Sprintf(ip+"22.1.%d.%s", c, inst) }
+		o.add(col(1), gosnmp.Integer, Const(n.ifIndex))
+		o.add(col(2), gosnmp.OctetString, Const([]byte(n.mac)))
+		o.add(col(3), gosnmp.IPAddress, Const(n.addr.String()))
+		o.add(col(4), gosnmp.Integer, Const(3)) // dynamic
+	}
+
+	// IP-FORWARD-MIB's ipCidrRouteTable, indexed by destination, mask, TOS and
+	// next hop.
+	routes := s.allRoutes()
+	o.add(ip+"24.3.0", gosnmp.Gauge32, Const(uint32(len(routes))))
+	for _, r := range routes {
+		hop := r.nextHop
+		if !hop.IsValid() {
+			hop = netip.IPv4Unspecified()
+		}
+		inst := fmt.Sprintf("%s.%s.0.%s", r.dest.Addr(), maskOf(r.dest.Bits()), hop)
+		col := func(c int) string { return fmt.Sprintf(ip+"24.4.1.%d.%s", c, inst) }
+		kind := 4 // remote
+		if hop.IsUnspecified() {
+			kind = 3 // local: the subnet itself
+		}
+		o.add(col(1), gosnmp.IPAddress, Const(r.dest.Addr().String()))
+		o.add(col(2), gosnmp.IPAddress, Const(maskOf(r.dest.Bits())))
+		o.add(col(3), gosnmp.Integer, Const(0))
+		o.add(col(4), gosnmp.IPAddress, Const(hop.String()))
+		o.add(col(5), gosnmp.Integer, Const(r.ifIndex))
+		o.add(col(6), gosnmp.Integer, Const(kind))
+		o.add(col(7), gosnmp.Integer, Const(r.proto))
+		o.add(col(8), gosnmp.Integer, engineSeconds{}) // learnt as the device came up
+		o.add(col(9), gosnmp.ObjectIdentifier, Const(".0.0"))
+		o.add(col(10), gosnmp.Integer, Const(r.as))
+		o.add(col(11), gosnmp.Integer, Const(r.metric))
+		for c := 12; c <= 15; c++ {
+			o.add(col(c), gosnmp.Integer, Const(-1)) // metrics this protocol has not
+		}
+		o.add(col(16), gosnmp.Integer, Const(1)) // active
+	}
+}
+
+// arpEntry is a neighbour in the ARP cache.
+type arpEntry struct {
+	ifIndex int
+	addr    netip.Addr
+	mac     net.HardwareAddr
+}
+
+// neighbours are the ARP cache: the gateway where it is on a subnet of the
+// device, and the other hosts each subnet says it has.
+func (s stack) neighbours() []arpEntry {
+	var out []arpEntry
+	for i, a := range s.addrs {
+		subnet := a.prefix.Masked()
+		if s.gateway.IsValid() && subnet.Contains(s.gateway) {
+			out = append(out, arpEntry{a.ifIndex, s.gateway, peerMAC(s.seed, 0)})
+		}
+		offset := int(mix(s.seed+uint64(i)) % 7)
+		for k, n := 0, 0; k < a.neighbours; n++ {
+			addr := hostIn(subnet, 20+offset+3*n)
+			if !subnet.Contains(addr) || n > 1<<10 {
+				break
+			}
+			if addr == a.prefix.Addr() || addr == s.gateway {
+				continue
+			}
+			out = append(out, arpEntry{a.ifIndex, addr, peerMAC(s.seed, uint64(100*(i+1)+k))})
+			k++
+		}
+	}
+	return out
+}
+
+// allRoutes are the routes to the device's own subnets, the default one, and
+// those it learnt.
+func (s stack) allRoutes() []route {
+	var out []route
+	seen := map[netip.Prefix]bool{}
+	for _, a := range s.addrs {
+		if subnet := a.prefix.Masked(); !seen[subnet] {
+			seen[subnet] = true
+			out = append(out, route{dest: subnet, ifIndex: a.ifIndex, proto: protoLocal})
+		}
+	}
+	if s.gateway.IsValid() {
+		out = append(out, route{dest: netip.PrefixFrom(netip.IPv4Unspecified(), 0), nextHop: s.gateway,
+			ifIndex: s.ifIndexFor(s.gateway), proto: protoStatic, metric: 1})
+	}
+	return append(out, s.routes...)
+}
+
+// addICMP adds the icmp group: what pings and unreachable ports make of a
+// device, a few a minute.
+func addICMP(o *objects, seed uint64) {
+	const icmp = "1.3.6.1.2.1.5."
+	rates := [26]float64{
+		// in: messages, errors, destination unreachable, time exceeded, parameter
+		// problems, source quenches, redirects, echoes, echo replies, timestamps,
+		// timestamp replies, address masks, address mask replies
+		0.09, 0.001, 0.02, 0.002, 0, 0, 0, 0.06, 0.01, 0, 0, 0, 0,
+		// out, in the same order
+		0.1, 0, 0.03, 0, 0, 0, 0, 0.01, 0.06, 0, 0, 0, 0,
+	}
+	for i, r := range rates {
+		n := uint64(i)
+		var v Reading = Const(uint32(0))
+		if r > 0 {
+			v = Counter(r, uint64(100+5000*unit(seed+3300+n)), Swing{Depth: 0.8, Period: 20 * time.Minute, Seed: seed + 3300 + n})
+		}
+		o.add(fmt.Sprintf(icmp+"%d.0", i+1), gosnmp.Counter32, v)
+	}
+}
+
+// addTCP adds TCP-MIB: its scalars, the 64-bit segment counts, and
+// tcpConnTable — the sockets listening and the sessions established, indexed
+// by four things, as the conceptual-table decoder meets them on a real agent.
+func addTCP(o *objects, s stack) {
+	const tcp = "1.3.6.1.2.1.6."
+	o.add(tcp+"1.0", gosnmp.Integer, Const(1)) // tcpRtoAlgorithm: other, as Linux says
+	o.add(tcp+"2.0", gosnmp.Integer, Const(200))
+	o.add(tcp+"3.0", gosnmp.Integer, Const(120000))
+	o.add(tcp+"4.0", gosnmp.Integer, Const(-1))              // no fixed limit
+	o.add(tcp+"5.0", gosnmp.Counter32, s.counter(40, 0.002)) // tcpActiveOpens
+	o.add(tcp+"6.0", gosnmp.Counter32, s.counter(41, 0.004)) // tcpPassiveOpens
+	o.add(tcp+"7.0", gosnmp.Counter32, s.counter(42, 4e-4))  // tcpAttemptFails
+	o.add(tcp+"8.0", gosnmp.Counter32, s.counter(43, 2e-4))  // tcpEstabResets
+	o.add(tcp+"9.0", gosnmp.Gauge32, Const(uint32(len(s.sessions))))
+	o.add(tcp+"10.0", gosnmp.Counter32, s.counter(45, 0.6))   // tcpInSegs
+	o.add(tcp+"11.0", gosnmp.Counter32, s.counter(46, 0.62))  // tcpOutSegs
+	o.add(tcp+"12.0", gosnmp.Counter32, s.counter(47, 0.002)) // tcpRetransSegs
+	o.add(tcp+"14.0", gosnmp.Counter32, s.counter(48, 1e-5))  // tcpInErrs
+	o.add(tcp+"15.0", gosnmp.Counter32, s.counter(49, 0.001)) // tcpOutRsts
+	o.add(tcp+"17.0", gosnmp.Counter64, s.counter64(45, 0.6))
+	o.add(tcp+"18.0", gosnmp.Counter64, s.counter64(46, 0.62))
+
+	conn := func(state int, local netip.Addr, localPort uint16, remote netip.Addr, remotePort uint16) {
+		inst := fmt.Sprintf("%s.%d.%s.%d", local, localPort, remote, remotePort)
+		col := func(c int) string { return fmt.Sprintf(tcp+"13.1.%d.%s", c, inst) }
+		o.add(col(1), gosnmp.Integer, Const(state))
+		o.add(col(2), gosnmp.IPAddress, Const(local.String()))
+		o.add(col(3), gosnmp.Integer, Const(int(localPort)))
+		o.add(col(4), gosnmp.IPAddress, Const(remote.String()))
+		o.add(col(5), gosnmp.Integer, Const(int(remotePort)))
+	}
+	any := netip.IPv4Unspecified()
+	for _, port := range s.listen {
+		conn(2, any, port, any, 0) // listen
+	}
+	for _, ses := range s.sessions {
+		conn(5, s.primary(), ses.local, ses.peer.Addr(), ses.peer.Port()) // established
+	}
+}
+
+// addUDP adds UDP-MIB: its counters and udpTable, the ports listening — SNMP's
+// among them, since the device answers on it.
+func addUDP(o *objects, s stack) {
+	const udp = "1.3.6.1.2.1.7."
+	o.add(udp+"1.0", gosnmp.Counter32, s.counter(60, 0.3)) // udpInDatagrams
+	o.add(udp+"2.0", gosnmp.Counter32, s.counter(61, 0.01))
+	o.add(udp+"3.0", gosnmp.Counter32, Const(uint32(0)))
+	o.add(udp+"4.0", gosnmp.Counter32, s.counter(63, 0.3))
+	o.add(udp+"8.0", gosnmp.Counter64, s.counter64(60, 0.3))
+	o.add(udp+"9.0", gosnmp.Counter64, s.counter64(63, 0.3))
+	ports := s.udp
+	if !slices.Contains(ports, 161) {
+		ports = append(slices.Clone(ports), 161)
+	}
+	for _, port := range ports {
+		inst := fmt.Sprintf("0.0.0.0.%d", port)
+		o.add(udp+"5.1.1."+inst, gosnmp.IPAddress, Const("0.0.0.0"))
+		o.add(udp+"5.1.2."+inst, gosnmp.Integer, Const(int(port)))
+	}
+}
+
+// addEtherLike adds EtherLike-MIB's dot3StatsTable for each Ethernet
+// interface: full duplex and no collisions where a link is up, and FCS errors
+// that follow the interface's input errors.
+func addEtherLike(o *objects, seed uint64, ifs []iface) {
+	const dot3 = "1.3.6.1.2.1.10.7.2.1."
+	zero := Const(uint32(0))
+	for _, f := range ifs {
+		if f.ifType != ifTypeEthernet {
+			continue
+		}
+		col := func(c int) string { return fmt.Sprintf(dot3+"%d.%d", c, f.index) }
+		up := f.up && !f.adminDown
+		o.add(col(1), gosnmp.Integer, Const(f.index))
+		o.add(col(2), gosnmp.Counter32, zero) // alignment errors
+		fcs := zero
+		if up && f.errorRate > 0 {
+			fcs = Counter(f.errorRate*0.6, 0, Swing{Depth: 0.9, Period: 11 * time.Minute, Seed: seed + uint64(f.index)*16 + 3})
+		}
+		o.add(col(3), gosnmp.Counter32, fcs)
+		for _, c := range []int{4, 5, 6, 7, 8, 9, 10, 11, 13, 16, 18} {
+			o.add(col(c), gosnmp.Counter32, zero)
+		}
+		duplex := 1 // unknown: no link
+		if up {
+			duplex = 3 // full
+		}
+		o.add(col(19), gosnmp.Integer, Const(duplex))
+	}
+}
+
+// physical is one entry of ENTITY-MIB's entPhysicalTable.
+type physical struct {
+	index, container, relPos, class int
+	descr, name, model, serial      string
+	hwRev, fwRev, swRev, mfg        string
+	// vendorType is an AutonomousType; zeroDotZero, which the MIB allows, when
+	// it is not known.
+	vendorType string
+	fru        bool
+	// ifIndex is a port's interface (entAliasMappingTable).
+	ifIndex int
+}
+
+// The entPhysicalClass values the models use.
+const (
+	classOther       = 1
+	classChassis     = 3
+	classContainer   = 5
+	classPowerSupply = 6
+	classFan         = 7
+	classSensor      = 8
+	classModule      = 9
+	classPort        = 10
+	classCPU         = 12
+)
+
+// addEntity adds ENTITY-MIB: the physical table, what contains what, and which
+// interface each port is.
+func addEntity(o *objects, ents []physical) {
+	const e = "1.3.6.1.2.1.47.1."
+	for _, p := range ents {
+		col := func(c int) string { return fmt.Sprintf(e+"1.1.1.%d.%d", c, p.index) }
+		fru := 2
+		if p.fru {
+			fru = 1
+		}
+		o.add(col(2), gosnmp.OctetString, Const(p.descr))
+		o.add(col(3), gosnmp.ObjectIdentifier, Const(cmp.Or(p.vendorType, ".0.0")))
+		o.add(col(4), gosnmp.Integer, Const(p.container))
+		o.add(col(5), gosnmp.Integer, Const(p.class))
+		o.add(col(6), gosnmp.Integer, Const(p.relPos))
+		o.add(col(7), gosnmp.OctetString, Const(p.name))
+		o.add(col(8), gosnmp.OctetString, Const(p.hwRev))
+		o.add(col(9), gosnmp.OctetString, Const(p.fwRev))
+		o.add(col(10), gosnmp.OctetString, Const(p.swRev))
+		o.add(col(11), gosnmp.OctetString, Const(p.serial))
+		o.add(col(12), gosnmp.OctetString, Const(p.mfg))
+		o.add(col(13), gosnmp.OctetString, Const(p.model))
+		o.add(col(14), gosnmp.OctetString, Const(""))
+		o.add(col(15), gosnmp.OctetString, Const(""))
+		o.add(col(16), gosnmp.Integer, Const(fru))
+		if p.ifIndex > 0 {
+			o.add(fmt.Sprintf(e+"3.2.1.2.%d.0", p.index), gosnmp.ObjectIdentifier,
+				Const(fmt.Sprintf(".1.3.6.1.2.1.2.2.1.1.%d", p.ifIndex)))
+		}
+		if p.container > 0 {
+			o.add(fmt.Sprintf(e+"3.3.1.1.%d.%d", p.container, p.index), gosnmp.Integer, Const(p.index))
+		}
+	}
+	o.add(e+"4.1.0", gosnmp.TimeTicks, Const(uint32(0))) // entLastChangeTime
+}

--- a/pkg/simulator/stack_test.go
+++ b/pkg/simulator/stack_test.go
@@ -1,0 +1,219 @@
+package simulator
+
+import (
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// column is what every instance of a column holds, by instance.
+func column(tr *tree, col string) map[string]any {
+	prefix, _ := parseOID(col)
+	out := map[string]any{}
+	for e := tr.next(prefix, nil); e != nil && e.oid.hasPrefix(prefix); e = tr.next(e.oid, nil) {
+		out[strings.TrimPrefix(e.oid[len(prefix):].String(), ".")] = e.val.read(clock{})
+	}
+	return out
+}
+
+// whole is a value read from the tree as a whole number, whatever its type.
+func whole(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case uint32:
+		return int(n)
+	case uint64:
+		return int(n)
+	}
+	return -1
+}
+
+// Every model's standard MIBs agree with each other, as a real agent's do:
+// every interface one of them names is one ifTable lists, every entity sits in
+// one that exists, every bridge port a station was learnt on is a port, and
+// every count counts what it says it does.
+func TestTheStandardMIBsAgree(t *testing.T) {
+	for _, m := range models {
+		t.Run(m.ID, func(t *testing.T) {
+			tr, err := newTree(slices.Concat(m.build(Identity{Name: "dev-01", Seed: 11}), agentObjects(false, nil, 1, false)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			scalar := func(oid string) any {
+				id, _ := parseOID(oid)
+				if e := tr.get(id); e != nil {
+					return e.val.read(clock{})
+				}
+				return nil
+			}
+
+			interfaces := column(tr, "1.3.6.1.2.1.2.2.1.1")
+			if n := whole(scalar("1.3.6.1.2.1.2.1.0")); n != len(interfaces) {
+				t.Errorf("ifNumber is %d, and ifTable has %d rows", n, len(interfaces))
+			}
+			isInterface := func(v any) bool { _, ok := interfaces[strconv.Itoa(whole(v))]; return ok }
+			for name, col := range map[string]string{
+				"ipAdEntIfIndex":       "1.3.6.1.2.1.4.20.1.2",
+				"ipNetToMediaIfIndex":  "1.3.6.1.2.1.4.22.1.1",
+				"ipAddressIfIndex":     "1.3.6.1.2.1.4.34.1.3",
+				"ipCidrRouteIfIndex":   "1.3.6.1.2.1.4.24.4.1.5",
+				"dot1dBasePortIfIndex": "1.3.6.1.2.1.17.1.4.1.2",
+				"dot3StatsIndex":       "1.3.6.1.2.1.10.7.2.1.1",
+				"hrNetworkIfIndex":     "1.3.6.1.2.1.25.3.4.1.1",
+			} {
+				for inst, v := range column(tr, col) {
+					if !isInterface(v) {
+						t.Errorf("%s.%s names interface %v, which ifTable does not list", name, inst, v)
+					}
+				}
+			}
+			for inst, v := range column(tr, "1.3.6.1.2.1.47.1.3.2.1.2") {
+				if !isInterface(strings.TrimPrefix(v.(string), ".1.3.6.1.2.1.2.2.1.1.")) &&
+					!isInterface(whole(atoi(strings.TrimPrefix(v.(string), ".1.3.6.1.2.1.2.2.1.1.")))) {
+					t.Errorf("entAliasMappingIdentifier.%s points at %v, no interface", inst, v)
+				}
+			}
+			for inst := range column(tr, "1.0.8802.1.1.2.1.3.7.1.2") {
+				if !isInterface(atoi(inst)) {
+					t.Errorf("lldpLocPortNum %s is no interface", inst)
+				}
+			}
+			for inst := range column(tr, "1.0.8802.1.1.2.1.4.1.1.9") {
+				if local := strings.Split(inst, ".")[1]; !isInterface(atoi(local)) {
+					t.Errorf("an LLDP neighbour is heard on port %s, which is no interface", local)
+				}
+			}
+
+			entities := column(tr, "1.3.6.1.2.1.47.1.1.1.1.5")
+			for inst, v := range column(tr, "1.3.6.1.2.1.47.1.1.1.1.4") {
+				if n := whole(v); n != 0 {
+					if _, ok := entities[strconv.Itoa(n)]; !ok {
+						t.Errorf("entity %s is contained in %d, which is not an entity", inst, n)
+					}
+				}
+			}
+			if v := scalar("1.3.6.1.4.1.9.9.109.1.1.1.1.2.1"); v != nil && len(entities) > 0 {
+				if _, ok := entities[strconv.Itoa(whole(v))]; !ok {
+					t.Errorf("cpmCPUTotalPhysicalIndex is %v, which is not an entity", v)
+				}
+			}
+
+			established := 0
+			for _, v := range column(tr, "1.3.6.1.2.1.6.13.1.1") {
+				if whole(v) == 5 {
+					established++
+				}
+			}
+			if n := whole(scalar("1.3.6.1.2.1.6.9.0")); n != established {
+				t.Errorf("tcpCurrEstab is %d, and tcpConnTable has %d session(s) established", n, established)
+			}
+			if n, routes := whole(scalar("1.3.6.1.2.1.4.24.3.0")), len(column(tr, "1.3.6.1.2.1.4.24.4.1.1")); n != routes {
+				t.Errorf("ipCidrRouteNumber is %d, and the table has %d route(s)", n, routes)
+			}
+			if running := column(tr, "1.3.6.1.2.1.25.4.2.1.1"); len(running) > 0 {
+				if n := whole(scalar("1.3.6.1.2.1.25.1.6.0")); n != len(running) {
+					t.Errorf("hrSystemProcesses is %d, and hrSWRunTable lists %d", n, len(running))
+				}
+			}
+			if ports := column(tr, "1.3.6.1.2.1.17.1.4.1.1"); len(ports) > 0 {
+				if n := whole(scalar("1.3.6.1.2.1.17.1.2.0")); n != len(ports) {
+					t.Errorf("dot1dBaseNumPorts is %d, and the port table has %d", n, len(ports))
+				}
+				for inst, v := range column(tr, "1.3.6.1.2.1.17.4.3.1.2") {
+					if p := whole(v); p != 0 {
+						if _, ok := ports[strconv.Itoa(p)]; !ok {
+							t.Errorf("station %s was learnt on port %d, which is not a bridge port", inst, p)
+						}
+					}
+				}
+				if n, vlans := whole(scalar("1.3.6.1.2.1.17.7.1.1.4.0")), len(column(tr, "1.3.6.1.2.1.17.7.1.4.3.1.1")); n != vlans {
+					t.Errorf("dot1qNumVlans is %d, and there are %d VLAN(s)", n, vlans)
+				}
+			}
+			if len(column(tr, "1.3.6.1.2.1.1.9.1.2")) == 0 {
+				t.Error("sysORTable is empty")
+			}
+		})
+	}
+}
+
+func atoi(s string) int {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return -1
+	}
+	return n
+}
+
+// The snmp group counts what the agent does, as it does it: every datagram,
+// every GET and GETNEXT, the varbinds it read, the refused community, the
+// answers it sent.
+func TestTheAgentCountsWhatItAnswers(t *testing.T) {
+	a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public"})
+	g := connect(t, manager(a, gosnmp.Version2c, "public"))
+	read := func(oid string) uint64 {
+		t.Helper()
+		res, err := g.Get([]string{oid})
+		if err != nil || res.Variables[0].Type != gosnmp.Counter32 {
+			t.Fatalf("%s: %v %v", oid, res, err)
+		}
+		return gosnmp.ToBigInt(res.Variables[0].Value).Uint64()
+	}
+	const (
+		inPkts       = ".1.3.6.1.2.1.11.1.0"
+		badCommunity = ".1.3.6.1.2.1.11.4.0"
+		reqVars      = ".1.3.6.1.2.1.11.13.0"
+		gets         = ".1.3.6.1.2.1.11.15.0"
+		getNexts     = ".1.3.6.1.2.1.11.16.0"
+		responses    = ".1.3.6.1.2.1.11.28.0"
+	)
+	// Counted on arrival: a GET of snmpInPkts counts itself.
+	first := read(inPkts)
+	if again := read(inPkts); again != first+1 {
+		t.Errorf("snmpInPkts went from %d to %d over one request", first, again)
+	}
+	before := read(gets)
+	if after := read(gets); after != before+1 {
+		t.Errorf("snmpInGetRequests went from %d to %d over one GET", before, after)
+	}
+	nexts, vars := read(getNexts), read(reqVars)
+	if err := g.Walk(".1.3.6.1.2.1.1", func(gosnmp.SnmpPDU) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if n := read(getNexts); n <= nexts {
+		t.Errorf("a walk left snmpInGetNexts at %d", n)
+	}
+	if n := read(reqVars); n < vars+4 {
+		t.Errorf("snmpInTotalReqVars went from %d to %d over a walk of the system group", vars, n)
+	}
+	if n := read(responses); n < read(gets) {
+		t.Errorf("%d responses for more GETs than that", n)
+	}
+
+	stranger := manager(a, gosnmp.Version2c, "private")
+	stranger.Timeout = silent
+	connect(t, stranger)
+	_, _ = stranger.Get([]string{sysDescrOID})
+	if n := read(badCommunity); n != 1 {
+		t.Errorf("snmpInBadCommunityNames is %d after one wrong community", n)
+	}
+	res, err := g.Get([]string{".1.3.6.1.2.1.11.30.0"})
+	if err != nil || gosnmp.ToBigInt(res.Variables[0].Value).Int64() != 2 {
+		t.Errorf("snmpEnableAuthenTraps, with none configured: %v %v", res, err)
+	}
+}
+
+// hrSystemDate is the time now, and it moves.
+func TestTheSystemDateIsNow(t *testing.T) {
+	now := time.Date(2026, 9, 11, 16, 5, 42, 300_000_000, time.FixedZone("CEST", 2*3600))
+	got := dateAndTime{}.read(clock{now: now}).([]byte)
+	want := []byte{0x07, 0xEA, 9, 11, 16, 5, 42, 3, '+', 2, 0}
+	if !slices.Equal(got, want) {
+		t.Errorf("DateAndTime of %v is %v, want %v", now, got, want)
+	}
+}

--- a/pkg/simulator/synology.go
+++ b/pkg/simulator/synology.go
@@ -2,6 +2,7 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -9,8 +10,8 @@ import (
 
 // synologyNAS is a DS920+ running DSM, whose agent is net-snmp — so its
 // sysObjectID is net-snmp's Linux one, as a real DiskStation's is — with
-// Synology's own system, disk and RAID tables beside the host resources and
-// the interfaces.
+// Synology's own system, disk and RAID tables beside the host resources, UCD's
+// memory and disks, and a file server's sockets: SMB, AFP, NFS, DSM.
 var synologyNAS = model{
 	ModelInfo:     ModelInfo{ID: "synology-nas", Category: "storage"},
 	enterprise:    8072, // net-snmp
@@ -22,27 +23,74 @@ func buildSynologyNAS(id Identity) []Object {
 	var o objects
 	addSystem(&o, id, fmt.Sprintf("Linux %s 4.4.302+ #69057 SMP Fri Jan 12 17:02:28 CST 2024 x86_64", id.Name),
 		".1.3.6.1.4.1.8072.3.2.10", "admin@"+id.Name, "Office, storage shelf", 76)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
-			up: true, inRate: 5_000, outRate: 5_000},
-		{index: 2, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
-			mac: deviceMAC(id.Seed, 1), up: true, inRate: 3_800_000, outRate: 1_100_000, errorRate: 0.0002},
-		{index: 3, descr: "eth1", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
-			mac: deviceMAC(id.Seed, 2)},
+	lan := lanPrefix(id.Seed)
+	peer := func(n int, port uint16) netip.AddrPort { return netip.AddrPortFrom(hostIn(lan, n), port) }
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
+				up: true, inRate: 5_000, outRate: 5_000},
+			{index: 2, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+				mac: deviceMAC(id.Seed, 1), up: true, inRate: 3_800_000, outRate: 1_100_000, errorRate: 0.0002},
+			{index: 3, descr: "eth1", ifType: ifTypeEthernet, mtu: 1500, speed: 1_000_000_000,
+				mac: deviceMAC(id.Seed, 2)},
+		},
+		addrs:   []ifAddr{{ifIndex: 2, prefix: addrIn(lan, 5), neighbours: 8}},
+		gateway: hostIn(lan, 1),
+		pps:     3100,
+		listen:  []uint16{22, 80, 111, 139, 443, 445, 548, 2049, 5000, 5001, 5432},
+		udp:     []uint16{111, 123, 137, 138, 161, 1900, 2049, 5353},
+		sessions: []session{
+			{445, peer(64, 50412)}, // two file shares and a Mac on AFP
+			{445, peer(71, 61023)},
+			{548, peer(83, 49231)},
+			{5001, peer(50, 52102)}, // DSM, open in someone's browser
+		},
+		modules: []sysOR{moduleHostResources},
 	})
+
+	const mem, swap = 4194304, 4194304
 	addHostResources(&o, id.Seed, hostResources{
-		memoryKiB: 4194304, // 4 GiB
+		memoryKiB: mem,
 		users:     [2]float64{0, 1},
-		processes: [2]float64{260, 320},
 		storage: []storageArea{
-			{1, hrStorageRam, "Physical memory", 1024, 4194304, 0.4, 0.6, 4 * time.Minute},
-			{3, hrStorageVirtualMemory, "Virtual memory", 1024, 6291456, 0.3, 0.45, 5 * time.Minute},
+			{1, hrStorageRam, "Physical memory", 1024, mem, 0.4, 0.6, 4 * time.Minute},
+			{3, hrStorageVirtualMemory, "Virtual memory", 1024, mem + swap, 0.3, 0.45, 5 * time.Minute},
+			{6, hrStorageOther, "Memory buffers", 1024, mem, 0.03, 0.04, 30 * time.Minute},
+			{7, hrStorageOther, "Cached memory", 1024, mem, 0.3, 0.38, 25 * time.Minute},
+			{10, hrStorageVirtualMemory, "Swap space", 1024, swap, 0.01, 0.03, time.Hour},
 			{31, hrStorageFixedDisk, "/", 4096, 614400, 0.55, 0.56, 6 * time.Hour},
 			{51, hrStorageFixedDisk, "/volume1", 65536, 332640000, 0.37, 0.38, 12 * time.Hour},
 		},
 		processors: []int{196608, 196609, 196610, 196611},
 		cpuLo:      2,
 		cpuHi:      30,
+		cpu:        "GenuineIntel: Intel(R) Celeron(R) J4125 CPU @ 2.00GHz",
+		boot:       393216,
+		bootParams: "root=/dev/md0 netif_num=2 syno_hw_version=DS920+ console=ttyS0,115200n8",
+		devices: []hrDevice{
+			{index: 262145, kind: hrDeviceNetwork, descr: "network interface lo", ifIndex: 1},
+			{index: 262146, kind: hrDeviceNetwork, descr: "network interface eth0", ifIndex: 2},
+			{index: 262147, kind: hrDeviceNetwork, descr: "network interface eth1", ifIndex: 3},
+			{index: 393216, kind: hrDeviceDiskStorage, descr: "SCSI disk (/dev/sata1)", diskKB: 7814026584},
+			{index: 393232, kind: hrDeviceDiskStorage, descr: "SCSI disk (/dev/sata2)", diskKB: 7814026584},
+			{index: 393248, kind: hrDeviceDiskStorage, descr: "SCSI disk (/dev/sata3)", diskKB: 7814026584},
+			{index: 393264, kind: hrDeviceDiskStorage, descr: "SCSI disk (/dev/sata4)", diskKB: 7814026584},
+		},
+		fs: []hrFS{
+			{"/", hrFSLinuxExt2, 31, true},
+			{"/volume1", hrFSOther, 51, false},
+		},
+		procs:    synologyProcesses(),
+		software: synologyPackages(),
+	})
+	addUCD(&o, id.Seed, ucdInfo{
+		memKB: mem, swapKB: swap, memUsed: [2]float64{0.25, 0.4}, cpus: 4,
+		load: [2]float64{0.3, 1.8}, user: [2]float64{2, 22}, system: [2]float64{1, 8},
+		disks: []ucdDisk{
+			{"/", "/dev/md0", 2455568, [2]float64{0.55, 0.56}},
+			{"/volume1", "/dev/mapper/cachedev_0", 21288960000, [2]float64{0.37, 0.38}},
+		},
 	})
 
 	// SYNOLOGY-SYSTEM-MIB, -DISK-MIB and -RAID-MIB. "Normal" is 1 throughout.
@@ -57,6 +105,7 @@ func buildSynologyNAS(id Identity) []Object {
 	o.add(syno+"1.5.2.0", gosnmp.OctetString, Const(fmt.Sprintf("20B0PDN%06d", int(unit(id.Seed+31)*1e6))))
 	o.add(syno+"1.5.3.0", gosnmp.OctetString, Const("DSM 7.2.1-69057 Update 5"))
 	o.add(syno+"1.5.4.0", gosnmp.Integer, Const(2)) // upgradeAvailable: unavailable
+	o.add(syno+"1.6.0", gosnmp.Integer, Const(0))   // controllerNumber
 
 	// Four disks, numbered from 0 as DSM numbers them.
 	for disk := 0; disk < 4; disk++ {
@@ -86,4 +135,67 @@ func buildSynologyNAS(id Identity) []Object {
 	o.add(raid(5), gosnmp.Counter64, Const(uint64(21_800_000_000_000)))
 	o.add(raid(6), gosnmp.Integer, Const(0)) // hot spares
 	return o
+}
+
+// synologyProcesses is what DSM runs on a file server: the kernel's threads,
+// then DSM's own services and the file-sharing ones.
+func synologyProcesses() []process {
+	procs := []process{{pid: 1, name: "systemd", path: "/sbin/init", kind: 4, cpu: 0.001, memKB: 7100}}
+	for i, name := range []string{"kthreadd", "ksoftirqd/0", "kworker/0:0H", "rcu_sched", "rcu_bh",
+		"migration/0", "migration/1", "ksoftirqd/1", "migration/2", "ksoftirqd/2", "migration/3", "ksoftirqd/3",
+		"khelper", "kdevtmpfs", "netns", "kblockd", "ata_sff", "md", "kswapd0", "fsnotify_mark",
+		"crypto", "scsi_eh_0", "scsi_eh_1", "scsi_eh_2", "scsi_eh_3", "md0_raid1", "md1_raid1",
+		"md2_raid5", "jbd2/md0-8", "btrfs-worker", "btrfs-cleaner", "btrfs-transaction", "nfsd", "nfsd", "lockd"} {
+		procs = append(procs, process{pid: 2 + i, name: name, kind: 2})
+	}
+	pid := 3120
+	for _, s := range []struct {
+		name, path, args string
+		cpu              float64
+		memKB            int
+	}{
+		{"systemd-journald", "/lib/systemd/systemd-journald", "", 0.001, 14200},
+		{"systemd-udevd", "/lib/systemd/systemd-udevd", "", 0, 4600},
+		{"syslog-ng", "/usr/bin/syslog-ng", "-F -p /var/run/syslog-ng.pid", 0.001, 8200},
+		{"synoscgi", "synoscgi", "", 0.004, 38000},
+		{"synologand", "/usr/syno/sbin/synologand", "", 0.001, 11100},
+		{"synostoraged", "/usr/syno/sbin/synostoraged", "", 0.002, 16300},
+		{"synoindexd", "/usr/syno/bin/synoindexd", "", 0.001, 21700},
+		{"synoelasticd", "/usr/syno/sbin/synoelasticd", "", 0.001, 13200},
+		{"pkgctl-SynologyPhotos", "/var/packages/SynologyPhotos/target/usr/bin/synofoto-bin-backend", "", 0.003, 88000},
+		{"pkgctl-HyperBackup", "/var/packages/HyperBackup/target/bin/img_backup", "-S", 0.002, 61000},
+		{"nginx", "nginx: master process /usr/bin/nginx", "", 0, 14600},
+		{"nginx", "nginx: worker process", "", 0.01, 22100},
+		{"smbd", "/usr/local/sbin/smbd", "-F --no-process-group", 0.008, 29400},
+		{"smbd", "/usr/local/sbin/smbd", "-F --no-process-group", 0.03, 34100},
+		{"nmbd", "/usr/local/sbin/nmbd", "-F", 0.001, 8700},
+		{"afpd", "/usr/sbin/afpd", "-d -F /etc/afp.conf", 0.004, 13800},
+		{"rpcbind", "/sbin/rpcbind", "-w", 0, 2100},
+		{"rpc.mountd", "/usr/sbin/rpc.mountd", "-p 892", 0, 2600},
+		{"snmpd", "/usr/bin/snmpd", "-f -c /etc/snmp/snmpd.conf -p /run/snmpd.pid", 0.004, 10400},
+		{"postgres", "/usr/bin/postgres", "-D /var/services/pgsql", 0.002, 33000},
+		{"postgres", "postgres: synofoto synofoto [local] idle", "", 0.01, 61000},
+		{"sshd", "/usr/bin/sshd", "", 0, 5200},
+		{"crond", "/usr/sbin/crond", "-f", 0, 2300},
+		{"ntpd", "/usr/sbin/ntpd", "-p /var/run/ntpd.pid -g", 0, 4100},
+		{"avahi-daemon", "avahi-daemon: running [" + "diskstation.local]", "", 0, 3900},
+	} {
+		procs = append(procs, process{pid: pid, name: s.name, path: s.path, args: s.args, kind: 4, cpu: s.cpu, memKB: s.memKB})
+		pid += 13 + pid%17
+	}
+	return procs
+}
+
+// synologyPackages are the DSM packages installed.
+func synologyPackages() []software {
+	base := time.Date(2024, 2, 19, 21, 40, 0, 0, time.UTC)
+	var out []software
+	for i, name := range []string{
+		"SynologyPhotos-1.6.2-0720", "HyperBackup-4.1.0-3718", "ActiveBackup-Business-2.7.0-13234",
+		"SynologyDrive-3.5.0-26085", "StorageAnalyzer-3.1.0-0205", "SMBService-4.15.13-2322",
+		"SecureSignIn-1.1.3-0415", "UniversalSearch-1.7.3-0344", "Node.js_v18-18.20.4-1057", "PHP8.2-8.2.21-0105",
+	} {
+		out = append(out, software{name: name, installed: base.Add(time.Duration(i) * 53 * time.Hour)})
+	}
+	return out
 }

--- a/pkg/simulator/tree.go
+++ b/pkg/simulator/tree.go
@@ -43,6 +43,9 @@ type Reading interface {
 type clock struct {
 	started time.Time // when the agent started answering
 	now     time.Time
+	// stats are the agent's own counters, which SNMPv2-MIB's snmp group and
+	// the USM statistics read (agentObjects); nil where no agent is answering.
+	stats *counters
 }
 
 // uptime is the time since the agent started, in hundredths of a second.

--- a/pkg/simulator/ucd.go
+++ b/pkg/simulator/ucd.go
@@ -1,0 +1,163 @@
+package simulator
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// UCD-SNMP-MIB is net-snmp's own: memory, disks, load averages and processor
+// time as Linux counts them, which is what most tools read from a Linux host
+// before HOST-RESOURCES-MIB. Every figure it gives twice agrees: the memory
+// available is the total less what is in use, a disk's percentage is its used
+// space over its size, and the idle processor time is what the rest leaves.
+type ucdInfo struct {
+	memKB, swapKB int
+	// memUsed is the share of memory in use, which swings between the two.
+	memUsed [2]float64
+	cpus    int
+	// load is the one-minute load average's range; the five- and fifteen-
+	// minute ones move within it, more slowly.
+	load [2]float64
+	// user and system are the processor time in percent.
+	user, system [2]float64
+	disks        []ucdDisk
+}
+
+type ucdDisk struct {
+	path, device string
+	totalKB      float64
+	used         [2]float64 // share of the disk in use
+}
+
+func addUCD(o *objects, seed uint64, u ucdInfo) {
+	const ucd = "1.3.6.1.4.1.2021."
+	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: seed + 90000 + n} }
+	widen := func(r Reading) Reading {
+		return derived{typ: gosnmp.Counter64, f: func(c clock) any { return uint64(number(r, c)) }}
+	}
+
+	// memory, in kilobytes
+	total, swap := float64(u.memKB), float64(u.swapKB)
+	used := IntegerGauge(u.memUsed[0]*total, u.memUsed[1]*total, swing(0, 4*time.Minute))
+	swapUsed := IntegerGauge(0, swap*0.02, swing(1, time.Hour))
+	availReal := remainder(gosnmp.Integer, total, used)
+	availSwap := remainder(gosnmp.Integer, swap, swapUsed)
+	free := remainder(gosnmp.Integer, total+swap, used, swapUsed)
+	mem := func(n int) string { return fmt.Sprintf(ucd+"4.%d.0", n) }
+	o.add(mem(1), gosnmp.Integer, Const(0))
+	o.add(mem(2), gosnmp.OctetString, Const("swap"))
+	o.add(mem(3), gosnmp.Integer, Const(u.swapKB))
+	o.add(mem(4), gosnmp.Integer, availSwap)
+	o.add(mem(5), gosnmp.Integer, Const(u.memKB))
+	o.add(mem(6), gosnmp.Integer, availReal)
+	o.add(mem(11), gosnmp.Integer, free)
+	o.add(mem(12), gosnmp.Integer, Const(16000))
+	o.add(mem(13), gosnmp.Integer, IntegerGauge(total*0.01, total*0.015, swing(2, 30*time.Minute)))
+	o.add(mem(14), gosnmp.Integer, IntegerGauge(total*0.02, total*0.03, swing(3, 30*time.Minute)))
+	o.add(mem(15), gosnmp.Integer, IntegerGauge(total*0.18, total*0.24, swing(4, 25*time.Minute)))
+	o.add(mem(18), gosnmp.Counter64, Const(uint64(u.swapKB)))
+	o.add(mem(19), gosnmp.Counter64, widen(availSwap))
+	o.add(mem(20), gosnmp.Counter64, Const(uint64(u.memKB)))
+	o.add(mem(21), gosnmp.Counter64, widen(availReal))
+	o.add(mem(22), gosnmp.Counter64, widen(free))
+	o.add(mem(100), gosnmp.Integer, Const(0)) // no error
+	o.add(mem(101), gosnmp.OctetString, Const(""))
+
+	// dskTable: each file system, its size in kilobytes also as two 32-bit
+	// halves, since an Integer32 stops at 2 TB.
+	for i, d := range u.disks {
+		n := i + 1
+		col := func(c int) string { return fmt.Sprintf(ucd+"9.1.%d.%d", c, n) }
+		usedKB := Gauge64(d.used[0]*d.totalKB, d.used[1]*d.totalKB, swing(10+uint64(n), 12*time.Hour))
+		availKB := remainder(gosnmp.Counter64, d.totalKB, usedKB)
+		totalKB := Const(uint64(d.totalKB))
+		capped := func(r Reading) Reading {
+			return derived{typ: gosnmp.Integer, f: func(c clock) any { return as(gosnmp.Integer, number(r, c)) }}
+		}
+		o.add(col(1), gosnmp.Integer, Const(n))
+		o.add(col(2), gosnmp.OctetString, Const(d.path))
+		o.add(col(3), gosnmp.OctetString, Const(d.device))
+		o.add(col(4), gosnmp.Integer, Const(-1)) // a minimum in percent, not in kilobytes
+		o.add(col(5), gosnmp.Integer, Const(10))
+		o.add(col(6), gosnmp.Integer, capped(totalKB))
+		o.add(col(7), gosnmp.Integer, capped(availKB))
+		o.add(col(8), gosnmp.Integer, capped(usedKB))
+		o.add(col(9), gosnmp.Integer, percentOf(gosnmp.Integer, usedKB, d.totalKB))
+		o.add(col(10), gosnmp.Integer, IntegerGauge(2, 6, swing(20+uint64(n), 6*time.Hour)))
+		o.add(col(11), gosnmp.Gauge32, word(totalKB, false))
+		o.add(col(12), gosnmp.Gauge32, word(totalKB, true))
+		o.add(col(13), gosnmp.Gauge32, word(availKB, false))
+		o.add(col(14), gosnmp.Gauge32, word(availKB, true))
+		o.add(col(15), gosnmp.Gauge32, word(usedKB, false))
+		o.add(col(16), gosnmp.Gauge32, word(usedKB, true))
+		o.add(col(100), gosnmp.Integer, Const(0))
+		o.add(col(101), gosnmp.OctetString, Const(""))
+	}
+
+	// laTable: the load averages, written out and in hundredths, from one swing
+	// each so that the two agree.
+	for i, l := range []struct {
+		name, config string
+		narrow       float64
+		period       time.Duration
+	}{
+		{"Load-1", "12.00", 1, 3 * time.Minute},
+		{"Load-5", "14.00", 0.7, 12 * time.Minute},
+		{"Load-15", "14.00", 0.5, 35 * time.Minute},
+	} {
+		n := i + 1
+		mid := (u.load[0] + u.load[1]) / 2
+		half := (u.load[1] - u.load[0]) / 2 * l.narrow
+		lo, hi := (mid-half)*100, (mid+half)*100
+		s := swing(30+uint64(n), l.period)
+		col := func(c int) string { return fmt.Sprintf(ucd+"10.1.%d.%d", c, n) }
+		o.add(col(1), gosnmp.Integer, Const(n))
+		o.add(col(2), gosnmp.OctetString, Const(l.name))
+		o.add(col(3), gosnmp.OctetString, LoadText(lo, hi, s))
+		o.add(col(4), gosnmp.OctetString, Const(l.config))
+		o.add(col(5), gosnmp.Integer, IntegerGauge(lo, hi, s))
+		o.add(col(100), gosnmp.Integer, Const(0))
+		o.add(col(101), gosnmp.OctetString, Const(""))
+	}
+
+	// systemStats: the processor in percent, and its raw time in ticks of a
+	// hundredth of a second per processor.
+	user := IntegerGauge(u.user[0], u.user[1], swing(40, 90*time.Second))
+	system := IntegerGauge(u.system[0], u.system[1], swing(41, 2*time.Minute))
+	ss := func(n int) string { return fmt.Sprintf(ucd+"11.%d.0", n) }
+	o.add(ss(1), gosnmp.Integer, Const(1))
+	o.add(ss(2), gosnmp.OctetString, Const("systemStats"))
+	o.add(ss(3), gosnmp.Integer, Const(0))
+	o.add(ss(4), gosnmp.Integer, Const(0))
+	o.add(ss(5), gosnmp.Integer, IntegerGauge(20, 400, swing(42, 4*time.Minute)))
+	o.add(ss(6), gosnmp.Integer, IntegerGauge(5, 90, swing(43, 5*time.Minute)))
+	o.add(ss(7), gosnmp.Integer, IntegerGauge(400, 1400, swing(44, 3*time.Minute)))
+	o.add(ss(8), gosnmp.Integer, IntegerGauge(900, 4000, swing(45, 3*time.Minute)))
+	o.add(ss(9), gosnmp.Integer, user)
+	o.add(ss(10), gosnmp.Integer, system)
+	o.add(ss(11), gosnmp.Integer, remainder(gosnmp.Integer, 100, user, system))
+	ticks := float64(100 * u.cpus)
+	avgUser := (u.user[0] + u.user[1]) / 200
+	avgSystem := (u.system[0] + u.system[1]) / 200
+	raw := func(n uint64, share float64) Reading {
+		return Counter(ticks*share, uint64(1e6+4e7*unit(seed+91000+n)), Swing{Depth: 0.5, Period: 5 * time.Minute, Seed: seed + 91000 + n})
+	}
+	o.add(ss(50), gosnmp.Counter32, raw(50, avgUser))
+	o.add(ss(51), gosnmp.Counter32, raw(51, avgUser*0.02))
+	o.add(ss(52), gosnmp.Counter32, raw(52, avgSystem))
+	o.add(ss(53), gosnmp.Counter32, raw(53, 1-avgUser-avgSystem))
+	o.add(ss(54), gosnmp.Counter32, raw(54, 0.004))
+	o.add(ss(55), gosnmp.Counter32, raw(52, avgSystem*0.9))
+	o.add(ss(56), gosnmp.Counter32, raw(56, 0.001))
+	o.add(ss(57), gosnmp.Counter32, raw(57, 1.6))
+	o.add(ss(58), gosnmp.Counter32, raw(58, 0.4))
+	o.add(ss(59), gosnmp.Counter32, raw(59, 9))
+	o.add(ss(60), gosnmp.Counter32, raw(60, 24))
+	o.add(ss(61), gosnmp.Counter32, raw(61, 0.003))
+	for n := 62; n <= 66; n++ {
+		o.add(ss(n), gosnmp.Counter32, Const(uint32(0)))
+	}
+	o.add(ss(67), gosnmp.Integer, Const(u.cpus))
+}

--- a/pkg/simulator/unifi.go
+++ b/pkg/simulator/unifi.go
@@ -2,6 +2,7 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -10,8 +11,10 @@ import (
 // unifiU6Pro is a UniFi U6 Pro access point: its uplink, two radios and three
 // SSIDs — the office network on both bands and a guest one on 5 GHz.
 // UBNT-UniFi-MIB gives what a wireless dashboard polls: each radio's channel use
-// and each SSID's clients and traffic. A U6 runs Linux and answers with
-// net-snmp's sysObjectID, a sysDescr naming the model, and host resources.
+// and traffic, each SSID's clients, traffic, errors and retries, the interfaces
+// as the controller sees them. A U6 runs Linux and answers with net-snmp's
+// sysObjectID, a sysDescr naming the model, host resources and UCD-SNMP-MIB, and
+// LLDP says which switch port it hangs from.
 var unifiU6Pro = model{
 	ModelInfo:     ModelInfo{ID: "unifi-u6-pro", Category: "wireless"},
 	enterprise:    41112, // Ubiquiti
@@ -22,20 +25,23 @@ var unifiU6Pro = model{
 // The access point's SSIDs, each on an interface of its own, as a UniFi names
 // them.
 var unifiVAPs = []struct {
-	essid, iface, radio string
-	channel, txPower    int
-	stations            [2]float64
-	rx, tx              float64 // octets per second
+	essid, iface, radio, usage string
+	channel, txPower           int
+	stations                   [2]float64
+	rx, tx                     float64 // octets per second
 }{
-	{"Office", "ath0", "ng", 6, 20, [2]float64{3, 9}, 90_000, 260_000},
-	{"Office", "ath1", "na", 44, 23, [2]float64{8, 22}, 700_000, 2_600_000},
-	{"Guest", "ath2", "na", 44, 23, [2]float64{0, 6}, 60_000, 380_000},
+	{"Office", "ath0", "ng", "user", 6, 20, [2]float64{3, 9}, 90_000, 260_000},
+	{"Office", "ath1", "na", "user", 44, 23, [2]float64{8, 22}, 700_000, 2_600_000},
+	{"Guest", "ath2", "na", "guest", 44, 23, [2]float64{0, 6}, 60_000, 380_000},
 }
 
 func buildUniFiU6Pro(id Identity) []Object {
 	var o objects
 	const version = "6.6.77.15402"
-	addSystem(&o, id, "U6-Pro "+version, ".1.3.6.1.4.1.8072.3.2.10", "noc@example.com", "Open space, ceiling", 66)
+	descr := "U6-Pro " + version
+	addSystem(&o, id, descr, ".1.3.6.1.4.1.8072.3.2.10", "noc@example.com", "Open space, ceiling", 66)
+	lan := lanPrefix(id.Seed)
+	own := addrIn(lan, 60+int(id.Seed%20))
 	ifs := []iface{
 		{index: 1, descr: "lo", ifType: ifTypeSoftwareLoopback, mtu: 65536, speed: 10_000_000,
 			up: true, inRate: 3_000, outRate: 3_000},
@@ -52,62 +58,178 @@ func buildUniFiU6Pro(id Identity) []Object {
 	}
 	ifs = append(ifs, iface{index: 8, descr: "br0", ifType: ifTypeBridge, mtu: 1500,
 		mac: deviceMAC(id.Seed, 0), up: true, inRate: 2_800_000, outRate: 850_000})
-	addInterfaces(&o, id.Seed, ifs)
+	addStack(&o, stack{
+		seed:    id.Seed,
+		ifs:     ifs,
+		addrs:   []ifAddr{{ifIndex: 8, prefix: own, neighbours: 4}},
+		gateway: hostIn(lan, 1),
+		pps:     900,
+		listen:  []uint16{22},
+		udp:     []uint16{161, 10001},
+		// The access point keeps its controller informed.
+		sessions: []session{{45872, netip.AddrPortFrom(hostIn(lan, 20), 8080)}},
+		lldp: &lldpInfo{name: id.Name, descr: descr, caps: capWLAN | capBridge, neighbours: []neighbour{
+			{ifIndex: 2, name: "sw-floor-2", descr: catalystDescr, port: "Gi0/3", portDescr: "GigabitEthernet0/3",
+				chassis: peerMAC(id.Seed, 900), caps: capBridge},
+		}},
+		modules: []sysOR{moduleHostResources},
+	})
 
 	const unifi = "1.3.6.1.4.1.41112.1.6."
 	swing := func(n uint64, depth float64, period time.Duration) Swing {
 		return Swing{Depth: depth, Period: period, Seed: id.Seed + 45000 + n}
 	}
-	// unifiRadioTable: how much of each radio's airtime is in use, and how much
-	// of that is this access point's own.
+	start := func(n uint64) uint64 { return uint64(1e5 + 1e7*unit(id.Seed+45500+n)) }
+	// unifiRadioTable: how much of each radio's airtime is in use, how much of
+	// that is this access point's own, and the other networks it hears.
 	for i, r := range []struct {
 		name, radio string
 		lo, hi      float64
-	}{{"wifi0", "ng", 28, 61}, {"wifi1", "na", 9, 34}} {
+		pps         float64
+		others      int
+	}{{"wifi0", "ng", 28, 61, 420, 14}, {"wifi1", "na", 9, 34, 3100, 5}} {
 		row := i + 1
 		col := func(c int) string { return fmt.Sprintf(unifi+"1.1.1.%d.%d", c, row) }
-		n := uint64(i) * 4
+		n := uint64(i) * 8
 		o.add(col(1), gosnmp.Integer, Const(row))
 		o.add(col(2), gosnmp.OctetString, Const(r.name))
 		o.add(col(3), gosnmp.OctetString, Const(r.radio))
+		o.add(col(4), gosnmp.Counter32, Counter(r.pps*0.4, start(n), swing(n+3, 0.6, 5*time.Minute)))
+		o.add(col(5), gosnmp.Counter32, Counter(r.pps*0.6, start(n+1), swing(n+4, 0.6, 5*time.Minute)))
 		o.add(col(6), gosnmp.Integer, IntegerGauge(r.lo, r.hi, swing(n, 0, 4*time.Minute)))
 		o.add(col(7), gosnmp.Integer, IntegerGauge(r.lo*0.3, r.hi*0.3, swing(n+1, 0, 4*time.Minute)))
 		o.add(col(8), gosnmp.Integer, IntegerGauge(r.lo*0.2, r.hi*0.25, swing(n+2, 0, 4*time.Minute)))
+		o.add(col(9), gosnmp.Integer, Const(r.others))
 	}
 	// unifiVapTable: one row per SSID and band.
 	for i, v := range unifiVAPs {
 		row := i + 1
 		col := func(c int) string { return fmt.Sprintf(unifi+"1.2.1.%d.%d", c, row) }
-		n := 20 + uint64(i)*4
+		n := 20 + uint64(i)*8
+		rx := func(k uint64, share float64) Reading {
+			return Counter(v.rx*share, start(n+k), swing(n+1, 0.6, 5*time.Minute))
+		}
+		tx := func(k uint64, share float64) Reading {
+			return Counter(v.tx*share, start(n+k), swing(n+2, 0.6, 7*time.Minute))
+		}
 		o.add(col(1), gosnmp.Integer, Const(row))
+		o.add(col(2), gosnmp.OctetString, Const([]byte(deviceMAC(id.Seed, uint64(4+i))))) // the BSSID
+		o.add(col(3), gosnmp.Integer, IntegerGauge(78, 97, swing(n+3, 0, 9*time.Minute))) // CCQ, %
 		o.add(col(4), gosnmp.Integer, Const(v.channel))
+		o.add(col(5), gosnmp.Integer, Const(0))
 		o.add(col(6), gosnmp.OctetString, Const(v.essid))
 		o.add(col(7), gosnmp.OctetString, Const(v.iface))
 		o.add(col(8), gosnmp.Integer, IntegerGauge(v.stations[0], v.stations[1], swing(n, 0, 30*time.Minute)))
 		o.add(col(9), gosnmp.OctetString, Const(v.radio))
-		o.add(col(10), gosnmp.Counter32, Counter(v.rx, 0, swing(n+1, 0.6, 5*time.Minute)))
-		o.add(col(16), gosnmp.Counter32, Counter(v.tx, 0, swing(n+2, 0.6, 7*time.Minute)))
-		o.add(col(21), gosnmp.Integer, Const(v.txPower)) // dBm
-		o.add(col(22), gosnmp.Integer, Const(1))         // up: true
+		o.add(col(10), gosnmp.Counter32, rx(0, 1))
+		o.add(col(11), gosnmp.Counter32, rx(1, 0.0001))
+		o.add(col(12), gosnmp.Counter32, rx(2, 0.00002))
+		o.add(col(13), gosnmp.Counter32, rx(3, 0.00001))
+		o.add(col(14), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(15), gosnmp.Counter32, rx(4, 1.0/800))
+		o.add(col(16), gosnmp.Counter32, tx(5, 1))
+		o.add(col(17), gosnmp.Counter32, tx(6, 0.00003))
+		o.add(col(18), gosnmp.Counter32, tx(7, 0.00001))
+		o.add(col(19), gosnmp.Counter32, tx(5, 1.0/900))
+		o.add(col(20), gosnmp.Counter32, tx(5, 1.0/9000)) // retries, a tenth of a percent of packets
+		o.add(col(21), gosnmp.Integer, Const(v.txPower))  // dBm
+		o.add(col(22), gosnmp.Integer, Const(1))          // up: true
+		o.add(col(23), gosnmp.OctetString, Const(v.usage))
+	}
+	// unifiIfTable: the wired interfaces, as the controller counts them.
+	for i, f := range []iface{ifs[1], ifs[len(ifs)-1]} {
+		row := i + 1
+		col := func(c int) string { return fmt.Sprintf(unifi+"2.1.1.%d.%d", c, row) }
+		n := 60 + uint64(i)*8
+		ip := "0.0.0.0"
+		if f.ifType == ifTypeBridge {
+			ip = own.Addr().String()
+		}
+		o.add(col(1), gosnmp.Integer, Const(row))
+		o.add(col(2), gosnmp.Integer, Const(1)) // full duplex
+		o.add(col(3), gosnmp.IPAddress, Const(ip))
+		o.add(col(4), gosnmp.OctetString, Const([]byte(f.mac)))
+		o.add(col(5), gosnmp.OctetString, Const(f.descr))
+		o.add(col(6), gosnmp.Counter32, Counter(f.inRate, start(n), swing(n+1, 0.6, 5*time.Minute)))
+		o.add(col(7), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(8), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(9), gosnmp.Counter32, Counter(f.inRate/900*0.02, start(n+2), swing(n+1, 0.6, 5*time.Minute)))
+		o.add(col(10), gosnmp.Counter32, Counter(f.inRate/900, start(n+3), swing(n+1, 0.6, 5*time.Minute)))
+		o.add(col(11), gosnmp.Integer, Const(int(f.speed/1_000_000)))
+		o.add(col(12), gosnmp.Counter32, Counter(f.outRate, start(n+4), swing(n+2, 0.5, 7*time.Minute)))
+		o.add(col(13), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(14), gosnmp.Counter32, Const(uint32(0)))
+		o.add(col(15), gosnmp.Counter32, Counter(f.outRate/700, start(n+5), swing(n+2, 0.5, 7*time.Minute)))
+		o.add(col(16), gosnmp.Integer, Const(1)) // up: true
 	}
 	// unifiApSystem
-	o.add(unifi+"3.1.0", gosnmp.IPAddress, Const("10.20.0.25"))
+	o.add(unifi+"3.1.0", gosnmp.IPAddress, Const(own.Addr().String()))
 	o.add(unifi+"3.2.0", gosnmp.Integer, Const(2)) // isolated: false
 	o.add(unifi+"3.3.0", gosnmp.OctetString, Const("U6-Pro"))
+	o.add(unifi+"3.4.0", gosnmp.OctetString, Const("eth0"))
 	o.add(unifi+"3.5.0", gosnmp.Counter32, Counter(1, 0, Swing{})) // seconds up
 	o.add(unifi+"3.6.0", gosnmp.OctetString, Const(version))
 
+	const mem = 1_015_808
 	addHostResources(&o, id.Seed, hostResources{
-		memoryKiB: 1_015_808,
+		memoryKiB: mem,
 		users:     [2]float64{0, 1},
-		processes: [2]float64{92, 118},
 		storage: []storageArea{
-			{1, hrStorageRam, "Physical memory", 1024, 1_015_808, 0.41, 0.52, 25 * time.Minute},
+			{1, hrStorageRam, "Physical memory", 1024, mem, 0.41, 0.52, 25 * time.Minute},
+			{6, hrStorageOther, "Memory buffers", 1024, mem, 0.01, 0.02, 30 * time.Minute},
+			{7, hrStorageOther, "Cached memory", 1024, mem, 0.12, 0.16, 25 * time.Minute},
 			{31, hrStorageFixedDisk, "/", 4096, 7_680, 0.61, 0.62, 12 * time.Hour},
 		},
 		processors: []int{196608, 196609, 196610, 196611},
 		cpuLo:      2,
 		cpuHi:      31,
+		cpu:        "Qualcomm IPQ8074 (ARMv8)",
+		devices: []hrDevice{
+			{index: 262145, kind: hrDeviceNetwork, descr: "network interface lo", ifIndex: 1},
+			{index: 262146, kind: hrDeviceNetwork, descr: "network interface eth0", ifIndex: 2},
+			{index: 262153, kind: hrDeviceNetwork, descr: "network interface br0", ifIndex: 8},
+		},
+		fs:    []hrFS{{"/", hrFSOther, 31, true}},
+		procs: unifiProcesses(),
+	})
+	addUCD(&o, id.Seed, ucdInfo{
+		memKB: mem, memUsed: [2]float64{0.35, 0.45}, cpus: 4,
+		load: [2]float64{0.2, 0.9}, user: [2]float64{2, 20}, system: [2]float64{1, 9},
+		disks: []ucdDisk{{"/", "overlay", 30720, [2]float64{0.61, 0.62}}},
 	})
 	return o
+}
+
+// unifiProcesses is what a UniFi access point runs: busybox and Ubiquiti's
+// daemons.
+func unifiProcesses() []process {
+	procs := []process{{pid: 1, name: "init", path: "/sbin/init", kind: 4, memKB: 1400}}
+	for i, name := range []string{"kthreadd", "ksoftirqd/0", "kworker/0:0H", "migration/0", "migration/1",
+		"ksoftirqd/1", "migration/2", "ksoftirqd/2", "migration/3", "ksoftirqd/3", "kswapd0", "cfg80211"} {
+		procs = append(procs, process{pid: 2 + i, name: name, kind: 2})
+	}
+	pid := 812
+	for _, s := range []struct {
+		name, args string
+		cpu        float64
+		memKB      int
+	}{
+		{"ubnt-daemon", "", 0.001, 3200},
+		{"syswrapper.sh", "", 0, 1100},
+		{"mcad", "", 0.004, 8600},
+		{"stamgr", "", 0.003, 7200},
+		{"hostapd", "-B -P /run/hostapd.pid -g /run/hostapd/global", 0.012, 9800},
+		{"wevent", "", 0.001, 2300},
+		{"dropbear", "-F -r /etc/dropbear/dropbear_rsa_host_key -p 22", 0, 900},
+		{"snmpd", "-Lsd -Lf /dev/null -p /var/run/snmpd.pid -c /etc/snmp/snmpd.conf", 0.003, 3900},
+		{"lldpd", "-M 4", 0, 1600},
+		{"utermd", "", 0, 2100},
+		{"ubnt-protocol-support", "", 0.001, 2700},
+		{"logread", "-f", 0, 800},
+	} {
+		procs = append(procs, process{pid: pid, name: s.name, path: "/usr/bin/" + s.name, args: s.args, kind: 4,
+			cpu: s.cpu, memKB: s.memKB})
+		pid += 9 + pid%13
+	}
+	return procs
 }

--- a/pkg/simulator/ups.go
+++ b/pkg/simulator/ups.go
@@ -2,15 +2,19 @@ package simulator
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
 )
 
 // apcSmartUPS is a three-phase APC Smart-UPS on its network management card,
-// answering the standard UPS-MIB (RFC 1628): the MIB the "UPS (RFC 1628)" preset
-// polls, three output lines included — which is why it is the three-phase model
-// rather than a single-phase one. It runs on mains, charged.
+// answering the standard UPS-MIB (RFC 1628) — the MIB the "UPS (RFC 1628)"
+// preset polls, three output lines included, which is why it is the
+// three-phase model — and APC's PowerNet-MIB beside it, which most tools read
+// an APC by. The two say the same things, from the same readings, each in its
+// own units: minutes remaining and a TimeTicks run time, volts and tenths of a
+// volt. It runs on mains, charged.
 var apcSmartUPS = model{
 	ModelInfo:  ModelInfo{ID: "apc-smart-ups", Category: "power"},
 	enterprise: 318, // APC
@@ -23,6 +27,12 @@ var apcSmartUPS = model{
 	}},
 }
 
+// scaled is what r reads times factor, as a figure of type t: the same reading
+// in other units.
+func scaled(t gosnmp.Asn1BER, r Reading, factor float64) Reading {
+	return derived{typ: t, f: func(c clock) any { return as(t, math.Round(number(r, c)*factor)) }}
+}
+
 func buildAPCSmartUPS(id Identity) []Object {
 	var o objects
 	serial := fmt.Sprintf("5A%04dT%05d", 2100+int(unit(id.Seed+1)*4), int(unit(id.Seed+2)*100000))
@@ -31,13 +41,26 @@ func buildAPCSmartUPS(id Identity) []Object {
 		"(Embedded PowerNet SNMP Agent SW v2.2 compatible)",
 		".1.3.6.1.4.1.318.1.3.17.1", // smartUPS3Phase10kVA
 		"facilities@example.com", "Server room, UPS bay", 72)
-	addInterfaces(&o, id.Seed, []iface{
-		{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
-			mac: deviceMAC(id.Seed, 1), up: true, inRate: 400, outRate: 700},
+	lan := lanPrefix(id.Seed)
+	addStack(&o, stack{
+		seed: id.Seed,
+		ifs: []iface{
+			{index: 1, descr: "eth0", ifType: ifTypeEthernet, mtu: 1500, speed: 100_000_000,
+				mac: deviceMAC(id.Seed, 1), up: true, inRate: 400, outRate: 700},
+		},
+		addrs:   []ifAddr{{ifIndex: 1, prefix: addrIn(lan, 230+int(id.Seed%10))}},
+		gateway: hostIn(lan, 1),
+		pps:     8,
+		listen:  []uint16{21, 22, 80, 443},
+		udp:     []uint16{161},
 	})
 
 	const ups = "1.3.6.1.2.1.33.1."
 	swing := func(n uint64, period time.Duration) Swing { return Swing{Period: period, Seed: id.Seed + 20000 + n} }
+	minutes := IntegerGauge(38, 44, swing(0, 20*time.Minute))
+	charge := IntegerGauge(99, 100, swing(1, 40*time.Minute))
+	volts := IntegerGauge(2180, 2200, swing(2, 15*time.Minute)) // tenths of a volt
+	celsius := IntegerGauge(24, 27, swing(3, 3*time.Hour))
 	// upsIdent
 	o.add(ups+"1.1.0", gosnmp.OctetString, Const("APC"))
 	o.add(ups+"1.2.0", gosnmp.OctetString, Const("Smart-UPS VT 10kVA"))
@@ -46,26 +69,29 @@ func buildAPCSmartUPS(id Identity) []Object {
 	o.add(ups+"1.5.0", gosnmp.OctetString, Const(id.Name))
 	o.add(ups+"1.6.0", gosnmp.OctetString, Const("Racks A1 to A4"))
 	// upsBattery
-	o.add(ups+"2.1.0", gosnmp.Integer, Const(2))                                           // upsBatteryStatus: normal
-	o.add(ups+"2.2.0", gosnmp.Integer, Const(0))                                           // upsSecondsOnBattery
-	o.add(ups+"2.3.0", gosnmp.Integer, IntegerGauge(38, 44, swing(0, 20*time.Minute)))     // minutes remaining
-	o.add(ups+"2.4.0", gosnmp.Integer, IntegerGauge(99, 100, swing(1, 40*time.Minute)))    // % charge remaining
-	o.add(ups+"2.5.0", gosnmp.Integer, IntegerGauge(2180, 2200, swing(2, 15*time.Minute))) // 0.1 V DC
-	o.add(ups+"2.6.0", gosnmp.Integer, Const(0))                                           // 0.1 A: not discharging
-	o.add(ups+"2.7.0", gosnmp.Integer, IntegerGauge(24, 27, swing(3, 3*time.Hour)))        // °C
+	o.add(ups+"2.1.0", gosnmp.Integer, Const(2)) // upsBatteryStatus: normal
+	o.add(ups+"2.2.0", gosnmp.Integer, Const(0)) // upsSecondsOnBattery
+	o.add(ups+"2.3.0", gosnmp.Integer, minutes)
+	o.add(ups+"2.4.0", gosnmp.Integer, charge)
+	o.add(ups+"2.5.0", gosnmp.Integer, volts)
+	o.add(ups+"2.6.0", gosnmp.Integer, Const(0)) // 0.1 A: not discharging
+	o.add(ups+"2.7.0", gosnmp.Integer, celsius)
 	// upsInput, one line per phase
+	inVolts := make([]Reading, 3)
 	o.add(ups+"3.1.0", gosnmp.Counter32, Const(uint32(0))) // upsInputLineBads
 	o.add(ups+"3.2.0", gosnmp.Integer, Const(3))
 	for line := 1; line <= 3; line++ {
 		n := 10 + uint64(line)*8
 		col := func(c int) string { return fmt.Sprintf(ups+"3.3.1.%d.%d", c, line) }
+		inVolts[line-1] = IntegerGauge(228, 234, swing(n+1, 9*time.Minute))
 		o.add(col(1), gosnmp.Integer, Const(line))
 		o.add(col(2), gosnmp.Integer, IntegerGauge(499, 501, swing(n, 3*time.Minute)))     // 0.1 Hz
-		o.add(col(3), gosnmp.Integer, IntegerGauge(228, 234, swing(n+1, 9*time.Minute)))   // V RMS
+		o.add(col(3), gosnmp.Integer, inVolts[line-1])                                     // V RMS
 		o.add(col(4), gosnmp.Integer, IntegerGauge(95, 140, swing(n+2, 7*time.Minute)))    // 0.1 A RMS
 		o.add(col(5), gosnmp.Integer, IntegerGauge(2100, 3100, swing(n+3, 7*time.Minute))) // W
 	}
 	// upsOutput, one line per phase, each loaded differently
+	loads := make([]Reading, 3)
 	o.add(ups+"4.1.0", gosnmp.Integer, Const(3)) // upsOutputSource: normal, which is mains
 	o.add(ups+"4.2.0", gosnmp.Integer, Const(500))
 	o.add(ups+"4.3.0", gosnmp.Integer, Const(3))
@@ -73,11 +99,12 @@ func buildAPCSmartUPS(id Identity) []Object {
 		line := i + 1
 		n := 50 + uint64(line)*8
 		col := func(c int) string { return fmt.Sprintf(ups+"4.4.1.%d.%d", c, line) }
+		loads[i] = IntegerGauge(load[0], load[1], swing(n+2, 6*time.Minute))
 		o.add(col(1), gosnmp.Integer, Const(line))
 		o.add(col(2), gosnmp.Integer, Const(230))
 		o.add(col(3), gosnmp.Integer, IntegerGauge(80+load[0], 80+load[1], swing(n, 6*time.Minute)))   // 0.1 A RMS
 		o.add(col(4), gosnmp.Integer, IntegerGauge(load[0]*55, load[1]*55, swing(n+1, 6*time.Minute))) // W
-		o.add(col(5), gosnmp.Integer, IntegerGauge(load[0], load[1], swing(n+2, 6*time.Minute)))       // %
+		o.add(col(5), gosnmp.Integer, loads[i])                                                        // %
 	}
 	o.add(ups+"6.1.0", gosnmp.Gauge32, Const(uint32(0))) // upsAlarmsPresent
 	// upsConfig: 230 V and 50 Hz in and out, 10 kVA, 8 kW, two minutes' warning
@@ -85,5 +112,47 @@ func buildAPCSmartUPS(id Identity) []Object {
 	for i, v := range []int{230, 50, 230, 50, 10000, 8000, 2, 2, 160, 282} {
 		o.add(fmt.Sprintf(ups+"9.%d.0", i+1), gosnmp.Integer, Const(v))
 	}
+
+	// PowerNet-MIB's upsIdent, upsBattery, upsInput and upsOutput.
+	const pn = "1.3.6.1.4.1.318.1.1.1."
+	averageLoad := derived{typ: gosnmp.Gauge32, f: func(c clock) any {
+		return uint32(math.Round((number(loads[0], c) + number(loads[1], c) + number(loads[2], c)) / 3))
+	}}
+	o.add(pn+"1.1.1.0", gosnmp.OctetString, Const("Smart-UPS VT 10kVA"))
+	o.add(pn+"1.1.2.0", gosnmp.OctetString, Const(id.Name))
+	o.add(pn+"1.2.1.0", gosnmp.OctetString, Const("UPS 09.1 / ID=1015"))
+	o.add(pn+"1.2.2.0", gosnmp.OctetString, Const("03/14/2021"))
+	o.add(pn+"1.2.3.0", gosnmp.OctetString, Const(serial))
+	o.add(pn+"1.2.5.0", gosnmp.OctetString, Const("SUVTP10KH3B4S"))
+	o.add(pn+"1.2.6.0", gosnmp.OctetString, Const("05"))
+	o.add(pn+"2.1.1.0", gosnmp.Integer, Const(2))                // upsBasicBatteryStatus: normal
+	o.add(pn+"2.1.2.0", gosnmp.TimeTicks, Const(uint32(0)))      // upsBasicBatteryTimeOnBattery
+	o.add(pn+"2.1.3.0", gosnmp.OctetString, Const("09/02/2021")) // upsBasicBatteryLastReplaceDate
+	o.add(pn+"2.2.1.0", gosnmp.Gauge32, scaled(gosnmp.Gauge32, charge, 1))
+	o.add(pn+"2.2.2.0", gosnmp.Gauge32, scaled(gosnmp.Gauge32, celsius, 1))
+	o.add(pn+"2.2.3.0", gosnmp.TimeTicks, scaled(gosnmp.TimeTicks, minutes, 6000)) // run time, in hundredths
+	o.add(pn+"2.2.4.0", gosnmp.Integer, Const(1))                                  // no battery needs replacing
+	o.add(pn+"2.2.5.0", gosnmp.Integer, Const(2))
+	o.add(pn+"2.2.6.0", gosnmp.Integer, Const(0))
+	o.add(pn+"2.2.7.0", gosnmp.Integer, Const(216))
+	o.add(pn+"2.2.8.0", gosnmp.Integer, scaled(gosnmp.Integer, volts, 0.1))
+	o.add(pn+"2.3.1.0", gosnmp.Gauge32, scaled(gosnmp.Gauge32, charge, 10))
+	o.add(pn+"2.3.2.0", gosnmp.Gauge32, scaled(gosnmp.Gauge32, celsius, 10))
+	o.add(pn+"2.3.3.0", gosnmp.Integer, Const(2160))
+	o.add(pn+"2.3.4.0", gosnmp.Integer, volts)
+	o.add(pn+"3.1.1.0", gosnmp.Integer, Const(3))                                // upsBasicInputPhase
+	o.add(pn+"3.2.1.0", gosnmp.Gauge32, scaled(gosnmp.Gauge32, inVolts[0], 1))   // upsAdvInputLineVoltage
+	o.add(pn+"3.2.2.0", gosnmp.Gauge32, Const(uint32(236)))                      // highest in the last minute
+	o.add(pn+"3.2.3.0", gosnmp.Gauge32, Const(uint32(226)))                      // lowest
+	o.add(pn+"3.2.4.0", gosnmp.Gauge32, Const(uint32(50)))                       // Hz
+	o.add(pn+"3.2.5.0", gosnmp.Integer, Const(1))                                // no transfer
+	o.add(pn+"3.3.1.0", gosnmp.Gauge32, scaled(gosnmp.Gauge32, inVolts[0], 10))  // tenths of a volt
+	o.add(pn+"3.3.4.0", gosnmp.Gauge32, Const(uint32(500)))                      // tenths of a hertz
+	o.add(pn+"4.1.1.0", gosnmp.Integer, Const(2))                                // upsBasicOutputStatus: onLine
+	o.add(pn+"4.1.2.0", gosnmp.Integer, Const(3))                                // upsBasicOutputPhase
+	o.add(pn+"4.2.1.0", gosnmp.Gauge32, Const(uint32(230)))                      // upsAdvOutputVoltage
+	o.add(pn+"4.2.2.0", gosnmp.Gauge32, Const(uint32(50)))                       // upsAdvOutputFrequency
+	o.add(pn+"4.2.3.0", gosnmp.Gauge32, averageLoad)                             // upsAdvOutputLoad, %
+	o.add(pn+"4.2.4.0", gosnmp.Gauge32, Gauge(12, 16, swing(90, 6*time.Minute))) // upsAdvOutputCurrent, A
 	return o
 }

--- a/pkg/simulator/values.go
+++ b/pkg/simulator/values.go
@@ -79,6 +79,8 @@ type counter struct {
 	start     uint64
 	swing     Swing
 	wide      bool
+	// integer is an INTEGER that counts all the same: hrSWRunPerfCPU.
+	integer bool
 }
 
 // Counter answers a Counter32 that grows by perSecond on average from start.
@@ -95,6 +97,13 @@ func Counter64(perSecond float64, start uint64, s Swing) Reading {
 	return counter{perSecond: perSecond, start: start, swing: s, wide: true}
 }
 
+// IntegerCounter is Counter for an INTEGER that counts — hrSWRunPerfCPU, the
+// centi-seconds of processor a process has had — kept below 2^31 as an Integer32
+// must be.
+func IntegerCounter(perSecond float64, start uint64, s Swing) Reading {
+	return counter{perSecond: perSecond, start: start, swing: s, integer: true}
+}
+
 func (c counter) count(t float64) uint64 {
 	depth := math.Min(math.Max(c.swing.Depth, 0), 0.95)
 	return c.start + uint64(c.perSecond*(t+depth*c.swing.area(t)))
@@ -102,16 +111,22 @@ func (c counter) count(t float64) uint64 {
 
 func (c counter) read(k clock) any {
 	n := c.count(elapsed(k))
-	if c.wide {
+	switch {
+	case c.wide:
 		return n
+	case c.integer:
+		return int(n % (1 << 31))
 	}
 	return uint32(n) // the wrap
 }
 
 func (c counter) check(t gosnmp.Asn1BER) error {
 	want := gosnmp.Counter32
-	if c.wide {
+	switch {
+	case c.wide:
 		want = gosnmp.Counter64
+	case c.integer:
+		want = gosnmp.Integer
 	}
 	if t != want {
 		return fmt.Errorf("this counter is a %v, not a %v", want, t)
@@ -128,6 +143,9 @@ type gauge struct {
 	lo, hi  float64
 	swing   Swing
 	integer bool
+	// wide is a level carried in 64 bits: a CounterBasedGauge64, which is a
+	// Counter64 on the wire.
+	wide bool
 }
 
 // Gauge answers a Gauge32 swinging between lo and hi.
@@ -139,10 +157,21 @@ func IntegerGauge(lo, hi float64, s Swing) Reading {
 	return gauge{lo: lo, hi: hi, swing: s, integer: true}
 }
 
+// Gauge64 is Gauge for a level too large for 32 bits — UCD-SNMP-MIB's memory in
+// kilobytes, as a CounterBasedGauge64.
+func Gauge64(lo, hi float64, s Swing) Reading { return gauge{lo: lo, hi: hi, swing: s, wide: true} }
+
+func (g gauge) value(k clock) float64 {
+	return math.Round(g.lo + (g.hi-g.lo)*(0.5+0.5*g.swing.wave(elapsed(k))))
+}
+
 func (g gauge) read(k clock) any {
-	v := math.Round(g.lo + (g.hi-g.lo)*(0.5+0.5*g.swing.wave(elapsed(k))))
-	if g.integer {
+	v := g.value(k)
+	switch {
+	case g.integer:
 		return int(v)
+	case g.wide:
+		return uint64(v)
 	}
 	return uint32(v)
 }
@@ -151,16 +180,142 @@ func (g gauge) check(t gosnmp.Asn1BER) error {
 	switch {
 	case g.integer && t != gosnmp.Integer:
 		return fmt.Errorf("this gauge is an Integer, not a %v", t)
-	case !g.integer && t != gosnmp.Gauge32:
+	case g.wide && t != gosnmp.Counter64:
+		return fmt.Errorf("this gauge is a Counter64, not a %v", t)
+	case !g.integer && !g.wide && t != gosnmp.Gauge32:
 		return fmt.Errorf("this gauge is a Gauge32, not a %v", t)
 	case math.IsNaN(g.lo) || math.IsNaN(g.hi) || g.hi < g.lo:
 		return fmt.Errorf("a gauge swings from a low to a high, not from %v to %v", g.lo, g.hi)
 	case g.integer && (g.lo < math.MinInt32 || g.hi > math.MaxInt32):
 		return fmt.Errorf("%v to %v does not fit an Integer32", g.lo, g.hi)
-	case !g.integer && (g.lo < 0 || g.hi > math.MaxUint32):
+	case g.wide && (g.lo < 0 || g.hi > 1<<62):
+		return fmt.Errorf("%v to %v does not fit a Counter64", g.lo, g.hi)
+	case !g.integer && !g.wide && (g.lo < 0 || g.hi > math.MaxUint32):
 		return fmt.Errorf("%v to %v does not fit a Gauge32", g.lo, g.hi)
 	}
 	return nil
+}
+
+// LoadText is a level written as a decimal string, as UCD-SNMP-MIB's laLoad
+// writes a load average: hundredths from lo to hi, read as "0.42". Built from
+// the arguments of an IntegerGauge in hundredths, the two agree.
+func LoadText(lo, hi float64, s Swing) Reading {
+	return loadText{gauge{lo: lo, hi: hi, swing: s, integer: true}}
+}
+
+type loadText struct{ g gauge }
+
+func (l loadText) read(k clock) any { return fmt.Sprintf("%.2f", l.g.value(k)/100) }
+
+func (l loadText) check(t gosnmp.Asn1BER) error {
+	if t != gosnmp.OctetString {
+		return fmt.Errorf("a load written out is an OCTET STRING, not a %v", t)
+	}
+	return l.g.check(gosnmp.Integer)
+}
+
+// DateAndTime answers the time now as SNMPv2-TC's DateAndTime, in the machine's
+// own zone: hrSystemDate.
+func DateAndTime() Reading { return dateAndTime{} }
+
+type dateAndTime struct{}
+
+func (dateAndTime) read(c clock) any { return dateAndTimeOf(c.now) }
+
+func (dateAndTime) check(t gosnmp.Asn1BER) error {
+	if t != gosnmp.OctetString {
+		return fmt.Errorf("a DateAndTime is an OCTET STRING, not a %v", t)
+	}
+	return nil
+}
+
+// dateAndTimeOf is t in the eleven octets of SNMPv2-TC's DateAndTime: the year
+// in two, month, day, hour, minutes, seconds, tenths, and the offset from UTC.
+func dateAndTimeOf(t time.Time) []byte {
+	_, offset := t.Zone()
+	sign := byte('+')
+	if offset < 0 {
+		sign, offset = '-', -offset
+	}
+	year := t.Year()
+	return []byte{byte(year >> 8), byte(year), byte(t.Month()), byte(t.Day()), byte(t.Hour()), byte(t.Minute()),
+		byte(t.Second()), byte(t.Nanosecond() / 100_000_000), sign, byte(offset / 3600), byte(offset % 3600 / 60)}
+}
+
+// derived is a figure computed from others at the same instant, so that what a
+// MIB states twice agrees when it is read: the memory used and the memory
+// available, a percentage and its parts, the two halves of a 64-bit count.
+// Unexported like the rest: a device file cannot describe one.
+type derived struct {
+	typ gosnmp.Asn1BER
+	f   func(c clock) any
+}
+
+func (d derived) read(c clock) any { return d.f(c) }
+
+func (d derived) check(t gosnmp.Asn1BER) error {
+	if t != d.typ {
+		return fmt.Errorf("this figure is a %v, not a %v", d.typ, t)
+	}
+	return nil
+}
+
+// number is what r reads, as a number whatever Go type it is read in.
+func number(r Reading, c clock) float64 {
+	switch v := r.read(c).(type) {
+	case int:
+		return float64(v)
+	case uint32:
+		return float64(v)
+	case uint64:
+		return float64(v)
+	}
+	return 0
+}
+
+// remainder is total less what the parts read: the processor time left idle,
+// the space left free.
+func remainder(t gosnmp.Asn1BER, total float64, parts ...Reading) Reading {
+	return derived{typ: t, f: func(c clock) any {
+		v := total
+		for _, p := range parts {
+			v -= number(p, c)
+		}
+		return as(t, max(v, 0))
+	}}
+}
+
+// percentOf is what part reads as a whole percentage of total.
+func percentOf(t gosnmp.Asn1BER, part Reading, total float64) Reading {
+	return derived{typ: t, f: func(c clock) any {
+		if total <= 0 {
+			return as(t, 0)
+		}
+		return as(t, math.Round(100*number(part, c)/total))
+	}}
+}
+
+// word is one 32-bit half of what r reads: UCD-SNMP-MIB gives a disk's size in
+// kilobytes as a low and a high Unsigned32.
+func word(r Reading, high bool) Reading {
+	return derived{typ: gosnmp.Gauge32, f: func(c clock) any {
+		v := uint64(number(r, c))
+		if high {
+			return uint32(v >> 32)
+		}
+		return uint32(v)
+	}}
+}
+
+// as is v in the Go type Const holds for t.
+func as(t gosnmp.Asn1BER, v float64) any {
+	switch t {
+	case gosnmp.Integer:
+		return int(min(v, math.MaxInt32))
+	case gosnmp.Counter64:
+		return uint64(v)
+	}
+	return uint32(min(v, math.MaxUint32))
 }
 
 // SecondsUp answers the seconds since the agent started as a Gauge32: how long

--- a/pkg/simulator/windows.go
+++ b/pkg/simulator/windows.go
@@ -2,13 +2,17 @@ package simulator
 
 import (
 	"fmt"
+	"net/netip"
 	"time"
 )
 
-// windowsServer is a Windows Server 2022 host with the SNMP service: the system
-// group as Windows answers it, the loopback and two adapters, and the host
-// resources — its drives by letter, its memory and four processors, numbered as
-// Windows numbers them. It fits the "Interfaces" and "Host resources" presets.
+// windowsServer is a Windows Server 2022 host with the SNMP service, as a walk
+// of one finds it: the system group as Windows answers it; the loopback, two
+// adapters and the pseudo-interfaces Windows lists beside them, down; its
+// address, routes and sockets — RDP, SMB, WinRM; and the host resources: its
+// drives by letter, its memory, four processors numbered as Windows numbers
+// them, its devices, the processes running and the programs installed. It fits
+// the "Interfaces" and "Host resources" presets.
 var windowsServer = model{
 	ModelInfo:     ModelInfo{ID: "windows-server", Category: "server"},
 	enterprise:    311, // Microsoft
@@ -22,7 +26,9 @@ func buildWindowsServer(id Identity) []Object {
 		"Hardware: Intel64 Family 6 Model 85 Stepping 7 AT/AT COMPATIBLE - Software: Windows Version 6.3 (Build 20348 Multiprocessor Free)",
 		".1.3.6.1.4.1.311.1.1.3.1.2", // a Windows server
 		"Administrator", "Server room, rack B2", 76)
-	addInterfaces(&o, id.Seed, []iface{
+	lan := lanPrefix(id.Seed)
+	peer := func(n int, port uint16) netip.AddrPort { return netip.AddrPortFrom(hostIn(lan, n), port) }
+	ifs := []iface{
 		{index: 1, descr: "Software Loopback Interface 1", name: "loopback_0", ifType: ifTypeSoftwareLoopback,
 			mtu: 1500, speed: 1_073_741_824, up: true},
 		{index: 6, descr: "Intel(R) Ethernet Server Adapter I350-T2", name: "ethernet_32768", ifType: ifTypeEthernet,
@@ -30,13 +36,50 @@ func buildWindowsServer(id Identity) []Object {
 			inRate: 2_100_000, outRate: 4_600_000, errorRate: 0.001},
 		{index: 7, descr: "Intel(R) Ethernet Server Adapter I350-T2 #2", name: "ethernet_32769", ifType: ifTypeEthernet,
 			mtu: 1500, speed: 1_000_000_000, mac: deviceMAC(id.Seed, 2)},
+	}
+	// The miniports and tunnels Windows always lists, none of them carrying
+	// anything.
+	for i, p := range []struct {
+		descr, name string
+		kind        int
+	}{
+		{"WAN Miniport (SSTP)", "wman_0", ifTypePPP},
+		{"WAN Miniport (IKEv2)", "wman_1", ifTypePPP},
+		{"WAN Miniport (L2TP)", "wman_2", ifTypePPP},
+		{"WAN Miniport (PPTP)", "wman_3", ifTypePPP},
+		{"WAN Miniport (IP)", "ethernet_0", ifTypeEthernet},
+		{"WAN Miniport (IPv6)", "ethernet_1", ifTypeEthernet},
+		{"WAN Miniport (Network Monitor)", "ethernet_2", ifTypeEthernet},
+		{"Microsoft Kernel Debug Network Adapter", "ethernet_3", ifTypeEthernet},
+		{"Teredo Tunneling Pseudo-Interface", "tunnel_0", ifTypeTunnel},
+		{"Microsoft IP-HTTPS Platform Interface", "tunnel_1", ifTypeTunnel},
+	} {
+		index := []int{2, 3, 4, 5, 8, 9, 10, 11, 12, 13}[i]
+		ifs = append(ifs, iface{index: index, descr: p.descr, name: p.name, ifType: p.kind, mtu: 1500})
+	}
+	addStack(&o, stack{
+		seed:    id.Seed,
+		ifs:     ifs,
+		addrs:   []ifAddr{{ifIndex: 6, prefix: addrIn(lan, 12+int(id.Seed%40)), neighbours: 5}},
+		gateway: hostIn(lan, 1),
+		ttl:     128,
+		pps:     2600,
+		listen:  []uint16{80, 135, 139, 445, 3389, 5985, 47001, 49664, 49665, 49666, 49667, 49668},
+		udp:     []uint16{123, 137, 138, 161, 500, 3389, 4500, 5353},
+		sessions: []session{
+			{3389, peer(50, 52877)}, // an administrator's remote desktop
+			{445, peer(64, 50412)},  // a file share in use
+			{445, peer(71, 61023)},
+			{80, peer(88, 58113)},
+		},
+		modules: []sysOR{moduleHostResources},
 	})
+
 	// A volume serial number, as Windows writes one into hrStorageDescr.
 	serial := func(n uint64) string { return fmt.Sprintf("%08x", uint32(mix(id.Seed+n))) }
 	addHostResources(&o, id.Seed, hostResources{
 		memoryKiB: 16777216, // 16 GiB
 		users:     [2]float64{1, 3},
-		processes: [2]float64{110, 140},
 		storage: []storageArea{
 			{1, hrStorageFixedDisk, `C:\ Label:  Serial Number ` + serial(1), 4096, 32768000, 0.46, 0.52, 3 * time.Hour},
 			{2, hrStorageFixedDisk, `D:\ Label:Data  Serial Number ` + serial(2), 4096, 131072000, 0.61, 0.62, 12 * time.Hour},
@@ -46,6 +89,110 @@ func buildWindowsServer(id Identity) []Object {
 		processors: []int{5, 6, 7, 8},
 		cpuLo:      3,
 		cpuHi:      45,
+		cpu:        "Intel(R) Xeon(R) Gold 6230 CPU @ 2.10GHz",
+		boot:       3,
+		devices: []hrDevice{
+			{index: 1, kind: hrDevicePrinter, descr: "Microsoft Print To PDF"},
+			{index: 2, kind: hrDevicePrinter, descr: "Microsoft XPS Document Writer v4"},
+			{index: 3, kind: hrDeviceDiskStorage, descr: "Fixed Disk", diskKB: 134217728},
+			{index: 4, kind: hrDeviceDiskStorage, descr: "Fixed Disk", diskKB: 536870912},
+			{index: 9, kind: hrDeviceNetwork, descr: "Software Loopback Interface 1", ifIndex: 1},
+			{index: 10, kind: hrDeviceNetwork, descr: "Intel(R) Ethernet Server Adapter I350-T2", ifIndex: 6},
+			{index: 11, kind: hrDeviceNetwork, descr: "Intel(R) Ethernet Server Adapter I350-T2 #2", ifIndex: 7},
+		},
+		fs: []hrFS{
+			{`C:\`, hrFSNTFS, 1, true},
+			{`D:\`, hrFSNTFS, 2, false},
+		},
+		procs:    windowsProcesses(),
+		software: windowsPrograms(),
 	})
 	return o
+}
+
+// windowsProcesses is what Windows Server runs with IIS and remote desktop in
+// use, named and pathed as the SNMP service reports them.
+func windowsProcesses() []process {
+	const sys = `C:\Windows\system32\`
+	type p struct {
+		pid        int
+		name, args string
+		cpu        float64
+		memKB      int
+	}
+	procs := []process{{pid: 4, name: "System", kind: 2, cpu: 0.02, memKB: 144}}
+	for _, x := range []p{
+		{92, "Registry", "", 0, 72000},
+		{316, "smss.exe", "", 0, 1200},
+		{440, "csrss.exe", "", 0.001, 5400},
+		{516, "wininit.exe", "", 0, 6800},
+		{528, "csrss.exe", "", 0.001, 5900},
+		{600, "winlogon.exe", "", 0, 11200},
+		{640, "services.exe", "", 0.001, 10400},
+		{656, "lsass.exe", "", 0.003, 24100},
+		{760, "svchost.exe", "-k DcomLaunch -p", 0.002, 31500},
+		{784, "fontdrvhost.exe", "", 0, 3900},
+		{812, "svchost.exe", "-k RPCSS -p", 0.001, 12700},
+		{868, "svchost.exe", "-k LocalServiceNoNetwork -p", 0, 7200},
+		{932, "dwm.exe", "", 0.004, 61000},
+		{968, "svchost.exe", "-k netsvcs -p -s Schedule", 0.001, 21400},
+		{1004, "svchost.exe", "-k LocalServiceNetworkRestricted -p", 0.001, 14800},
+		{1072, "svchost.exe", "-k NetworkService -p", 0.002, 18900},
+		{1120, "svchost.exe", "-k LocalSystemNetworkRestricted -p", 0.001, 16300},
+		{1236, "svchost.exe", "-k netsvcs -p -s Winmgmt", 0.004, 19700},
+		{1392, "spoolsv.exe", "", 0, 16900},
+		{1476, "svchost.exe", "-k appmodel -p -s StateRepository", 0.001, 12100},
+		{1528, "svchost.exe", "-k utcsvc -p", 0.001, 24300},
+		{1600, "MsMpEng.exe", "", 0.012, 212000},
+		{1648, "snmp.exe", "", 0.003, 8900},
+		{1692, "svchost.exe", "-k iissvcs", 0.001, 20100},
+		{1736, "svchost.exe", "-k termsvcs -s TermService", 0.002, 18400},
+		{1804, "vmtoolsd.exe", "", 0.002, 25400},
+		{1860, "svchost.exe", "-k NetworkServiceNetworkRestricted -p -s PolicyAgent", 0, 8800},
+		{2012, "WmiPrvSE.exe", "", 0.003, 19600},
+		{2196, "dllhost.exe", "/Processid:{02D4B3F1-FD88-11D1-960D-00805FC79235}", 0, 12300},
+		{2308, "msdtc.exe", "", 0, 9200},
+		{2544, "NisSrv.exe", "", 0.001, 11300},
+		{2780, "w3wp.exe", `-ap "DefaultAppPool" -v "v4.0" -l "webengine4.dll" -a \\.\pipe\iisipm`, 0.03, 148000},
+		{2904, "w3wp.exe", `-ap "Intranet" -v "v4.0" -l "webengine4.dll" -a \\.\pipe\iisipm`, 0.02, 121000},
+		{3120, "svchost.exe", "-k UnistackSvcGroup", 0, 9700},
+		{3368, "csrss.exe", "", 0.001, 6200},
+		{3412, "winlogon.exe", "", 0, 10600},
+		{3500, "rdpclip.exe", "", 0, 9800},
+		{3544, "sihost.exe", "", 0, 21800},
+		{3600, "svchost.exe", "-k UserSvcGroup", 0.001, 14700},
+		{3648, "taskhostw.exe", "", 0, 11700},
+		{3780, "explorer.exe", "", 0.003, 96000},
+		{3912, "ctfmon.exe", "", 0, 12900},
+		{4080, "ServerManager.exe", "", 0.002, 118000},
+		{4216, "RuntimeBroker.exe", "", 0, 18200},
+		{4388, "conhost.exe", "0x4", 0, 6400},
+		{4452, "powershell.exe", "", 0.001, 71000},
+	} {
+		procs = append(procs, process{pid: x.pid, name: x.name, path: sys + x.name, args: x.args, kind: 4, cpu: x.cpu, memKB: x.memKB})
+	}
+	return procs
+}
+
+// windowsPrograms are what the server lists as installed.
+func windowsPrograms() []software {
+	base := time.Date(2023, 11, 8, 10, 4, 0, 0, time.UTC)
+	var out []software
+	for i, name := range []string{
+		"Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.38.33135",
+		"Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.38.33135",
+		"VMware Tools",
+		"Microsoft Edge",
+		"Microsoft Edge Update",
+		"7-Zip 23.01 (x64)",
+		"Notepad++ (64-bit x64)",
+		"PowerShell 7-x64",
+		"Microsoft Web Deploy 4.0",
+		"IIS URL Rewrite Module 2",
+		"Microsoft .NET Runtime - 8.0.8 (x64)",
+		"Microsoft ASP.NET Core 8.0.8 - Shared Framework (x64)",
+	} {
+		out = append(out, software{name: name, installed: base.Add(time.Duration(i) * 97 * time.Hour)})
+	}
+	return out
 }


### PR DESCRIPTION
Stacked on #69 — review that one first; this diff is against its head.

## Why

A simulated device answered the few OIDs its presets poll, and not much else. Walking one showed a skeleton no real agent serves: an ifTable with half its columns, no addresses, no routes, no sockets, no hardware. Enough to draw a dashboard, not enough to test a MIB browser against.

## What a model answers now

A device is described **once** — its interfaces, addresses, gateway and routes, sockets, hardware, bridge ports and VLANs, LLDP neighbours — and every standard MIB is built from that one description (`stack.go`, `bridge.go`, `ucd.go`, `hostres.go`). So they agree the way a real agent's do:

- an address sits on an interface ifTable lists, and a route leaves through one;
- `tcpCurrEstab` counts the sessions `tcpConnTable` lists, and `hrSystemProcesses` the rows of `hrSWRunTable`;
- a bridge port is an interface, and the stations learnt on it sit behind it;
- a port in ENTITY-MIB points at its interface;
- the ISR's BGP-learnt routes go through the peer BGP4-MIB says is established, over the TCP session on port 179 that `tcpConnTable` lists.

| | |
| --- | --- |
| Standard stack | IF-MIB whole (all 22 ifTable and 19 ifXTable columns, 32/64-bit twins from one reading, ifStackTable), IP-MIB (ipAddrTable, ipAddressTable, ipAddressPrefixTable, ipNetToMediaTable), IP-FORWARD, ICMP, TCP, UDP, EtherLike, ENTITY-MIB, BRIDGE / Q-BRIDGE, LLDP (under 1.0.8802, as on a real device), sysORTable |
| Hosts | HOST-RESOURCES with devices, processors, file systems, processes with their perf, installed software; UCD-SNMP-MIB (memory, disks, load, systemStats) wherever the agent is net-snmp |
| Vendors | Cisco CPU, memory, environment, CDP, VTP · FortiGate VDOM, HA, policies, IPsec · iDRAC BIOS, processors, DIMMs, PSUs, RAID controller and disks · UniFi radios and VAPs · MikroTik health, gauges, neighbours · PowerNet derived from UPS-MIB's readings · the Printer MIB (trays, bins, covers, markers, colorants, interpreters, console) |

From 58–1 136 objects per model to **291–5 627** (19 653 over the catalogue). A figure a MIB states twice — memory used and available, a percentage and its parts, the two halves of a 64-bit disk size, APC's run time in TimeTicks and UPS-MIB's in minutes — is derived from one reading at the same instant rather than drawn twice. Vendor OIDs were resolved from the MIBs themselves (LibreNMS's copies), not remembered.

## What the agent counts is the agent's

`agentobjects.go`: SNMPv2-MIB's snmp group on every device, and for v3 snmpEngine, the MPD and USM statistics and snmpUnknownContexts, are read live from the counters the agent keeps as it answers. A request is counted on arrival, as net-snmp does, so a GET of `snmpInPkts` counts itself. A custom model that tries to answer one of these is refused at import, naming the OID.

## Tests

- `TestTheStandardMIBsAgree` — every model's cross-references: ifIndex references, ENTITY containment, route and process counts, bridge ports, VLAN count, LLDP ports.
- `TestSimulatedTablesDecode` (`pkg/mib`) — walks every model and decodes 20 tables with SnmpLens's own `DecodeIndexes`: an index written any way but RFC 2578 7.7's fails there rather than as garbled rows on screen. `TestASimulatedServersConnectionsDecode` does tcpConnTable's four-part index specifically.
- `TestTheAgentCountsWhatItAnswers`, `TestTheSystemDateIsNow`.
- `TestEveryModelServesAWalk` now walks both roots and compares against the tree, agent objects included.

Gates run locally: `go vet`, `staticcheck` 0.8.1, `go test -race ./...`, `npm test`, `svelte-check`, the Vite build.

The model descriptions are rewritten in the five locales to say what each model now answers.
