### PR TITLE
Record a real device as a simulator model, and export any model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -672,6 +672,20 @@ folder of the archive's own names — and a lone file as `<id>.json`. Importing 
 writing, and `loadModels` takes the newer when a stopped import leaves both: two kept forms of one ID would
 otherwise fail `SetCustomModels` and take every custom model with them.
 
+**Recording a device is walking it into a package** (`app_simrecord.go`, `pkg/snmp/record.go`,
+`pkg/simulator/record.go`). `Client.Record` walks one device under `.1.3.6.1` and `.1.0.8802`, keeping each varbind
+as gosnmp DECODED it — the types are the point, and `Walk`'s formatted results lose them — and `simulator.Recording`
+writes each as a `.snmprec` line: an OCTET STRING as text only when every octet is printable ASCII and in hex
+otherwise, so that the octets read back are the octets sent (`TestARecordingReadsBackAsWhatWasSent` round-trips every
+type through `readWalk`). The agent's own subtrees are never WRITTEN, not merely not served: a recording is a file
+somebody may pass on, and in a real walk that subtree holds the device's user names and community table. The walk
+runs outside the simulator's lock, which a large device would hold for minutes — one recording at a time, guarded
+apart, and `SimulatorCancelRecording` stops it with nothing kept. The request is built in the renderer through
+`getEffectiveSettings`, as every request is, so a device is recorded with its target's profile or overrides, and
+`recordRequest` is checked against the Go struct's tags as the other request builders are. Export writes a kept
+model as a package FOLDER (`repackUnder`), its icon under the name the model gives it, which imports back as itself:
+that is how a recording is edited.
+
 **What only a notification carries** (`Object.NotifyOnly`). An iDRAC alert carries eleven objects its MIB makes
 accessible-for-notify (RFC 2578 7.3) — a message ID, the message, the service tag — and no request may read them.
 They are kept beside the tree rather than in it: a GET answers `noSuchObject`, a walk passes them by, and

--- a/README.md
+++ b/README.md
@@ -459,6 +459,12 @@ Three rules put the files together:
 
 **Recorded counters move.** Each starts at the value recorded and grows at the rate it had averaged since the device booted — its value over the sysUpTime recorded beside it — swinging around that rate as traffic does. hrSystemUptime and hrSystemDate are the device's own; everything else answers what was recorded. A line of a walk that cannot be read is left out and counted, and the import says where the first one was. A walk is at most 16 MB, and a package's walks record at most 65 536 objects between them. The example is `pkg/simulator/testdata/package`.
 
+### Recording a device
+
+**Record a device…** in the model picker walks a real device — `.1.3.6.1`, then `.1.0.8802` for LLDP — with the identifiers its target uses, and keeps what it answered as a package: a model like any other, from which a device answers what the real one did, its counters moving. The recorded device's own agent — its snmp group, engine, USM users, VACM groups and community table — is never written. A recording can be stopped, and then keeps nothing; a device answering more than 65 536 objects is refused rather than cut short.
+
+**Export** (beside a custom model's delete button) writes any custom model to a ZIP as a package folder, with its icon. It is how a recording is edited — add an `oids.json` beside its walk to make a recorded constant move, or a `traps.json` to give it notifications — and imported again, or passed on.
+
 ---
 
 ## Test Agent

--- a/app_simmodels.go
+++ b/app_simmodels.go
@@ -170,13 +170,24 @@ func readKept(name, form string) (simulator.CustomModel, error) {
 		}
 		return simulator.ParseCustomModel(bytes.TrimPrefix(raw, utf8BOM))
 	}
-	data, err := readAtMost(name, maxKeptPackageBytes)
+	files, err := keptPackageFiles(name)
 	if err != nil {
 		return simulator.CustomModel{}, err
 	}
+	m, _, err := simulator.ParseCustomPackage(files)
+	return m, err
+}
+
+// keptPackageFiles reads back the files of a package the directory keeps, by
+// their names in the package.
+func keptPackageFiles(name string) ([]simulator.PackageFile, error) {
+	data, err := readAtMost(name, maxKeptPackageBytes)
+	if err != nil {
+		return nil, err
+	}
 	ar, err := openArchive(data)
 	if err != nil {
-		return simulator.CustomModel{}, err
+		return nil, err
 	}
 	var files []simulator.PackageFile
 	for _, f := range ar.files {
@@ -185,12 +196,11 @@ func readKept(name, form string) (simulator.CustomModel, error) {
 		}
 		b, err := ar.read(f, packageFileLimit(f.Name))
 		if err != nil {
-			return simulator.CustomModel{}, err
+			return nil, err
 		}
 		files = append(files, simulator.PackageFile{Name: f.Name, Data: b})
 	}
-	m, _, err := simulator.ParseCustomPackage(files)
-	return m, err
+	return files, nil
 }
 
 // emitSimulatorModelsChanged tells the renderer to list the models again.
@@ -297,21 +307,27 @@ func (a *App) importSimulatorModels(paths []string) []SimulatorModelImportResult
 	}
 	s.loadModels()
 	for r := range results {
-		res := &results[r]
-		if !res.Success || !res.Replaced {
-			continue
-		}
-		for i, d := range s.devices {
-			if d.Model != res.ModelID || !s.fleet.Stop(d.ID) {
-				continue
-			}
-			if err := a.startSimulatedLocked(s, i); err != nil {
-				res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "restartFailed", Detail: fmt.Sprintf("%s: %v", d.Name, err)})
-			}
-		}
+		a.restartModelDevicesLocked(s, &results[r])
 	}
 	a.emitSimulatorModelsChanged()
 	return results
+}
+
+// restartModelDevicesLocked restarts the running devices of the model a result
+// replaced, so that they answer as it now is — as an edited device restarts.
+// s.mu is held.
+func (a *App) restartModelDevicesLocked(s *simulatorService, res *SimulatorModelImportResult) {
+	if !res.Success || !res.Replaced {
+		return
+	}
+	for i, d := range s.devices {
+		if d.Model != res.ModelID || !s.fleet.Stop(d.ID) {
+			continue
+		}
+		if err := a.startSimulatedLocked(s, i); err != nil {
+			res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "restartFailed", Detail: fmt.Sprintf("%s: %v", d.Name, err)})
+		}
+	}
 }
 
 // importModelFile imports what one picked file holds: a model, or an archive of
@@ -560,11 +576,15 @@ func (s *simulatorService) importPackage(archiveName string, ar *archive, root s
 
 // repack is the ZIP a package is kept as: the files it reads and nothing else,
 // by their names in the package.
-func repack(files []simulator.PackageFile) ([]byte, error) {
+func repack(files []simulator.PackageFile) ([]byte, error) { return repackUnder("", files) }
+
+// repackUnder is a ZIP of a package's files, in a folder of that name when one
+// is given: the shape a package is exported in.
+func repackUnder(folder string, files []simulator.PackageFile) ([]byte, error) {
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
 	for _, f := range files {
-		w, err := zw.CreateHeader(&zip.FileHeader{Name: f.Name, Method: zip.Deflate})
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: path.Join(folder, f.Name), Method: zip.Deflate})
 		if err != nil {
 			return nil, err
 		}

--- a/app_simrecord.go
+++ b/app_simrecord.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/snmp"
+
+	"github.com/gosnmp/gosnmp"
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// Recording a device: SnmpLens walks a real one and keeps what it answered as a
+// package (simulator.RecordedPackage), a custom model like any imported one.
+// And any custom model can be exported as the package it is, to be edited —
+// an oids file beside a recorded walk makes a recorded constant move — and
+// imported again, or passed on.
+
+// SimulatorRecordRequest is what a recording takes: the device and how to reach
+// it, built as every request is (snmp.SnmpRequest, with one target), and what
+// the model it makes is to be called.
+type SimulatorRecordRequest struct {
+	snmp.SnmpRequest
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Vendor      string `json:"vendor"`
+	Category    string `json:"category"`
+}
+
+// recordRoots are the subtrees a device answers in: LLDP-MIB lives under
+// 1.0.8802, outside .1.3.6.1.
+var recordRoots = []string{".1.3.6.1", ".1.0.8802"}
+
+// recordProgressEvery is how many objects pass between two progress events.
+const recordProgressEvery = 250
+
+var errRecordingStopped = errors.New("the recording was stopped, and nothing of it was kept")
+
+// recorder is the recording under way, if one is. A recording holds none of
+// the simulator's lock while it walks — a large device takes minutes — so it
+// is guarded apart.
+type recorder struct {
+	mu     sync.Mutex
+	cancel context.CancelFunc
+}
+
+func (r *recorder) begin(cancel context.CancelFunc) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cancel != nil {
+		return false
+	}
+	r.cancel = cancel
+	return true
+}
+
+func (r *recorder) end() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cancel != nil {
+		r.cancel()
+		r.cancel = nil
+	}
+}
+
+// SimulatorRecordDevice walks a device and keeps what it answered as a custom
+// model, replacing a model of the same name as importing it again would, and
+// returns what became of it as an import does. One recording runs at a time,
+// and SimulatorCancelRecording stops it.
+func (a *App) SimulatorRecordDevice(req SimulatorRecordRequest) (SimulatorModelImportResult, error) {
+	s := a.sim
+	if s == nil {
+		return SimulatorModelImportResult{}, errNoSimulator
+	}
+	if len(req.Targets) != 1 || strings.TrimSpace(req.Targets[0]) == "" {
+		return SimulatorModelImportResult{}, errors.New("a recording walks one device")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	if !s.rec.begin(cancel) {
+		cancel()
+		return SimulatorModelImportResult{}, errors.New("a device is already being recorded")
+	}
+	defer s.rec.end()
+
+	var rec simulator.Recording
+	err := a.snmpClient.Record(ctx, req.SnmpRequest, recordRoots, func(pdu gosnmp.SnmpPDU) error {
+		if err := rec.Add(pdu); err != nil {
+			return err
+		}
+		if n := rec.Objects(); n%recordProgressEvery == 0 {
+			a.emitRecording(n)
+		}
+		return nil
+	})
+	switch {
+	case errors.Is(err, context.Canceled):
+		return SimulatorModelImportResult{}, errRecordingStopped
+	case err != nil:
+		return SimulatorModelImportResult{}, err
+	}
+	files, m, err := simulator.RecordedPackage(simulator.RecordedModel{Name: req.Name, Description: req.Description,
+		Vendor: req.Vendor, Category: req.Category}, &rec)
+	if err != nil {
+		return SimulatorModelImportResult{}, err
+	}
+	packed, err := repack(files)
+	if err != nil {
+		return SimulatorModelImportResult{}, err
+	}
+
+	res := SimulatorModelImportResult{File: req.Targets[0], Warnings: []SimulatorModelWarning{}}
+	if n := rec.LeftOut(); n > 0 {
+		res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "walkAgentOwned", Detail: strconv.Itoa(n)})
+	}
+	noIcon := func(string) (*modelIcon, *SimulatorModelWarning) { return nil, nil }
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	res = s.keepModel(res, m, noIcon, keptPackage, packed)
+	s.loadModels()
+	a.restartModelDevicesLocked(s, &res)
+	a.emitSimulatorModelsChanged()
+	return res, nil
+}
+
+// SimulatorCancelRecording stops the recording under way, if one is. Nothing of
+// it is kept.
+func (a *App) SimulatorCancelRecording() {
+	if s := a.sim; s != nil {
+		s.rec.end()
+	}
+}
+
+// emitRecording tells the renderer how many objects the recording has kept.
+func (a *App) emitRecording(objects int) {
+	if a.ctx != nil {
+		runtime.EventsEmit(a.ctx, "simulator:recording", objects)
+	}
+}
+
+// SimulatorExportModelDialog writes a custom model to a ZIP the user names, as
+// a package folder — its model file, its other files, and its icon under the
+// name the model gives it — which imports back as the same model. It returns
+// where the file went, or "" when the dialog was cancelled.
+func (a *App) SimulatorExportModelDialog(id string) (string, error) {
+	s := a.sim
+	if s == nil {
+		return "", errNoSimulator
+	}
+	slug, ok := simulator.CustomModelSlug(id)
+	if !ok {
+		return "", fmt.Errorf("%q is not a custom model", id)
+	}
+	s.mu.Lock()
+	data, err := s.exportModel(slug)
+	s.mu.Unlock()
+	if err != nil {
+		return "", err
+	}
+	if a.ctx == nil {
+		return "", fmt.Errorf("no window")
+	}
+	dest, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+		Title:           "Export simulator model",
+		DefaultFilename: slug + ".zip",
+		Filters:         []runtime.FileFilter{{DisplayName: "Simulator model package (ZIP)", Pattern: "*.zip"}},
+	})
+	if err != nil || dest == "" {
+		return "", err
+	}
+	if !strings.EqualFold(filepath.Ext(dest), ".zip") {
+		dest += ".zip"
+	}
+	if err := os.WriteFile(dest, data, 0o644); err != nil {
+		return "", fmt.Errorf("writing %s: %w", filepath.Base(dest), err)
+	}
+	return dest, nil
+}
+
+// exportModel is the ZIP a kept model is exported as: a folder named after the
+// model, holding model.json and the rest of its package, and its icon.
+func (s *simulatorService) exportModel(slug string) ([]byte, error) {
+	var files []simulator.PackageFile
+	var icon string
+	switch s.keptFormOf(slug) {
+	case keptPackage:
+		kept, err := keptPackageFiles(filepath.Join(s.modelDir, slug+keptPackage))
+		if err != nil {
+			return nil, err
+		}
+		m, _, err := simulator.ParseCustomPackage(kept)
+		if err != nil {
+			return nil, err
+		}
+		files, icon = kept, m.Icon()
+	case keptFile:
+		raw, err := readAtMost(filepath.Join(s.modelDir, slug+keptFile), simulator.MaxCustomModelBytes)
+		if err != nil {
+			return nil, err
+		}
+		m, err := simulator.ParseCustomModel(bytes.TrimPrefix(raw, utf8BOM))
+		if err != nil {
+			return nil, err
+		}
+		files, icon = []simulator.PackageFile{{Name: simulator.PackageModelFile, Data: raw}}, m.Icon()
+	default:
+		return nil, fmt.Errorf("no custom model %q is kept", slug)
+	}
+	if icon != "" {
+		for _, ext := range []string{".png", ".jpg", ".gif"} {
+			if data, err := readAtMost(filepath.Join(s.modelDir, slug+ext), maxModelIconBytes); err == nil {
+				files = append(files, simulator.PackageFile{Name: icon, Data: data})
+				break
+			}
+		}
+	}
+	return repackUnder(slug, files)
+}
+
+// keptFormOf is the form a model is kept in — the newer, should a stopped
+// import have left both, as loadModels takes it — or "" when it is not kept.
+func (s *simulatorService) keptFormOf(slug string) string {
+	form, newest := "", time.Time{}
+	for _, f := range []string{keptFile, keptPackage} {
+		st, err := os.Stat(filepath.Join(s.modelDir, slug+f))
+		if err == nil && !st.IsDir() && (form == "" || st.ModTime().After(newest)) {
+			form, newest = f, st.ModTime()
+		}
+	}
+	return form
+}

--- a/app_simrecord_test.go
+++ b/app_simrecord_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/snmp"
+)
+
+// A device is recorded as a model: the walk kept as a package under an id made
+// from the name, the agent's own objects left out and counted, and a device
+// made from the model answering what the recorded one answered, under its own
+// name. Exported, the model imports back as itself.
+func TestADeviceIsRecordedAsAModel(t *testing.T) {
+	a := modelApp(t)
+	if a.snmpClient == nil {
+		a.snmpClient = snmp.NewClient(context.Background())
+	}
+	src := simDevice()
+	src.Name, src.Model, src.Versions, src.Users, src.Traps = "sw-source", "cisco-catalyst-24", []string{"v2c"}, nil, simulator.Traps{}
+	source := startSimulated(t, a, src)
+
+	res, err := a.SimulatorRecordDevice(SimulatorRecordRequest{
+		SnmpRequest: snmp.SnmpRequest{Targets: []string{fmt.Sprintf("%s:%d", source.Address, source.Port)},
+			Community: src.Community, Version: "v2c", Timeout: 2, Retries: 1},
+		Name: "Floor switch", Vendor: "Cisco", Category: "network", Description: "Recorded in a test.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success || res.Replaced || res.ModelID != "custom:floor-switch" ||
+		len(res.Warnings) != 1 || res.Warnings[0].Key != "walkAgentOwned" {
+		t.Fatalf("%+v", res)
+	}
+	if got := dirNames(t, a.sim.modelDir); !slices.Equal(got, []string{"floor-switch.zip"}) {
+		t.Errorf("the model directory holds %v", got)
+	}
+	if m := listedModel(a, "custom:floor-switch"); m == nil || m.Vendor != "Cisco" || m.Category != "network" {
+		t.Fatalf("listed as %+v", m)
+	}
+
+	replica := simDevice()
+	replica.Name, replica.Model, replica.Port = "sw-copy", "custom:floor-switch", src.Port+1
+	replica.Versions, replica.Users, replica.Traps = []string{"v2c"}, nil, simulator.Traps{}
+	copied := startSimulated(t, a, replica)
+	for _, oid := range []string{".1.3.6.1.2.1.1.1.0", ".1.3.6.1.2.1.1.2.0", ".1.3.6.1.2.1.2.2.1.2.2", ".1.3.6.1.2.1.47.1.1.1.1.2.1"} {
+		want := simGet(t, source, src.Community, oid)
+		got := simGet(t, copied, replica.Community, oid)
+		if got.Type != want.Type || !reflect.DeepEqual(got.Value, want.Value) {
+			t.Errorf("%s answers %v %v, and the recorded device %v %v", oid, got.Type, got.Value, want.Type, want.Value)
+		}
+	}
+	if v := simGet(t, copied, replica.Community, ".1.3.6.1.2.1.1.5.0"); string(v.Value.([]byte)) != "sw-copy" {
+		t.Errorf("sysName answers %v", v.Value)
+	}
+
+	a.sim.mu.Lock()
+	data, err := a.sim.exportModel("floor-switch")
+	a.sim.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again := onlyResult(t, a.importSimulatorModels([]string{writeModelFile(t, "floor-switch.zip", data)}))
+	if !again.Success || !again.Replaced || again.ModelID != "custom:floor-switch" ||
+		again.File != "floor-switch.zip › floor-switch/model.json" {
+		t.Errorf("imported back as %+v", again)
+	}
+}
+
+// A lone model exports as a package folder holding it as model.json, beside
+// its icon under the name it gives it.
+func TestALoneModelExportsAsAPackage(t *testing.T) {
+	a := modelApp(t)
+	onlyResult(t, a.importSimulatorModels([]string{writeZip(t, "acme.zip",
+		zipEntry{"custom-model.json", exampleModel(t)}, zipEntry{"acme-crac.png", pngIcon(t, 32)})}))
+	a.sim.mu.Lock()
+	data, err := a.sim.exportModel("acme-crac")
+	a.sim.mu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := onlyResult(t, a.importSimulatorModels([]string{writeModelFile(t, "export.zip", data)}))
+	if !res.Success || !res.Icon || res.ModelID != "custom:acme-crac" || res.File != "export.zip › acme-crac/model.json" {
+		t.Errorf("%+v", res)
+	}
+	if got := dirNames(t, a.sim.modelDir); !slices.Equal(got, []string{"acme-crac.png", "acme-crac.zip"}) {
+		t.Errorf("the model directory holds %v", got)
+	}
+}

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -45,6 +45,8 @@ type simulatorService struct {
 	// it held when it was last read.
 	modelDir string
 	models   []simulator.CustomModel
+	// rec is the recording under way, if one is (app_simrecord.go).
+	rec recorder
 }
 
 func newSimulatorService(dir string) *simulatorService {

--- a/frontend/screenshots/bridge/dynamic.js
+++ b/frontend/screenshots/bridge/dynamic.js
@@ -403,6 +403,8 @@ const DEMO_ONLY = {
   SimulatorSendTrap: 'A simulated device sends its notifications over UDP, from this machine.',
   ImportSimulatorModelsDialog: 'Importing a simulator model opens the operating system’s file dialog and writes the model to your configuration directory.',
   SimulatorDeleteModel: 'Deleting a simulator model removes its file from your configuration directory.',
+  SimulatorRecordDevice: 'Recording a device walks a real device on your network and writes the model to your configuration directory.',
+  SimulatorExportModelDialog: 'Exporting a simulator model opens the operating system’s file dialog and writes a file.',
 };
 
 for (const [name, why] of Object.entries(DEMO_ONLY)) {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -9,7 +9,7 @@
   import {
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
-    modelOf, modelName, modelDescription, importReport, firstImported,
+    modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
@@ -121,6 +121,46 @@
       notificationStore.add(String(e), 'error');
     } finally {
       importingModels = false;
+    }
+  }
+
+  let recordOpen = false;
+  let stopRequested = false;
+
+  // A device recorded becomes a model as one imported does, and the new
+  // device's model: recording one is how someone says they want it.
+  async function recordDevice({ target, name, vendor, category }) {
+    stopRequested = false;
+    const shown = $anonMode ? maskString(target) : target;
+    const description = $_('simulator.record.description', { values: { target, date: new Date().toLocaleDateString() } });
+    try {
+      const result = await simulatorStore.record(recordRequest($settingsStore, target, { name, vendor, category, description }));
+      for (const line of importReport([result])) {
+        notificationStore.add($_(line.key, { values: line.values }), line.level);
+      }
+      await simulatorStore.refreshModels();
+      if (result.success) {
+        recordOpen = false;
+        onModel(result.modelId);
+      }
+    } catch (e) {
+      if (stopRequested) notificationStore.add($_('simulator.record.stopped'), 'info');
+      else notificationStore.add($_('simulator.record.failed', { values: { target: shown, error: String(e) } }), 'error');
+    }
+  }
+
+  function stopRecording() {
+    stopRequested = true;
+    simulatorStore.stopRecording().catch(() => {});
+  }
+
+  async function exportModel(id) {
+    const name = modelName(modelOf($simulatorStore.models, id), $_, id);
+    try {
+      const path = await simulatorStore.exportModel(id);
+      if (path) notificationStore.add($_('simulator.models.exported', { values: { name, path } }), 'success');
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
     }
   }
 
@@ -305,8 +345,10 @@
         {:else}
           <h4 class="section-title first">{$_('simulator.field.model')}</h4>
           <ModelPicker models={$simulatorStore.models} icons={$simulatorStore.icons} devices={$simulatorStore.devices}
-            value={editing.model} busy={importingModels} on:change={(e) => onModel(e.detail)}
-            on:import={importModels} on:delete={(e) => deleteModel(e.detail)} />
+            value={editing.model} busy={importingModels || !!$simulatorStore.recording}
+            targets={recordableTargets($settingsStore)} recording={$simulatorStore.recording} bind:recordOpen
+            on:change={(e) => onModel(e.detail)} on:import={importModels} on:delete={(e) => deleteModel(e.detail)}
+            on:record={(e) => recordDevice(e.detail)} on:stop={stopRecording} on:export={(e) => exportModel(e.detail)} />
         {/if}
         <div class="grid">
           <div class="form-group">

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1442,14 +1442,31 @@
       "custom": "Eigenes",
       "import": "Modelle importieren…",
       "importTitle": "Modelle aus einer JSON-Datei hinzufügen oder aus einem ZIP mit ihren Symbolen oder ganzen Paketen samt aufgezeichneten Walks",
+      "record": "Gerät aufzeichnen…",
+      "recordTitle": "Ein echtes Gerät durchlaufen und seine Antworten als Modell behalten",
+      "exportModel": "Dieses Modell als Paket (ZIP) exportieren, um es zu bearbeiten oder weiterzugeben",
       "deleteModel": "Dieses eigene Modell löschen",
       "inUse": "{count, plural, one {# Gerät basiert auf diesem Modell: zuerst löschen} other {# Geräte basieren auf diesem Modell: zuerst löschen}}"
+    },
+    "record": {
+      "hint": "SnmpLens durchläuft das Gerät mit den Kennungen seines Ziels und behält jeden Wert, den es liefert, als Paket — außer seinen SNMP-Benutzern, Gruppen und Communities. Ein großes Gerät dauert eine Weile.",
+      "target": "Aufzuzeichnendes Gerät",
+      "name": "Modellname",
+      "vendor": "Hersteller",
+      "category": "Kategorie",
+      "start": "Aufzeichnen",
+      "stop": "Stoppen",
+      "progress": "{count, plural, one {# Objekt aufgezeichnet…} other {# Objekte aufgezeichnet…}}",
+      "description": "Aufgezeichnet von {target} am {date}.",
+      "stopped": "Die Aufzeichnung wurde gestoppt; nichts wurde behalten.",
+      "failed": "{target} konnte nicht aufgezeichnet werden: {error}"
     },
     "models": {
       "imported": "Modell „{name}“ importiert",
       "replaced": "Modell „{name}“ aktualisiert; laufende Geräte damit wurden neu gestartet",
       "failed": "{file}: {error}",
       "deleted": "Modell „{name}“ gelöscht",
+      "exported": "Modell „{name}“ nach {path} exportiert",
       "warning": {
         "iconSkipped": "{name}: Das Symbol „{detail}“ wurde nicht importiert — ein Symbol kommt in einem ZIP neben seinem Modell",
         "iconMissing": "{name}: Das Archiv enthält kein „{detail}“, das Modell hat also kein Symbol",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1442,14 +1442,31 @@
       "custom": "Custom",
       "import": "Import models…",
       "importTitle": "Add models from a JSON file, or from a ZIP holding their icons or whole packages with recorded walks",
+      "record": "Record a device…",
+      "recordTitle": "Walk a real device and keep what it answers as a model",
+      "exportModel": "Export this model as a package (ZIP), to edit or share it",
       "deleteModel": "Delete this custom model",
       "inUse": "{count, plural, one {# device is made from this model: delete it first} other {# devices are made from this model: delete them first}}"
+    },
+    "record": {
+      "hint": "SnmpLens walks the device with the identifiers its target uses and keeps every value it answers, as a package — its SNMP users, groups and communities excepted. A large device takes a while.",
+      "target": "Device to record",
+      "name": "Model name",
+      "vendor": "Vendor",
+      "category": "Category",
+      "start": "Record",
+      "stop": "Stop",
+      "progress": "{count, plural, one {# object recorded…} other {# objects recorded…}}",
+      "description": "Recorded from {target} on {date}.",
+      "stopped": "The recording was stopped; nothing was kept.",
+      "failed": "{target} could not be recorded: {error}"
     },
     "models": {
       "imported": "Model “{name}” imported",
       "replaced": "Model “{name}” updated; the devices running it have restarted",
       "failed": "{file}: {error}",
       "deleted": "Model “{name}” deleted",
+      "exported": "Model “{name}” exported to {path}",
       "warning": {
         "iconSkipped": "{name}: its icon “{detail}” was not imported — an icon travels in a ZIP, beside its model",
         "iconMissing": "{name}: the archive holds no “{detail}”, so the model has no icon",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1442,14 +1442,31 @@
       "custom": "Personalizado",
       "import": "Importar modelos…",
       "importTitle": "Añadir modelos desde un archivo JSON, o desde un ZIP con sus iconos o paquetes completos con walks grabados",
+      "record": "Grabar un equipo…",
+      "recordTitle": "Recorrer un equipo real y guardar lo que responde como modelo",
+      "exportModel": "Exportar este modelo como paquete (ZIP), para editarlo o compartirlo",
       "deleteModel": "Eliminar este modelo personalizado",
       "inUse": "{count, plural, one {# dispositivo se basa en este modelo: elimínelo primero} other {# dispositivos se basan en este modelo: elimínelos primero}}"
+    },
+    "record": {
+      "hint": "SnmpLens recorre el equipo con los identificadores de su destino y guarda cada valor que responde, como un paquete — salvo sus usuarios SNMP, grupos y comunidades. Un equipo grande tarda un rato.",
+      "target": "Equipo que grabar",
+      "name": "Nombre del modelo",
+      "vendor": "Fabricante",
+      "category": "Categoría",
+      "start": "Grabar",
+      "stop": "Detener",
+      "progress": "{count, plural, one {# objeto grabado…} other {# objetos grabados…}}",
+      "description": "Grabado desde {target} el {date}.",
+      "stopped": "La grabación se detuvo; no se guardó nada.",
+      "failed": "No se pudo grabar {target}: {error}"
     },
     "models": {
       "imported": "Modelo «{name}» importado",
       "replaced": "Modelo «{name}» actualizado; los dispositivos en marcha que lo usan se han reiniciado",
       "failed": "{file}: {error}",
       "deleted": "Modelo «{name}» eliminado",
+      "exported": "Modelo «{name}» exportado a {path}",
       "warning": {
         "iconSkipped": "{name}: su icono «{detail}» no se importó — un icono viaja en un ZIP, junto a su modelo",
         "iconMissing": "{name}: el archivo no contiene «{detail}», así que el modelo no tiene icono",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1442,14 +1442,31 @@
       "custom": "Personnalisé",
       "import": "Importer des modèles…",
       "importTitle": "Ajouter des modèles depuis un fichier JSON, ou depuis un ZIP qui contient leurs icônes ou des paquets complets avec des walks enregistrés",
+      "record": "Enregistrer un équipement…",
+      "recordTitle": "Parcourir un équipement réel et garder ce qu’il répond comme modèle",
+      "exportModel": "Exporter ce modèle en paquet (ZIP), pour le modifier ou le partager",
       "deleteModel": "Supprimer ce modèle personnalisé",
       "inUse": "{count, plural, one {# appareil est fait de ce modèle : supprimez-le d’abord} other {# appareils sont faits de ce modèle : supprimez-les d’abord}}"
+    },
+    "record": {
+      "hint": "SnmpLens parcourt l’équipement avec les identifiants de sa cible et garde chaque valeur qu’il répond, sous forme de paquet — sauf ses utilisateurs SNMP, ses groupes et ses communautés. Un gros équipement prend un moment.",
+      "target": "Équipement à enregistrer",
+      "name": "Nom du modèle",
+      "vendor": "Fabricant",
+      "category": "Catégorie",
+      "start": "Enregistrer",
+      "stop": "Arrêter",
+      "progress": "{count, plural, one {# objet enregistré…} other {# objets enregistrés…}}",
+      "description": "Enregistré depuis {target} le {date}.",
+      "stopped": "L’enregistrement a été arrêté ; rien n’a été gardé.",
+      "failed": "{target} n’a pas pu être enregistré : {error}"
     },
     "models": {
       "imported": "Modèle « {name} » importé",
       "replaced": "Modèle « {name} » mis à jour ; les appareils en marche qui l’utilisent ont redémarré",
       "failed": "{file} : {error}",
       "deleted": "Modèle « {name} » supprimé",
+      "exported": "Modèle « {name} » exporté vers {path}",
       "warning": {
         "iconSkipped": "{name} : son icône « {detail} » n’a pas été importée — une icône voyage dans un ZIP, à côté de son modèle",
         "iconMissing": "{name} : l’archive ne contient pas « {detail} », le modèle n’a donc pas d’icône",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1442,14 +1442,31 @@
       "custom": "自定义",
       "import": "导入型号…",
       "importTitle": "从 JSON 文件添加型号，或从 ZIP 添加：可附带图标，也可以是含录制 walk 的完整型号包",
+      "record": "录制设备…",
+      "recordTitle": "遍历一台真实设备，并将其应答保存为型号",
+      "exportModel": "将此型号导出为型号包（ZIP），以便编辑或分享",
       "deleteModel": "删除此自定义型号",
       "inUse": "{count, plural, other {有 # 台设备基于此型号：请先删除它们}}"
+    },
+    "record": {
+      "hint": "SnmpLens 使用其目标的标识符遍历该设备，并将其应答的每个值保存为型号包——其 SNMP 用户、组和团体除外。大型设备需要一些时间。",
+      "target": "要录制的设备",
+      "name": "型号名称",
+      "vendor": "厂商",
+      "category": "类别",
+      "start": "录制",
+      "stop": "停止",
+      "progress": "{count, plural, other {已录制 # 个对象…}}",
+      "description": "于 {date} 从 {target} 录制。",
+      "stopped": "录制已停止，未保存任何内容。",
+      "failed": "无法录制 {target}：{error}"
     },
     "models": {
       "imported": "已导入型号“{name}”",
       "replaced": "已更新型号“{name}”；使用它的运行中设备已重启",
       "failed": "{file}：{error}",
       "deleted": "已删除型号“{name}”",
+      "exported": "型号“{name}”已导出到 {path}",
       "warning": {
         "iconSkipped": "{name}：未导入其图标“{detail}”——图标需与型号一起放在 ZIP 中",
         "iconMissing": "{name}：压缩包中没有“{detail}”，因此该型号没有图标",

--- a/frontend/src/simulator/ModelPicker.svelte
+++ b/frontend/src/simulator/ModelPicker.svelte
@@ -3,6 +3,7 @@
   import { createEventDispatcher, tick } from 'svelte';
   import Icon from '../Icon.svelte';
   import ModelIcon from './ModelIcon.svelte';
+  import RecordForm from './RecordForm.svelte';
   import {
     filterModels, categoriesOf, categoryIcon, modelName, modelDescription, devicesOfModel,
   } from '../utils/simulator.js';
@@ -10,8 +11,9 @@
   /**
    * The model a new device is made from: a search over the catalogue and the
    * custom models, the categories to narrow it, and the chosen model described,
-   * with its icon when a custom model came with one. Importing and deleting a
-   * custom model are asked for here and done by the modal.
+   * with its icon when a custom model came with one. Importing, recording,
+   * exporting and deleting a custom model are asked for here and done by the
+   * modal.
    */
   export let models = [];
   /** The custom models' icons, by model ID. */
@@ -20,6 +22,12 @@
   export let devices = [];
   export let value = '';
   export let busy = false;
+  /** The targets a device may be recorded from. */
+  export let targets = [];
+  /** The recording under way — { objects } — or null. */
+  export let recording = null;
+  /** Whether the recording form is open; the modal closes it once a recording is kept. */
+  export let recordOpen = false;
 
   const dispatch = createEventDispatcher();
   let query = '';
@@ -77,7 +85,15 @@
       on:click={() => dispatch('import')}>
       <Icon name="upload" size={13} /> {$_('simulator.picker.import')}
     </button>
+    <button type="button" class="btn tertiary btn-small" disabled={busy && !recording} aria-expanded={recordOpen || !!recording}
+      title={$_('simulator.picker.recordTitle')} on:click={() => (recordOpen = !recordOpen)}>
+      <Icon name="circle-dot" size={13} /> {$_('simulator.picker.record')}
+    </button>
   </div>
+
+  {#if recordOpen || recording}
+    <RecordForm {targets} {recording} on:record on:stop on:close={() => (recordOpen = false)} />
+  {/if}
 
   <div class="chips" role="group" aria-label={$_('simulator.picker.categories')}>
     <button type="button" class="chip" class:active={!category} aria-pressed={!category} on:click={() => (category = '')}>
@@ -119,12 +135,18 @@
         <p class="sends"><Icon name="radio" size={12} /> {selected.notifications.map((n) => n.name).join(' · ')}</p>
       </div>
       {#if selected.custom}
-        <button type="button" class="icon-btn danger" class:confirming={confirmDelete === selected.id}
-          disabled={inUse > 0 || busy}
-          title={inUse > 0 ? $_('simulator.picker.inUse', { values: { count: inUse } }) : $_('simulator.picker.deleteModel')}
-          aria-label={$_('simulator.picker.deleteModel')} on:click={() => remove(selected)}>
-          {#if confirmDelete === selected.id}{$_('simulator.confirmDelete')}{:else}<Icon name="trash-2" size={14} />{/if}
-        </button>
+        <div class="detail-actions">
+          <button type="button" class="icon-btn" disabled={busy} title={$_('simulator.picker.exportModel')}
+            aria-label={$_('simulator.picker.exportModel')} on:click={() => dispatch('export', selected.id)}>
+            <Icon name="download" size={14} />
+          </button>
+          <button type="button" class="icon-btn danger" class:confirming={confirmDelete === selected.id}
+            disabled={inUse > 0 || busy}
+            title={inUse > 0 ? $_('simulator.picker.inUse', { values: { count: inUse } }) : $_('simulator.picker.deleteModel')}
+            aria-label={$_('simulator.picker.deleteModel')} on:click={() => remove(selected)}>
+            {#if confirmDelete === selected.id}{$_('simulator.confirmDelete')}{:else}<Icon name="trash-2" size={14} />{/if}
+          </button>
+        </div>
       {/if}
     </div>
   {/if}
@@ -140,8 +162,20 @@
 
   .bar {
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: 8px;
+  }
+
+  .detail-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .icon-btn:not(:disabled):not(.danger):hover {
+    color: var(--text-color);
+    background-color: var(--hover-overlay-medium);
   }
 
   .search {

--- a/frontend/src/simulator/RecordForm.svelte
+++ b/frontend/src/simulator/RecordForm.svelte
@@ -1,0 +1,171 @@
+<script>
+  import { _ } from 'svelte-i18n';
+  import { createEventDispatcher } from 'svelte';
+  import Icon from '../Icon.svelte';
+  import { CUSTOM_CATEGORIES } from '../utils/simulator.js';
+
+  /**
+   * Recording a real device as a model: which target, and what the model is
+   * called. SnmpLens reaches the device with what that target uses; the modal
+   * does the recording and says how far it has got.
+   */
+  /** The targets the settings list, offered first. */
+  export let targets = [];
+  /** The recording under way — { objects } — or null. */
+  export let recording = null;
+
+  const dispatch = createEventDispatcher();
+  let target = targets[0] || '';
+  let name = '';
+  let vendor = '';
+  let category = 'network';
+
+  $: ready = target.trim() !== '' && name.trim() !== '';
+
+  function submit() {
+    if (!ready || recording) return;
+    dispatch('record', { target: target.trim(), name: name.trim(), vendor: vendor.trim(), category });
+  }
+</script>
+
+<form class="record" on:submit|preventDefault={submit}>
+  <p class="hint"><Icon name="circle-dot" size={14} /> {$_('simulator.record.hint')}</p>
+  <div class="fields">
+    <div class="form-group">
+      <label for="sim-rec-target">{$_('simulator.record.target')}</label>
+      <input id="sim-rec-target" type="text" list="sim-rec-targets" spellcheck="false" autocomplete="off"
+        disabled={!!recording} bind:value={target} />
+      <datalist id="sim-rec-targets">
+        {#each targets as t (t)}<option value={t}></option>{/each}
+      </datalist>
+    </div>
+    <div class="form-group">
+      <label for="sim-rec-name">{$_('simulator.record.name')}</label>
+      <input id="sim-rec-name" type="text" maxlength="64" spellcheck="false" disabled={!!recording} bind:value={name} />
+    </div>
+    <div class="form-group">
+      <label for="sim-rec-vendor">{$_('simulator.record.vendor')}</label>
+      <input id="sim-rec-vendor" type="text" maxlength="64" spellcheck="false" disabled={!!recording} bind:value={vendor} />
+    </div>
+    <div class="form-group">
+      <label for="sim-rec-category">{$_('simulator.record.category')}</label>
+      <select id="sim-rec-category" disabled={!!recording} bind:value={category}>
+        {#each CUSTOM_CATEGORIES as c (c)}<option value={c}>{$_(`simulator.category.${c}`)}</option>{/each}
+      </select>
+    </div>
+  </div>
+  <div class="foot">
+    {#if recording}
+      <span class="progress" role="status">
+        <span class="spin"><Icon name="loader-circle" size={14} /></span>
+        {$_('simulator.record.progress', { values: { count: recording.objects } })}
+      </span>
+      <button type="button" class="btn secondary btn-small" on:click={() => dispatch('stop')}>
+        <Icon name="square" size={12} /> {$_('simulator.record.stop')}
+      </button>
+    {:else}
+      <button type="button" class="btn secondary btn-small" on:click={() => dispatch('close')}>{$_('common.cancel')}</button>
+      <button type="submit" class="btn btn-small" disabled={!ready}>
+        <Icon name="circle-dot" size={13} /> {$_('simulator.record.start')}
+      </button>
+    {/if}
+  </div>
+</form>
+
+<style>
+  .record {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 10px 12px 12px;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+  }
+
+  .hint {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.82em;
+    line-height: 1.4;
+    color: var(--text-muted);
+  }
+
+  .fields {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px 16px;
+    align-items: start;
+  }
+
+  .form-group {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    min-width: 0;
+  }
+
+  .form-group label {
+    margin-bottom: 5px;
+    font-size: 0.85em;
+    color: var(--text-light);
+  }
+
+  .form-group input,
+  .form-group select {
+    width: 100%;
+    padding: 7px 10px;
+    background-color: var(--bg-lighter-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+  }
+
+  .foot {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .foot .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .progress {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1;
+    font-size: 0.85em;
+    color: var(--text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .spin {
+    display: inline-flex;
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .spin {
+      animation: none;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .fields {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/stores/simulatorStore.js
+++ b/frontend/src/stores/simulatorStore.js
@@ -12,6 +12,9 @@ import {
   SimulatorSendTrap,
   ImportSimulatorModelsDialog,
   SimulatorDeleteModel,
+  SimulatorRecordDevice,
+  SimulatorCancelRecording,
+  SimulatorExportModelDialog,
   TrapListenerEngineID,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
@@ -26,7 +29,8 @@ import { EventsOn } from '../../wailsjs/runtime/runtime';
  * Nothing here is persisted; the lists are re-read.
  */
 function createSimulatorStore() {
-  const { subscribe, update } = writable({ models: [], icons: {}, devices: [], loaded: false });
+  // recording is the recording under way — { objects } kept so far — or null.
+  const { subscribe, update } = writable({ models: [], icons: {}, devices: [], recording: null, loaded: false });
   let subscribed = false;
 
   /** The devices, re-read: what the modal polls while it is open. */
@@ -60,6 +64,10 @@ function createSimulatorStore() {
       EventsOn('simulator:models', () => {
         Promise.all([refreshModels(), refresh()]).catch(() => {});
       });
+      // How far a recording has got, a few hundred objects at a time.
+      EventsOn('simulator:recording', (objects) => {
+        update((s) => (s.recording ? { ...s, recording: { objects } } : s));
+      });
     }
     return Promise.all([refreshModels(), refresh()]);
   }
@@ -80,6 +88,21 @@ function createSimulatorStore() {
     /** Asks for model files, JSON or ZIP, and imports them; resolves to what became of each. */
     importModels: async () => (await ImportSimulatorModelsDialog()) || [],
     removeModel: (id) => SimulatorDeleteModel(id),
+    /**
+     * Records a device as a model; resolves to what became of it, as an import
+     * does, and rejects when it was stopped or could not be walked.
+     */
+    record: async (req) => {
+      update((s) => ({ ...s, recording: { objects: 0 } }));
+      try {
+        return await SimulatorRecordDevice(req);
+      } finally {
+        update((s) => ({ ...s, recording: null }));
+      }
+    },
+    stopRecording: () => SimulatorCancelRecording(),
+    /** Writes a custom model to a ZIP the user names; resolves to where, or '' when cancelled. */
+    exportModel: async (id) => (await SimulatorExportModelDialog(id)) || '',
     /** The engine ID SnmpLens's own trap listener stands for, in hex. */
     listenerEngineId: async () => (await TrapListenerEngineID()) || '',
   };

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -13,6 +13,8 @@
  * destinations' communities filled in from the credential store by ID.
  */
 import { usesAuth, usesPriv } from './snmpSecurity.js';
+import { buildSnmpRequest } from './snmpParams.js';
+import { getEffectiveSettings, getTargetsAsArray } from './targets.js';
 
 /** The versions a device may answer, in the order they are shown. */
 export const SIM_VERSIONS = ['v1', 'v2c', 'v3'];
@@ -375,6 +377,29 @@ export function importReport(results) {
 /** The first model an import brought in, which the picker then selects. */
 export function firstImported(results) {
   return (results || []).find((r) => r.success)?.modelId || '';
+}
+
+/** The categories a recorded model may be filed under: Go's customCategories. */
+export const CUSTOM_CATEGORIES = Object.keys(CATEGORY_ICONS);
+
+/** The targets a device may be recorded from: the addresses the settings list. */
+export function recordableTargets(settings) {
+  return getTargetsAsArray(settings?.targets || '');
+}
+
+/**
+ * What SimulatorRecordDevice is asked: the device, reached as every request to
+ * that target is — its profile, its own overrides or the defaults, through
+ * getEffectiveSettings —, and what the model it makes is to be called.
+ */
+export function recordRequest(settings, target, { name, description = '', vendor = '', category = 'other' }) {
+  return {
+    ...buildSnmpRequest(getEffectiveSettings(settings, target), [target], ''),
+    name,
+    description,
+    vendor,
+    category,
+  };
 }
 
 /** What a device of the model can send, as Go lists it. */

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -66,6 +66,9 @@ const {
   devicesOfModel,
   importReport,
   firstImported,
+  CUSTOM_CATEGORIES,
+  recordableTargets,
+  recordRequest,
   preferredVersion,
   targetOf,
   addDeviceAsTarget,
@@ -384,8 +387,50 @@ for (const key of warningKeys) {
 for (const key of ['imported', 'replaced', 'failed', 'deleted']) {
   check(`en.json says simulator.models.${key}`, Boolean(en.simulator?.models?.[key]));
 }
-for (const key of ['search', 'all', 'categories', 'noMatch', 'custom', 'import', 'importTitle', 'deleteModel', 'inUse']) {
+for (const key of ['search', 'all', 'categories', 'noMatch', 'custom', 'import', 'importTitle', 'deleteModel', 'inUse',
+  'record', 'recordTitle', 'exportModel']) {
   check(`en.json says simulator.picker.${key}`, Boolean(en.simulator?.picker?.[key]));
 }
+for (const key of ['hint', 'target', 'name', 'vendor', 'category', 'start', 'stop', 'progress', 'description', 'stopped', 'failed']) {
+  check(`en.json says simulator.record.${key}`, Boolean(en.simulator?.record?.[key]));
+}
+check('en.json says simulator.models.exported', Boolean(en.simulator?.models?.exported));
+
+// A device is recorded with what its target uses — its profile, its own
+// overrides or the defaults — and the request carries exactly what Go's
+// SimulatorRecordRequest reads, SnmpRequest's fields included: a key Go does
+// not declare is dropped by encoding/json, and a field the renderer forgets
+// arrives as its zero value, a port of 0 among them.
+const goTags = (src, type) => {
+  const body = src.match(new RegExp(`type ${type} struct \\{([\\s\\S]*?)\\n\\}`))?.[1] || '';
+  return [...body.matchAll(/json:"([^",]+)/g)].map((m) => m[1]);
+};
+const recordGo = readFileSync(new URL('../../app_simrecord.go', import.meta.url), 'utf8');
+const paramsGo = readFileSync(new URL('../../pkg/snmp/params.go', import.meta.url), 'utf8');
+const declared = [...goTags(recordGo, 'SimulatorRecordRequest'), ...goTags(paramsGo, 'SnmpRequest')].sort();
+const recordSettings = {
+  targets: '10.0.0.9 # core\n10.0.0.10',
+  community: 'public', snmpVersion: 'v2c', port: 161, timeout: 3, retries: 1,
+  v3: { user: '', securityLevel: 'noAuthNoPriv', authProtocol: 'SHA', authPass: '', privProtocol: 'AES', privPass: '', contextName: '' },
+  targetOverrides: { '10.0.0.10': { community: 'lab-ro', snmpVersion: 'v1', port: 1161 } },
+  credentialProfiles: [],
+};
+const recordReq = recordRequest(recordSettings, '10.0.0.10', { name: 'Core', vendor: 'Acme', category: 'network', description: 'd' });
+check('a recording request carries what SimulatorRecordRequest reads, and nothing else',
+  declared.length >= 12 && JSON.stringify(Object.keys(recordReq).sort()) === JSON.stringify(declared),
+  `${Object.keys(recordReq).sort()} vs ${declared}`);
+check('and reaches the device with what its target uses',
+  recordReq.community === 'lab-ro' && recordReq.version === 'v1' && recordReq.port === 1161 &&
+  JSON.stringify(recordReq.targets) === '["10.0.0.10"]' && recordReq.name === 'Core', JSON.stringify(recordReq));
+check('the targets a device may be recorded from are the addresses the settings list',
+  JSON.stringify(recordableTargets(recordSettings)) === '["10.0.0.9","10.0.0.10"]' &&
+  recordableTargets({}).length === 0, JSON.stringify(recordableTargets(recordSettings)));
+
+// A recorded model is filed under a category Go accepts, and every one Go
+// accepts can be chosen.
+const goCategories = [...customCategories].sort();
+check('the categories a recording offers are those Go accepts',
+  goCategories.length > 0 && JSON.stringify([...CUSTOM_CATEGORIES].sort()) === JSON.stringify(goCategories),
+  `${CUSTOM_CATEGORIES} vs ${goCategories}`);
 
 process.exit(failures ? 1 : 0);

--- a/pkg/simulator/record.go
+++ b/pkg/simulator/record.go
@@ -1,0 +1,188 @@
+package simulator
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A Recording is what a device answered, written as a .snmprec walk while it is
+// walked: the walk of the package a real device's model is made of
+// (RecordedPackage). A recording is read back by the reader every walk goes
+// through (readWalk), so the two must agree, and the tests hold them together.
+type Recording struct {
+	walk    bytes.Buffer
+	objects int
+	leftOut int
+}
+
+// Add records one varbind the device answered. What a package never serves is
+// not written at all: the recorded device's snmp group, engine, USM users, VACM
+// groups and community table stay on the device rather than in a file somebody
+// may pass on. A varbind that holds no value — an exception, a NULL — is passed
+// over, and so is a type the format has no tag for.
+func (r *Recording) Add(pdu gosnmp.SnmpPDU) error {
+	id, err := parseOID(pdu.Name)
+	if err != nil {
+		return nil
+	}
+	if slices.ContainsFunc(agentSubtrees, id.hasPrefix) {
+		r.leftOut++
+		return nil
+	}
+	line, ok := snmprecOf(id, pdu)
+	if !ok {
+		return nil
+	}
+	if r.objects == MaxRecordedObjects {
+		return fmt.Errorf("the device answers more than %d objects, which is all a package keeps", MaxRecordedObjects)
+	}
+	r.walk.WriteString(line)
+	r.walk.WriteByte('\n')
+	r.objects++
+	return nil
+}
+
+// Objects is how many objects have been recorded.
+func (r *Recording) Objects() int { return r.objects }
+
+// LeftOut is how many of the agent's own objects were not.
+func (r *Recording) LeftOut() int { return r.leftOut }
+
+// snmprecTags are the tags snmpsim writes each type as.
+var snmprecTags = map[gosnmp.Asn1BER]int{
+	gosnmp.Integer: 2, gosnmp.OctetString: 4, gosnmp.ObjectIdentifier: 6, gosnmp.IPAddress: 64,
+	gosnmp.Counter32: 65, gosnmp.Gauge32: 66, gosnmp.TimeTicks: 67, gosnmp.Opaque: 68,
+	gosnmp.Counter64: 70, gosnmp.Uinteger32: 66,
+}
+
+// snmprecOf is one varbind as a line of a .snmprec: an OCTET STRING as text
+// when every octet is printable and in hex otherwise, so that the octets read
+// back are the octets the device sent.
+func snmprecOf(id oid, pdu gosnmp.SnmpPDU) (string, bool) {
+	tag, ok := snmprecTags[pdu.Type]
+	if !ok {
+		return "", false
+	}
+	name := strings.TrimPrefix(id.String(), ".")
+	switch pdu.Type {
+	case gosnmp.OctetString, gosnmp.Opaque:
+		b, ok := pdu.Value.([]byte)
+		if !ok {
+			return "", false // an Opaque gosnmp decoded as a float
+		}
+		if pdu.Type == gosnmp.OctetString && printable(b) {
+			return fmt.Sprintf("%s|%d|%s", name, tag, b), true
+		}
+		return fmt.Sprintf("%s|%dx|%s", name, tag, hex.EncodeToString(b)), true
+	case gosnmp.ObjectIdentifier:
+		s, _ := pdu.Value.(string)
+		o, err := parseOID(s)
+		if err != nil {
+			return "", false
+		}
+		return fmt.Sprintf("%s|%d|%s", name, tag, strings.TrimPrefix(o.String(), ".")), true
+	case gosnmp.IPAddress:
+		s, _ := pdu.Value.(string)
+		a, err := netip.ParseAddr(s)
+		if err != nil || !a.Is4() {
+			return "", false
+		}
+		return fmt.Sprintf("%s|%d|%s", name, tag, a), true
+	}
+	return fmt.Sprintf("%s|%d|%s", name, tag, gosnmp.ToBigInt(pdu.Value).String()), true
+}
+
+// printable reports whether every octet is printable ASCII, which is what a
+// .snmprec may carry as text.
+func printable(b []byte) bool {
+	for _, c := range b {
+		if c < 0x20 || c > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
+// RecordedModel is what a model made from a recording is called.
+type RecordedModel struct {
+	Name, Description, Vendor, Category string
+}
+
+// RecordedPackage is the package a recording makes: model.json, its id made
+// from its name and its system group left to the walk, which recorded the
+// device's own; and the walk. It is checked as any package is, so what it
+// returns is what an import would accept.
+func RecordedPackage(meta RecordedModel, r *Recording) ([]PackageFile, CustomModel, error) {
+	if r.objects == 0 {
+		return nil, CustomModel{}, errors.New("the device answered nothing to walk")
+	}
+	model, err := json.MarshalIndent(struct {
+		Kind          string `json:"kind"`
+		FormatVersion int    `json:"formatVersion"`
+		ID            string `json:"id"`
+		Name          string `json:"name"`
+		Description   string `json:"description,omitempty"`
+		Vendor        string `json:"vendor,omitempty"`
+		Category      string `json:"category,omitempty"`
+	}{CustomModelKind, CustomModelFormat, ModelSlug(meta.Name), strings.TrimSpace(meta.Name),
+		strings.TrimSpace(meta.Description), strings.TrimSpace(meta.Vendor), meta.Category}, "", "  ")
+	if err != nil {
+		return nil, CustomModel{}, err
+	}
+	files := []PackageFile{
+		{Name: PackageModelFile, Data: append(model, '\n')},
+		{Name: "walks/device.snmprec", Data: slices.Clone(r.walk.Bytes())},
+	}
+	m, _, err := ParseCustomPackage(files)
+	if err != nil {
+		return nil, CustomModel{}, err
+	}
+	return files, m, nil
+}
+
+// latinFolds are the accented letters a name is likely to hold, and what a slug
+// writes each as.
+var latinFolds = map[rune]string{
+	'à': "a", 'á': "a", 'â': "a", 'ä': "a", 'ã': "a", 'å': "a", 'ç': "c",
+	'è': "e", 'é': "e", 'ê': "e", 'ë': "e", 'ì': "i", 'í': "i", 'î': "i", 'ï': "i", 'ñ': "n",
+	'ò': "o", 'ó': "o", 'ô': "o", 'ö': "o", 'õ': "o", 'ø': "o",
+	'ù': "u", 'ú': "u", 'û': "u", 'ü': "u", 'ý': "y", 'ÿ': "y", 'æ': "ae", 'œ': "oe", 'ß': "ss",
+}
+
+// ModelSlug makes a custom model's id from a name: lower-case letters and
+// digits, one hyphen for whatever runs between them, the accents of a Latin
+// name taken off rather than made into hyphens.
+func ModelSlug(name string) string {
+	var b strings.Builder
+	gap := false
+	for _, r := range strings.ToLower(name) {
+		fold, ok := latinFolds[r]
+		switch {
+		case ok:
+			b.WriteString(fold)
+			gap = false
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			gap = false
+		case b.Len() > 0 && !gap:
+			b.WriteByte('-')
+			gap = true
+		}
+	}
+	slug := strings.TrimRight(b.String(), "-")
+	if len(slug) > 48 {
+		slug = strings.TrimRight(slug[:48], "-")
+	}
+	if slug == "" {
+		return "recorded-device"
+	}
+	return slug
+}

--- a/pkg/simulator/record_test.go
+++ b/pkg/simulator/record_test.go
@@ -1,0 +1,138 @@
+package simulator
+
+import (
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A recording reads back as what the device sent, type by type: an OCTET
+// STRING as text when it is printable and in hex when it is not — a MAC, a
+// line break, an accent —, every number at its full width. The agent's own
+// subtrees are never written, and what holds no value is passed over.
+func TestARecordingReadsBackAsWhatWasSent(t *testing.T) {
+	sent := []gosnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.1.1.0", Type: gosnmp.OctetString, Value: []byte("Linux router | edge")},
+		{Name: ".1.3.6.1.2.1.1.2.0", Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.8072.3.2.10"},
+		{Name: ".1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(8640000)},
+		{Name: ".1.3.6.1.2.1.1.4.0", Type: gosnmp.OctetString, Value: []byte("line one\nline two")},
+		{Name: ".1.3.6.1.2.1.1.5.0", Type: gosnmp.OctetString, Value: []byte{}},
+		{Name: ".1.3.6.1.2.1.1.6.0", Type: gosnmp.OctetString, Value: []byte("Salle serveur n°2")},
+		{Name: ".1.3.6.1.2.1.2.2.1.6.1", Type: gosnmp.OctetString, Value: []byte{0, 0x1a, 0x2b, 0x3c, 0x4d, 0x5e}},
+		{Name: ".1.3.6.1.2.1.2.2.1.8.1", Type: gosnmp.Integer, Value: -2},
+		{Name: ".1.3.6.1.2.1.2.2.1.10.1", Type: gosnmp.Counter32, Value: uint(4294967295)},
+		{Name: ".1.3.6.1.2.1.2.2.1.5.1", Type: gosnmp.Gauge32, Value: uint(1000000000)},
+		{Name: ".1.3.6.1.2.1.31.1.1.1.6.1", Type: gosnmp.Counter64, Value: uint64(18446744073709551615)},
+		{Name: ".1.3.6.1.2.1.4.20.1.1.10.0.0.1", Type: gosnmp.IPAddress, Value: "10.0.0.1"},
+		{Name: ".1.3.6.1.2.1.25.1.5.0", Type: gosnmp.Uinteger32, Value: uint32(3)},
+		{Name: ".1.3.6.1.4.1.2021.100.1.0", Type: gosnmp.Opaque, Value: []byte{0x9f, 0x78, 0x04, 0x41}},
+		// Never written.
+		{Name: ".1.3.6.1.2.1.11.1.0", Type: gosnmp.Counter32, Value: uint(123)},
+		{Name: ".1.3.6.1.6.3.18.1.1.1.2.112.117.98.108.105.99", Type: gosnmp.OctetString, Value: []byte("public")},
+		{Name: ".1.3.6.1.2.1.25.1.7.0", Type: gosnmp.NoSuchObject},
+		{Name: ".1.3.6.1.4.1.2021.100.2.0", Type: gosnmp.OpaqueFloat, Value: float32(1.5)},
+	}
+	want := map[string]typed{
+		".1.3.6.1.2.1.1.1.0":             {gosnmp.OctetString, "Linux router | edge"},
+		".1.3.6.1.2.1.1.2.0":             {gosnmp.ObjectIdentifier, ".1.3.6.1.4.1.8072.3.2.10"},
+		".1.3.6.1.2.1.1.3.0":             {gosnmp.TimeTicks, uint32(8640000)},
+		".1.3.6.1.2.1.1.4.0":             {gosnmp.OctetString, []byte("line one\nline two")},
+		".1.3.6.1.2.1.1.5.0":             {gosnmp.OctetString, ""},
+		".1.3.6.1.2.1.1.6.0":             {gosnmp.OctetString, []byte("Salle serveur n°2")},
+		".1.3.6.1.2.1.2.2.1.6.1":         {gosnmp.OctetString, []byte{0, 0x1a, 0x2b, 0x3c, 0x4d, 0x5e}},
+		".1.3.6.1.2.1.2.2.1.8.1":         {gosnmp.Integer, -2},
+		".1.3.6.1.2.1.2.2.1.10.1":        {gosnmp.Counter32, uint32(4294967295)},
+		".1.3.6.1.2.1.2.2.1.5.1":         {gosnmp.Gauge32, uint32(1000000000)},
+		".1.3.6.1.2.1.31.1.1.1.6.1":      {gosnmp.Counter64, uint64(18446744073709551615)},
+		".1.3.6.1.2.1.4.20.1.1.10.0.0.1": {gosnmp.IPAddress, "10.0.0.1"},
+		".1.3.6.1.2.1.25.1.5.0":          {gosnmp.Gauge32, uint32(3)},
+		".1.3.6.1.4.1.2021.100.1.0":      {gosnmp.Opaque, []byte{0x9f, 0x78, 0x04, 0x41}},
+	}
+	var r Recording
+	for _, pdu := range sent {
+		if err := r.Add(pdu); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if r.Objects() != len(want) || r.LeftOut() != 2 {
+		t.Errorf("%d recorded and %d left out, want %d and 2", r.Objects(), r.LeftOut(), len(want))
+	}
+	w, err := readWalk(r.walk.Bytes())
+	if err != nil || w.skipped != 0 {
+		t.Fatalf("%v, %d skipped, the first at %s", err, w.skipped, w.first)
+	}
+	got := map[string]typed{}
+	for _, e := range w.entries {
+		got[e.name] = typed{e.typ, e.val}
+	}
+	for name, want := range want {
+		if g, ok := got[name]; !ok || !reflect.DeepEqual(g, want) {
+			t.Errorf("%s reads back as %#v, want %#v", name, g, want)
+		}
+	}
+	if strings.Contains(r.walk.String(), "public") {
+		t.Error("the recorded device's community is in the walk")
+	}
+}
+
+// A recording makes a package an import would accept: its id from its name,
+// its identity from what the device answered.
+func TestAModelIsMadeFromARecording(t *testing.T) {
+	var r Recording
+	for _, pdu := range []gosnmp.SnmpPDU{
+		{Name: ".1.3.6.1.2.1.1.1.0", Type: gosnmp.OctetString, Value: []byte("Edge router, recorded")},
+		{Name: ".1.3.6.1.2.1.1.2.0", Type: gosnmp.ObjectIdentifier, Value: ".1.3.6.1.4.1.32473.1.7"},
+		{Name: ".1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(360000)},
+		{Name: ".1.3.6.1.4.1.32473.2.1.0", Type: gosnmp.Gauge32, Value: uint(41)},
+	} {
+		if err := r.Add(pdu); err != nil {
+			t.Fatal(err)
+		}
+	}
+	files, m, err := RecordedPackage(RecordedModel{Name: "Cœur de réseau — Bâtiment A", Vendor: "Acme",
+		Category: "network", Description: "Recorded in a test."}, &r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.ID() != "custom:coeur-de-reseau-batiment-a" || m.Name() != "Cœur de réseau — Bâtiment A" || m.m.enterprise != 32473 {
+		t.Errorf("%s, %q, enterprise %d", m.ID(), m.Name(), m.m.enterprise)
+	}
+	var names []string
+	for _, f := range files {
+		names = append(names, f.Name)
+	}
+	if !slices.Equal(names, []string{"model.json", "walks/device.snmprec"}) {
+		t.Errorf("the package holds %v", names)
+	}
+	tr, err := newTree(m.m.build(Identity{Name: "edge-01", Seed: 1}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := readAt(tr, "1.3.6.1.2.1.1.1.0", clock{}); got != "Edge router, recorded" {
+		t.Errorf("sysDescr answers %#v", got)
+	}
+	if _, _, err := RecordedPackage(RecordedModel{Name: "Nothing"}, &Recording{}); err == nil {
+		t.Error("a device that answered nothing made a model")
+	}
+}
+
+// A model's id is made from its name, and is always one a model file may give.
+func TestAModelSlugIsAnID(t *testing.T) {
+	for name, want := range map[string]string{
+		"Core switch":                "core-switch",
+		"  Édge — Router #2 ":        "edge-router-2",
+		"Straße Æther":               "strasse-aether",
+		"":                           "recorded-device",
+		"!!!":                        "recorded-device",
+		strings.Repeat("ab ", 30):    strings.TrimRight(strings.Repeat("ab-", 16), "-"),
+		"Catalyst 2960-24TT-L (lab)": "catalyst-2960-24tt-l-lab",
+	} {
+		got := ModelSlug(name)
+		if got != want || !customIDPattern.MatchString(got) {
+			t.Errorf("%q makes %q, want %q", name, got, want)
+		}
+	}
+}

--- a/pkg/snmp/record.go
+++ b/pkg/snmp/record.go
@@ -1,0 +1,48 @@
+package snmp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Record walks everything a device answers under each of roots and hands every
+// varbind to keep, in the order the device gives them: the recording a
+// simulator model is made from (app_simrecord.go). Unlike Walk it keeps the
+// varbinds as gosnmp decoded them — their types are what a recording is for —,
+// walks one device, and stops when ctx is done or keep returns an error.
+func (c *Client) Record(ctx context.Context, req SnmpRequest, roots []string, keep func(gosnmp.SnmpPDU) error) error {
+	if len(req.Targets) != 1 {
+		return errors.New("a recording walks one device")
+	}
+	g, err := c.newGoSNMP(req.Targets[0], req.Community, req.Version, req.Port, req.Timeout, req.Retries, req.V3)
+	if err != nil {
+		return err
+	}
+	g.Context = ctx
+	if err := g.Connect(); err != nil {
+		return fmt.Errorf("connect failed: %v", err)
+	}
+	defer g.Conn.Close()
+	walk := g.BulkWalk
+	if g.Version == gosnmp.Version1 {
+		walk = g.Walk
+	}
+	for _, root := range roots {
+		err := walk(root, func(pdu gosnmp.SnmpPDU) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			return keep(pdu)
+		})
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		if err != nil {
+			return fmt.Errorf("walking %s: %w", root, err)
+		}
+	}
+	return nil
+}

--- a/pkg/snmp/record_test.go
+++ b/pkg/snmp/record_test.go
@@ -1,0 +1,59 @@
+package snmp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"SnmpLens/pkg/simulator"
+	"SnmpLens/pkg/simulator/simtest"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A recording walks the whole device in both trees it answers in, keeps each
+// varbind as gosnmp decoded it, and stops when it is told to.
+func TestARecordingWalksTheWholeDevice(t *testing.T) {
+	d := simtest.Start(t, simulator.Device{Model: "cisco-catalyst-24", Name: "sw-rec"})
+	c := NewClient(context.Background())
+	req := SnmpRequest{Targets: []string{d.Target()}, Community: d.Community, Version: "v2c", Timeout: 2, Retries: 1}
+
+	var pdus []gosnmp.SnmpPDU
+	if err := c.Record(context.Background(), req, []string{".1.3.6.1", ".1.0.8802"}, func(p gosnmp.SnmpPDU) error {
+		pdus = append(pdus, p)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var name, lldp bool
+	for _, p := range pdus {
+		switch {
+		case p.Name == ".1.3.6.1.2.1.1.5.0":
+			v, _ := p.Value.([]byte)
+			name = p.Type == gosnmp.OctetString && string(v) == "sw-rec"
+		case strings.HasPrefix(p.Name, ".1.0.8802."):
+			lldp = true
+		}
+	}
+	if len(pdus) < 1000 || !name || !lldp {
+		t.Errorf("%d varbinds, sysName %v, LLDP %v", len(pdus), name, lldp)
+	}
+
+	// Stopped part of the way, it keeps nothing more and says why.
+	ctx, cancel := context.WithCancel(context.Background())
+	kept := 0
+	err := c.Record(ctx, req, []string{".1.3.6.1"}, func(gosnmp.SnmpPDU) error {
+		if kept++; kept == 100 {
+			cancel()
+		}
+		return nil
+	})
+	if !errors.Is(err, context.Canceled) || kept != 100 {
+		t.Errorf("stopped at 100: %v, %d kept", err, kept)
+	}
+
+	if err := c.Record(context.Background(), SnmpRequest{Targets: []string{"a", "b"}}, nil, nil); err == nil {
+		t.Error("a recording of two devices was walked")
+	}
+}


### PR DESCRIPTION
Stacked on #71 — review that one first; this diff is against its head.

## Why

#71 lets a package carry a recorded walk, but getting one meant leaving SnmpLens for `snmpwalk` or snmpsim's recorder. SnmpLens already reaches the device, with the right credentials: it can record it itself.

## What it does

- **Record a device…** in the model picker opens a small form: the device (any address, the settings' targets offered), the model's name, vendor and category. **Record** walks `.1.3.6.1`, then `.1.0.8802` for LLDP, shows how many objects have been kept, and can be stopped. The result is a custom model like an imported one; it becomes the new device's model, and a device made from it answers what the real one did, its counters moving (#71's rules).
- **Export** beside a custom model's delete button writes it to a ZIP chosen in a save dialog, as a package folder with its icon. It imports back as itself, which is how a recording is edited — add an `oids.json` beside the walk to make a recorded constant move, a `traps.json` for notifications — or passed on.

## How

- `snmp.Client.Record` walks one device and hands each varbind over as gosnmp decoded it — the types are what a recording is for, and `Walk`'s formatted results lose them. It honours a context, so a stop lands within one request.
- `simulator.Recording` writes each varbind as a `.snmprec` line: an OCTET STRING as text only when every octet is printable ASCII, in hex otherwise, so the octets read back are the octets sent. `RecordedPackage` makes `model.json` (id from the name via `ModelSlug`, accents folded; system group left to the walk) and checks the package as an import would.
- `SimulatorRecordDevice` walks outside the simulator's lock — a large device would hold it for minutes — with its own guard: one recording at a time, `SimulatorCancelRecording` stops it with nothing kept, progress goes out as `simulator:recording` every 250 objects. The model is kept through the same `keepModel` as an import (replacing a model of the same name, restarting its running devices).
- The renderer builds the request through `getEffectiveSettings`, as every request is, so a device is recorded with its target's profile or overrides.

## What never leaves the device

The agent's own subtrees — the snmp group and all of `1.3.6.1.6.3`: engine, USM user names, VACM groups, the community table — are **not written** to the recording at all, not merely left unserved. A recording is a file somebody may pass on. The count left out is reported like #71's `walkAgentOwned`.

## Tests

- `TestARecordingReadsBackAsWhatWasSent` round-trips every type through #71's reader: text, a MAC, a line break, an accent, full-width counters, an IP, an OID, Opaque; agent subtrees and exceptions left out; the community string absent from the file.
- `TestAModelIsMadeFromARecording`, `TestAModelSlugIsAnID`.
- `TestARecordingWalksTheWholeDevice` (`pkg/snmp`, against a simulated Catalyst): both trees, types kept, a stop after exactly 100 varbinds, one device only.
- `TestADeviceIsRecordedAsAModel` end to end: record a simulated Catalyst, make a device from the recording, compare sysDescr, sysObjectID, ifDescr and entPhysicalDescr with the source and check sysName is the copy's own; export and re-import. `TestALoneModelExportsAsAPackage`.
- `simulator.test.mjs`: `recordRequest` carries exactly `SimulatorRecordRequest`'s JSON tags (with `SnmpRequest` embedded) and resolves a target's overrides; the offered categories equal Go's `customCategories`.

Gates run locally: `go vet`, `staticcheck` 0.8.1, `go test -race ./...`, `npm test`, `svelte-check`, the Vite build. The demo refuses the two new calls, as it does the import. New strings in the five locales; README and CLAUDE.md describe recording and export.
