### PR TITLE
Move a simulated bench as a file, and duplicate or restart a device

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -686,6 +686,19 @@ apart, and `SimulatorCancelRecording` stops it with nothing kept. The request is
 model as a package FOLDER (`repackUnder`), its icon under the name the model gives it, which imports back as itself:
 that is how a recording is edited.
 
+**A bench moves as a file** (`app_simbench.go`, `pkg/simulator/devicefile.go`). A file of simulated devices holds one
+device or several as `FileDevice` — what makes the device the one it is, never its ID, engine ID or boots, so two
+imports of one file are two devices with two engines no manager confuses. The export ASKS every time whether to put
+the passwords in (the renderer's choice panel), writes `"secrets": "included"` or `"omitted"` into the file so nobody
+passes it on believing it holds none, and writes a file holding them 0600. The import is read as a model file is —
+`kind` and `formatVersion` first, then strictly — and makes every device NEW here: an ID, an engine and, when the
+address it names is taken, the one `suggestAddress` gives, said in a warning. A device that cannot be made here — a
+model this machine lacks, an address off loopback — is refused ON ITS OWN, and the others are kept. A file that says
+its passwords were left out has any it holds anyway ignored — what a file says of itself is what is believed — and
+its devices are checked by `ValidateWithoutSecrets`, everything but the secrets, and KEPT without them: starting one
+fails naming what it lacks until the editor gives it. Duplicating is the same making of a new device, from a device
+and with its passwords; restarting is a stop and a start, so the boots rise and coldStart goes out as on any start.
+
 **What only a notification carries** (`Object.NotifyOnly`). An iDRAC alert carries eleven objects its MIB makes
 accessible-for-notify (RFC 2578 7.3) — a message ID, the message, the service tag — and no request may read them.
 They are kept beside the tree rather than in it: a GET answers `noSuchObject`, a walk passes them by, and

--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ Everything SnmpLens writes lives in the user config directory:
 
 ---
 
+## Simulated Devices
+
+The **Simulator** indicator in the header opens the simulated devices: SNMP agents running on this machine, at loopback addresses only — `127.x.x.x` or `::1` — answering v1, v2c and v3 (the whole USM) from a catalogue of models, or from your own (below). A device can be started and stopped, **restarted** (uptime and counters from zero, and `coldStart` if it sends one on starting), **duplicated**, made to send any of its notifications on demand, and **added as a target** in one click, with its port and identifiers.
+
+A bench moves as a file. **Export all…**, or a device's export button, writes JSON, and SnmpLens asks every time whether to put the passwords in it — the communities and passphrases, which otherwise stay in the system keychain. The file says which (`"secrets": "included"` or `"omitted"`). **Import devices…** makes each device new on this machine: its own ID and engine ID, and another address when its own is taken. A device that cannot be made here — of a custom model that is not installed, say — is refused on its own; devices imported without their passwords start once they are given them in the editor.
+
+---
+
 ## Custom Simulator Models
 
 The simulator's catalogue can be extended with models of your own: a JSON file saying what a device answers, imported from the model picker (**Import models…**) on its own, or in a ZIP archive that also carries the model's icon — PNG, JPEG or GIF, up to 512 × 512 px. An archive may hold several models. A model imported again replaces the one kept, and the devices made from it restart.

--- a/app_simbench.go
+++ b/app_simbench.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"slices"
+	"strconv"
+	"strings"
+
+	"SnmpLens/pkg/secrets"
+	"SnmpLens/pkg/simulator"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// A bench of simulated devices as a file (pkg/simulator, DeviceFile): exported
+// with or without the passwords — the renderer asks, and the file says which —
+// and imported as NEW devices of this machine, each with an ID, an engine and,
+// when the address it names is taken, an address of its own. Duplicating a
+// device is the same making of a new one, from a device rather than a file.
+
+// SimulatorDeviceImportResult is what became of one device of a file.
+type SimulatorDeviceImportResult struct {
+	// Name is the device's, or the file's when the file as a whole was refused.
+	Name     string                  `json:"name"`
+	ID       string                  `json:"id,omitempty"`
+	Success  bool                    `json:"success"`
+	Error    string                  `json:"error,omitempty"`
+	Warnings []SimulatorModelWarning `json:"warnings"`
+}
+
+// SimulatorExportDevicesDialog writes simulated devices — those named, or every
+// one when none is — to a file the user names, with their passwords only when
+// withSecrets says so. It returns where the file went, or "" when the dialog was
+// cancelled.
+func (a *App) SimulatorExportDevicesDialog(ids []string, withSecrets bool) (string, error) {
+	data, name, err := a.exportDevices(ids, withSecrets)
+	if err != nil {
+		return "", err
+	}
+	if a.ctx == nil {
+		return "", fmt.Errorf("no window")
+	}
+	dest, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+		Title:           "Export simulated devices",
+		DefaultFilename: name,
+		Filters:         []runtime.FileFilter{{DisplayName: "Simulated devices (JSON)", Pattern: "*.json"}},
+	})
+	if err != nil || dest == "" {
+		return "", err
+	}
+	if !strings.EqualFold(filepath.Ext(dest), ".json") {
+		dest += ".json"
+	}
+	// A file holding passwords is its owner's alone to read.
+	perm := os.FileMode(0o644)
+	if withSecrets {
+		perm = 0o600
+	}
+	if err := os.WriteFile(dest, data, perm); err != nil {
+		return "", fmt.Errorf("writing %s: %w", filepath.Base(dest), err)
+	}
+	return dest, nil
+}
+
+// exportDevices is the file the devices are exported as, and the name it is
+// offered under.
+func (a *App) exportDevices(ids []string, withSecrets bool) ([]byte, string, error) {
+	s := a.sim
+	if s == nil {
+		return nil, "", errNoSimulator
+	}
+	s.mu.Lock()
+	var chosen []simulator.Device
+	for _, d := range s.devices {
+		if len(ids) == 0 || slices.Contains(ids, d.ID) {
+			chosen = append(chosen, d)
+		}
+	}
+	s.mu.Unlock()
+	switch {
+	case len(chosen) == 0:
+		return nil, "", errors.New("there is no simulated device to export")
+	case len(ids) > 0 && len(chosen) != len(ids):
+		return nil, "", errors.New("a device to export is no longer there")
+	}
+	if withSecrets {
+		for i := range chosen {
+			sec, err := a.simulatorSecrets(chosen[i].ID)
+			if err != nil {
+				return nil, "", err
+			}
+			chosen[i] = chosen[i].WithSecrets(sec)
+		}
+	}
+	data, err := simulator.ExportDevices(chosen, withSecrets)
+	name := "simulated-devices.json"
+	if len(chosen) == 1 {
+		name = simulator.Slug(chosen[0].Name, "simulated-device") + ".json"
+	}
+	return data, name, err
+}
+
+// ImportSimulatedDevicesDialog asks for files of simulated devices and imports
+// them.
+func (a *App) ImportSimulatedDevicesDialog() ([]SimulatorDeviceImportResult, error) {
+	if a.ctx == nil {
+		return nil, fmt.Errorf("no window")
+	}
+	paths, err := runtime.OpenMultipleFilesDialog(a.ctx, runtime.OpenDialogOptions{
+		Title:   "Import simulated devices",
+		Filters: []runtime.FileFilter{{DisplayName: "Simulated devices (JSON)", Pattern: "*.json"}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Cancelled is an empty list, never null: the caller reports each result.
+	results := []SimulatorDeviceImportResult{}
+	for _, p := range paths {
+		raw, err := readAtMost(p, simulator.MaxDeviceFileBytes)
+		if err != nil {
+			results = append(results, SimulatorDeviceImportResult{Name: filepath.Base(p), Error: err.Error(),
+				Warnings: []SimulatorModelWarning{}})
+			continue
+		}
+		results = append(results, a.importDevices(filepath.Base(p), raw)...)
+	}
+	return results, nil
+}
+
+// importDevices imports the devices of a file as new devices of this machine:
+// each is given an ID, an engine and, when another device answers where it
+// says, an address of its own. A device that cannot be made here — a model this
+// machine does not have, an address off loopback — is refused on its own, and
+// the others are kept. None is started.
+//
+// A file that says it left the passwords out has any it holds anyway ignored:
+// what a file says of itself is what is believed. Its devices are checked for
+// everything but their secrets, and kept to be given them.
+func (a *App) importDevices(file string, raw []byte) []SimulatorDeviceImportResult {
+	fail := func(err error) []SimulatorDeviceImportResult {
+		return []SimulatorDeviceImportResult{{Name: file, Error: err.Error(), Warnings: []SimulatorModelWarning{}}}
+	}
+	s := a.sim
+	if s == nil {
+		return fail(errNoSimulator)
+	}
+	if a.secrets == nil {
+		return fail(errors.New("the credential store is unavailable, so a simulated device cannot keep its community and passphrases"))
+	}
+	f, err := simulator.ParseDeviceFile(raw)
+	if err != nil {
+		return fail(err)
+	}
+	withSecrets := f.Secrets == simulator.SecretsIncluded
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	taken := make([]string, 0, len(s.devices)+len(f.Devices))
+	for _, d := range s.devices {
+		taken = append(taken, d.Listen())
+	}
+	results := make([]SimulatorDeviceImportResult, 0, len(f.Devices))
+	next := slices.Clone(s.devices)
+	var stored []string
+	for _, fd := range f.Devices {
+		d := fd.Device()
+		res := SimulatorDeviceImportResult{Name: d.Name, Warnings: []SimulatorModelWarning{}}
+		refuse := func(err error) {
+			res.Error = err.Error()
+			results = append(results, res)
+		}
+		if !withSecrets {
+			d = d.WithoutSecrets()
+		}
+		d.ID = simulator.NewDeviceID()
+		engineID, err := simulator.NewEngineID(d.Model, d.ID)
+		if err != nil {
+			refuse(err)
+			continue
+		}
+		d.EngineID, d.EngineBoots = engineID, 0
+		for i := range d.Traps.Destinations {
+			if d.Traps.Destinations[i].ID == "" {
+				d.Traps.Destinations[i].ID = simulator.NewDestinationID()
+			}
+		}
+		if slices.Contains(taken, d.Listen()) {
+			was := d.Listen()
+			moved := suggestAddress(goruntime.GOOS, taken, canBindUDP)
+			d.Address, d.Port = moved.Address, moved.Port
+			res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "addressMoved",
+				Detail: was + " → " + net.JoinHostPort(d.Address, strconv.Itoa(d.Port))})
+		}
+		check := d.Validate
+		if !withSecrets {
+			check = d.ValidateWithoutSecrets
+		}
+		if err := check(); err != nil {
+			refuse(err)
+			continue
+		}
+		if withSecrets {
+			sec, err := json.Marshal(d.Secrets())
+			if err != nil {
+				refuse(err)
+				continue
+			}
+			if err := a.secrets.Set(secrets.SimulatorDeviceRef(d.ID), string(sec)); err != nil {
+				refuse(fmt.Errorf("keeping the device's credentials: %w", err))
+				continue
+			}
+			stored = append(stored, d.ID)
+		} else if d.Validate() != nil {
+			// Complete without secrets is a device that needs none.
+			res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "noSecrets"})
+		}
+		taken = append(taken, d.Listen())
+		next = append(next, d.WithoutSecrets())
+		res.ID, res.Success = d.ID, true
+		results = append(results, res)
+	}
+	if len(next) == len(s.devices) {
+		return results
+	}
+	if err := s.write(next); err != nil {
+		for _, id := range stored {
+			_ = a.secrets.Delete(secrets.SimulatorDeviceRef(id))
+		}
+		for i := range results {
+			if results[i].Success {
+				results[i].Success, results[i].ID = false, ""
+				results[i].Error = fmt.Sprintf("saving the simulated devices: %v", err)
+			}
+		}
+		return results
+	}
+	s.devices = next
+	a.emitSimulatorChanged()
+	return results
+}
+
+// SimulatorDuplicateDevice makes a copy of a device under the name given — the
+// renderer's, in the user's language —, with an ID, an engine and an address of
+// its own, and the passwords of the one it copies. The copy is not started.
+func (a *App) SimulatorDuplicateDevice(id, name string) (SimulatedDevice, error) {
+	s := a.sim
+	if s == nil {
+		return SimulatedDevice{}, errNoSimulator
+	}
+	if a.secrets == nil {
+		return SimulatedDevice{}, errors.New("the credential store is unavailable, so a simulated device cannot keep its community and passphrases")
+	}
+	sec, err := a.simulatorSecrets(id)
+	if err != nil {
+		return SimulatedDevice{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.index(id)
+	if i < 0 {
+		return SimulatedDevice{}, fmt.Errorf("there is no simulated device %q", id)
+	}
+	d := s.devices[i].WithSecrets(sec)
+	d.Name = clipText(strings.TrimSpace(name), simulator.MaxDeviceName)
+	d.ID = simulator.NewDeviceID()
+	if d.EngineID, err = simulator.NewEngineID(d.Model, d.ID); err != nil {
+		return SimulatedDevice{}, err
+	}
+	d.EngineBoots = 0
+	taken := make([]string, len(s.devices))
+	for j, other := range s.devices {
+		taken[j] = other.Listen()
+	}
+	at := suggestAddress(goruntime.GOOS, taken, canBindUDP)
+	d.Address, d.Port = at.Address, at.Port
+	// A copy of a device still waiting for its passwords waits for them too.
+	if err := d.Validate(); err != nil && d.ValidateWithoutSecrets() != nil {
+		return SimulatedDevice{}, err
+	}
+	raw, err := json.Marshal(d.Secrets())
+	if err != nil {
+		return SimulatedDevice{}, err
+	}
+	ref := secrets.SimulatorDeviceRef(d.ID)
+	if err := a.secrets.Set(ref, string(raw)); err != nil {
+		return SimulatedDevice{}, fmt.Errorf("keeping the device's credentials: %w", err)
+	}
+	next := append(slices.Clone(s.devices), d.WithoutSecrets())
+	if err := s.write(next); err != nil {
+		_ = a.secrets.Delete(ref)
+		return SimulatedDevice{}, fmt.Errorf("saving the simulated devices: %w", err)
+	}
+	s.devices = next
+	a.emitSimulatorChanged()
+	return s.view(next[len(next)-1]), nil
+}
+
+// SimulatorRestartDevice restarts a running device as a device reboots: its
+// uptime and counters from zero, its boots one higher — which tells a manager
+// holding its clock to resynchronise —, and coldStart sent if it sends one when
+// it starts.
+func (a *App) SimulatorRestartDevice(id string) error {
+	s := a.sim
+	if s == nil {
+		return errNoSimulator
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.index(id)
+	if i < 0 {
+		return fmt.Errorf("there is no simulated device %q", id)
+	}
+	if !s.fleet.Stop(id) {
+		return fmt.Errorf("%q is not running", s.devices[i].Name)
+	}
+	err := a.startSimulatedLocked(s, i)
+	a.emitSimulatorChanged()
+	return err
+}

--- a/app_simbench_test.go
+++ b/app_simbench_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// freeSimPort is a UDP port on 127.0.0.1 that nothing holds right now.
+func freeSimPort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no UDP socket: %v", err)
+	}
+	defer c.Close()
+	return c.LocalAddr().(*net.UDPAddr).Port
+}
+
+func listedDevice(a *App, id string) SimulatedDevice {
+	for _, d := range a.ListSimulatedDevices() {
+		if d.ID == id {
+			return d
+		}
+	}
+	return SimulatedDevice{}
+}
+
+// A bench exported without its passwords holds none of them and says so;
+// exported with them it holds them and says that — and neither holds what is
+// this machine's: the device's ID, its engine, its boots.
+func TestABenchIsExportedWithOrWithoutItsPasswords(t *testing.T) {
+	a, _ := simApp(t)
+	saved, err := a.SimulatorSaveDevice(simDevice())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare, name, err := a.exportDevices(nil, false)
+	if err != nil || name != "srv-01.json" {
+		t.Fatalf("%q, %v", name, err)
+	}
+	full, _, err := a.exportDevices([]string{saved.ID}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range simSecrets {
+		if bytes.Contains(bare, []byte(secret)) {
+			t.Errorf("exported without passwords, the file holds %q", secret)
+		}
+		if !bytes.Contains(full, []byte(secret)) {
+			t.Errorf("exported with passwords, the file lacks %q", secret)
+		}
+	}
+	if !bytes.Contains(bare, []byte(`"secrets": "omitted"`)) || !bytes.Contains(full, []byte(`"secrets": "included"`)) {
+		t.Error("a file does not say whether it holds the passwords")
+	}
+	for _, mine := range []string{saved.ID, saved.EngineID, "engineBoots"} {
+		if bytes.Contains(full, []byte(mine)) {
+			t.Errorf("the file holds %s", mine)
+		}
+	}
+	if _, _, err := a.exportDevices([]string{"gone"}, false); err == nil {
+		t.Error("a device that is not there was exported")
+	}
+}
+
+// Imported, a bench is new devices of this machine: IDs and engines of their
+// own, another address for one whose own is taken, their passwords in the
+// store — and they answer.
+func TestABenchIsImportedAsNewDevices(t *testing.T) {
+	a, _ := simApp(t)
+	original := startSimulated(t, a, simDevice())
+	full, _, err := a.exportDevices(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := a.importDevices("bench.json", full)
+	if len(res) != 1 || !res[0].Success || len(res[0].Warnings) != 1 || res[0].Warnings[0].Key != "addressMoved" {
+		t.Fatalf("%+v", res)
+	}
+	imported := listedDevice(a, res[0].ID)
+	if imported.ID == "" || imported.ID == original.ID || imported.EngineID == original.EngineID || imported.EngineBoots != 0 ||
+		(imported.Address == original.Address && imported.Port == original.Port) {
+		t.Fatalf("imported as %+v, from %+v", imported, original)
+	}
+	creds, err := a.SimulatorDeviceCredentials(imported.ID)
+	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].AuthPass != "auth-s3cr3t" {
+		t.Fatalf("credentials: %+v, %v", creds, err)
+	}
+	if err := a.SimulatorStartDevice(imported.ID); err != nil {
+		t.Fatal(err)
+	}
+	if v := simGet(t, listedDevice(a, imported.ID), "s3cr3t-community", ".1.3.6.1.2.1.1.5.0"); string(v.Value.([]byte)) != "srv-01" {
+		t.Errorf("the imported device answers sysName %v", v.Value)
+	}
+}
+
+// A bench exported without its passwords is imported all the same, and says
+// so; a device of it starts once it is given them.
+func TestABenchWithoutPasswordsIsImportedToBeCompleted(t *testing.T) {
+	a, _ := simApp(t)
+	saved, err := a.SimulatorSaveDevice(simDevice())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare, _, err := a.exportDevices(nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.SimulatorDeleteDevice(saved.ID); err != nil {
+		t.Fatal(err)
+	}
+	res := a.importDevices("bench.json", bare)
+	if len(res) != 1 || !res[0].Success ||
+		!slices.ContainsFunc(res[0].Warnings, func(w SimulatorModelWarning) bool { return w.Key == "noSecrets" }) {
+		t.Fatalf("%+v", res)
+	}
+	id := res[0].ID
+	if err := a.SimulatorStartDevice(id); err == nil || !strings.Contains(err.Error(), "community") {
+		t.Fatalf("a device with no community started, or said %v", err)
+	}
+	d := simDevice()
+	d.ID, d.Address, d.Port = id, "127.0.0.1", freeSimPort(t)
+	d.Traps.Destinations[0].ID = listedDevice(a, id).Traps.Destinations[0].ID
+	if _, err := a.SimulatorSaveDevice(d); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.SimulatorStartDevice(id); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A file is refused as a whole when it is not one of devices, and a device of
+// it on its own when it cannot be made here; the others are kept.
+func TestADeviceFileIsReadWithCare(t *testing.T) {
+	a, _ := simApp(t)
+	for _, c := range []struct{ raw, want string }{
+		{`{"kind": "snmplens-simulator-model", "formatVersion": 1}`, "not a file of simulated devices"},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 2}`, "format version 2"},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "omitted", "devices": [], "extra": 1}`, `unknown field "extra"`},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "maybe", "devices": [{}]}`, `"secrets"`},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "omitted", "devices": []}`, "no device"},
+		{`not json`, "line 1"},
+	} {
+		res := a.importDevices("f.json", []byte(c.raw))
+		if len(res) != 1 || res[0].Success || res[0].Name != "f.json" || !strings.Contains(res[0].Error, c.want) {
+			t.Errorf("%s: %+v, want %q", c.raw, res, c.want)
+		}
+	}
+	port := freeSimPort(t)
+	raw := fmt.Sprintf(`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "included", "devices": [
+		{"name": "gone", "model": "custom:not-here", "address": "127.0.0.1", "port": %[1]d, "versions": ["v2c"], "community": "public", "traps": {}},
+		{"name": "outside", "model": "linux-server", "address": "192.0.2.1", "port": 161, "versions": ["v2c"], "community": "public", "traps": {}},
+		{"name": "kept", "model": "linux-server", "address": "127.0.0.1", "port": %[1]d, "versions": ["v2c"], "community": "public", "traps": {}}]}`, port)
+	res := a.importDevices("bench.json", []byte(raw))
+	if len(res) != 3 || res[0].Success || !strings.Contains(res[0].Error, "not a device model") ||
+		res[1].Success || res[1].Error == "" || res[2].Name != "kept" || !res[2].Success {
+		t.Fatalf("%+v", res)
+	}
+	if got := a.ListSimulatedDevices(); len(got) != 1 || got[0].Name != "kept" {
+		t.Errorf("the devices are %+v", got)
+	}
+}
+
+// A device duplicated is a device of its own — ID, engine and address — with
+// the passwords of the one it copies; a running device restarted comes back
+// with one boot more, and a stopped one is not restarted.
+func TestADeviceIsDuplicatedAndRestarted(t *testing.T) {
+	a, _ := simApp(t)
+	src := startSimulated(t, a, simDevice())
+	dup, err := a.SimulatorDuplicateDevice(src.ID, "srv-01 (copy)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dup.ID == src.ID || dup.EngineID == src.EngineID || dup.Running || dup.Name != "srv-01 (copy)" ||
+		(dup.Address == src.Address && dup.Port == src.Port) {
+		t.Fatalf("duplicated as %+v", dup)
+	}
+	creds, err := a.SimulatorDeviceCredentials(dup.ID)
+	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].PrivPass != "priv-s3cr3t" {
+		t.Errorf("the copy's credentials: %+v, %v", creds, err)
+	}
+	boots := listedDevice(a, src.ID).EngineBoots
+	if err := a.SimulatorRestartDevice(src.ID); err != nil {
+		t.Fatal(err)
+	}
+	if now := listedDevice(a, src.ID); !now.Running || now.EngineBoots != boots+1 {
+		t.Errorf("restarted: running %v, boots %d after %d", now.Running, now.EngineBoots, boots)
+	}
+	if err := a.SimulatorRestartDevice(dup.ID); err == nil {
+		t.Error("a stopped device was restarted")
+	}
+}

--- a/frontend/screenshots/bridge/dynamic.js
+++ b/frontend/screenshots/bridge/dynamic.js
@@ -405,6 +405,10 @@ const DEMO_ONLY = {
   SimulatorDeleteModel: 'Deleting a simulator model removes its file from your configuration directory.',
   SimulatorRecordDevice: 'Recording a device walks a real device on your network and writes the model to your configuration directory.',
   SimulatorExportModelDialog: 'Exporting a simulator model opens the operating system’s file dialog and writes a file.',
+  ImportSimulatedDevicesDialog: 'Importing simulated devices opens the operating system’s file dialog, and writes the devices to your configuration directory and their passwords to the system keychain.',
+  SimulatorExportDevicesDialog: 'Exporting simulated devices opens the operating system’s file dialog and writes a file.',
+  SimulatorDuplicateDevice: 'Duplicating a simulated device writes the copy to your configuration directory, and its passwords to the system keychain.',
+  SimulatorRestartDevice: 'Restarting a simulated device opens a UDP socket on this machine.',
 };
 
 for (const [name, why] of Object.entries(DEMO_ONLY)) {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -9,7 +9,7 @@
   import {
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
-    modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets,
+    modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets, deviceImportReport,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
@@ -62,6 +62,10 @@
   // The editor first, the dialog after: Escape backs out one level at a time.
   function onWindowKey(event) {
     if (event.key !== 'Escape') return;
+    if (exportIds) {
+      exportIds = null;
+      return;
+    }
     if (editing) {
       editing = null;
       return;
@@ -318,6 +322,70 @@
       simulatorStore.refresh().catch(() => {});
     }
   }
+
+  /** The devices whose export is being asked about — every one when empty — or null. */
+  let exportIds = null;
+  let benchBusy = false;
+
+  // What an export holds is asked every time: the passwords stay in the
+  // keychain unless the operator says to put them in the file.
+  function askExport(ids) {
+    exportIds = ids;
+  }
+
+  async function exportDevices(ids, withSecrets) {
+    exportIds = null;
+    benchBusy = true;
+    try {
+      const path = await simulatorStore.exportDevices(ids, withSecrets);
+      if (path) notificationStore.add($_('simulator.export.done', { values: { path } }), 'success');
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      benchBusy = false;
+    }
+  }
+
+  async function importDevices() {
+    benchBusy = true;
+    try {
+      const results = await simulatorStore.importDevices();
+      for (const line of deviceImportReport(results)) {
+        notificationStore.add($_(line.key, { values: line.values }), line.level);
+      }
+      await simulatorStore.refresh();
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      benchBusy = false;
+    }
+  }
+
+  async function duplicate(device) {
+    busy = { ...busy, [device.id]: true };
+    try {
+      const copy = await simulatorStore.duplicate(device.id, $_('simulator.copyName', { values: { name: device.name } }));
+      notificationStore.add($_('simulator.duplicated', { values: { name: device.name, copy: copy.name } }), 'success');
+      await simulatorStore.refresh();
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+    }
+  }
+
+  async function restart(device) {
+    busy = { ...busy, [device.id]: true };
+    try {
+      await simulatorStore.restart(device.id);
+      notificationStore.add($_('simulator.restarted', { values: { name: device.name } }), 'success');
+    } catch (e) {
+      notificationStore.add($_('simulator.startFailed', { values: { name: device.name, error: String(e) } }), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+      simulatorStore.refresh().catch(() => {});
+    }
+  }
 </script>
 
 <svelte:window on:keydown={onWindowKey} />
@@ -526,6 +594,22 @@
       </footer>
     {:else}
       <div class="sim-body">
+        {#if exportIds}
+          <div class="export-choice" role="alertdialog" aria-labelledby="sim-export-title" aria-describedby="sim-export-hint">
+            <h3 id="sim-export-title">
+              <Icon name="download" size={16} />
+              {$_('simulator.export.title', { values: { count: exportIds.length || $simulatorStore.devices.length } })}
+            </h3>
+            <p id="sim-export-hint"><Icon name="key-round" size={14} /> {$_('simulator.export.hint')}</p>
+            <div class="export-actions">
+              <button class="btn secondary btn-small" on:click={() => (exportIds = null)}>{$_('common.cancel')}</button>
+              <button class="btn secondary btn-small warn" on:click={() => exportDevices(exportIds, true)}>
+                <Icon name="triangle-alert" size={13} /> {$_('simulator.export.with')}
+              </button>
+              <button class="btn btn-small" on:click={() => exportDevices(exportIds, false)}>{$_('simulator.export.without')}</button>
+            </div>
+          </div>
+        {/if}
         <p class="intro">{$_('simulator.intro')}</p>
         {#if $simulatorStore.devices.length === 0}
           <div class="empty">
@@ -589,6 +673,20 @@
                   <button class="btn tertiary btn-small" title={$_('simulator.addAsTargetTitle')} on:click={() => addAsTarget(d)}>
                     <Icon name="target" size={13} /> {$_('simulator.addAsTarget')}
                   </button>
+                  {#if d.running}
+                    <button class="icon-btn" disabled={busy[d.id]} title={$_('simulator.restart')} aria-label={$_('simulator.restart')}
+                      on:click={() => restart(d)}>
+                      <Icon name="refresh-cw" size={14} />
+                    </button>
+                  {/if}
+                  <button class="icon-btn" disabled={busy[d.id]} title={$_('simulator.duplicate')} aria-label={$_('simulator.duplicate')}
+                    on:click={() => duplicate(d)}>
+                    <Icon name="copy" size={14} />
+                  </button>
+                  <button class="icon-btn" title={$_('simulator.exportDevice')} aria-label={$_('simulator.exportDevice')}
+                    on:click={() => askExport([d.id])}>
+                    <Icon name="download" size={14} />
+                  </button>
                   <button class="icon-btn" title={$_('common.edit')} aria-label={$_('common.edit')} on:click={() => edit(d)}>
                     <Icon name="pencil" size={14} />
                   </button>
@@ -603,6 +701,14 @@
         {/if}
       </div>
       <footer class="sim-footer">
+        <button class="btn tertiary" disabled={benchBusy} title={$_('simulator.importDevicesTitle')} on:click={importDevices}>
+          <Icon name="upload" size={14} /> {$_('simulator.importDevices')}
+        </button>
+        <button class="btn tertiary" disabled={benchBusy || $simulatorStore.devices.length === 0}
+          title={$_('simulator.exportAllTitle')} on:click={() => askExport([])}>
+          <Icon name="download" size={14} /> {$_('simulator.exportAll')}
+        </button>
+        <span class="footer-gap"></span>
         <button class="btn" on:click={() => newDevice($simulatorStore.models, $simulatorStore.devices)}>
           <Icon name="plus" size={14} /> {$_('simulator.new')}
         </button>
@@ -771,9 +877,68 @@
 
   .actions {
     display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     align-items: center;
     gap: 6px;
-    flex-shrink: 0;
+  }
+
+  .icon-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .export-choice {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 14px;
+    padding: 12px 14px;
+    background-color: var(--bg-color);
+    border: 1px solid var(--accent-border);
+    border-radius: 6px;
+  }
+
+  .export-choice h3 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.95em;
+  }
+
+  .export-choice p {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.85em;
+    line-height: 1.45;
+    color: var(--text-muted);
+  }
+
+  .export-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .export-actions .btn,
+  .sim-footer .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .export-actions .warn {
+    color: var(--warning-color);
+    border-color: var(--warning-border);
+  }
+
+  .footer-gap {
+    flex: 1;
   }
 
   .actions .btn {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} konnte nicht starten: {error}",
     "confirmDelete": "Löschen?",
     "deleteTitle": "Dieses Gerät löschen",
+    "importDevices": "Geräte importieren…",
+    "importDevicesTitle": "Simulierte Geräte aus einer von SnmpLens exportierten Datei hinzufügen",
+    "exportAll": "Alle exportieren…",
+    "exportAllTitle": "Alle simulierten Geräte in eine Datei schreiben, um die Testumgebung umzuziehen oder weiterzugeben",
+    "exportDevice": "Dieses Gerät in eine Datei exportieren",
+    "duplicate": "Dieses Gerät duplizieren",
+    "copyName": "{name} (Kopie)",
+    "duplicated": "„{name}“ als „{copy}“ dupliziert",
+    "restart": "Dieses Gerät neu starten: Uptime und Zähler ab null, und coldStart, falls es einen sendet",
+    "restarted": "{name} wurde neu gestartet",
+    "export": {
+      "title": "{count, plural, one {# Gerät} other {# Geräte}} exportieren",
+      "hint": "Die Passwörter — Communities und Passphrasen — bleiben im Schlüsselbund Ihres Systems, es sei denn, Sie legen sie in die Datei. Tun Sie das nur, um eine vollständige Testumgebung weiterzugeben: Wer die Datei hat, kann sie lesen.",
+      "without": "Ohne Passwörter",
+      "with": "Mit Passwörtern",
+      "done": "Nach {path} exportiert"
+    },
+    "devices": {
+      "imported": "Gerät „{name}“ importiert",
+      "failed": "{name}: {error}",
+      "warning": {
+        "addressMoved": "{name}: Seine Adresse war belegt, es antwortet daher woanders ({detail})",
+        "noSecrets": "{name}: Die Datei enthält keine Passwörter — geben Sie ihm seine Community oder Passphrasen, bevor Sie es starten"
+      }
+    },
     "loopbackHint": "Nur Loopback: 127.0.0.1 bis 127.255.255.254 oder ::1. Unter Linux und macOS erfordert ein Port unter 1024 Administratorrechte.",
     "field": {
       "name": "Name",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} could not start: {error}",
     "confirmDelete": "Delete?",
     "deleteTitle": "Delete this device",
+    "importDevices": "Import devices…",
+    "importDevicesTitle": "Add simulated devices from a file exported by SnmpLens",
+    "exportAll": "Export all…",
+    "exportAllTitle": "Write every simulated device to a file, to move the bench or pass it on",
+    "exportDevice": "Export this device to a file",
+    "duplicate": "Duplicate this device",
+    "copyName": "{name} (copy)",
+    "duplicated": "“{name}” duplicated as “{copy}”",
+    "restart": "Restart this device: uptime and counters from zero, and coldStart if it sends one",
+    "restarted": "{name} restarted",
+    "export": {
+      "title": "Export {count, plural, one {# device} other {# devices}}",
+      "hint": "The passwords — communities and passphrases — stay in your system’s keychain unless you put them in the file. Put them in only to hand over a complete bench: anyone who has the file can read them.",
+      "without": "Without passwords",
+      "with": "With passwords",
+      "done": "Exported to {path}"
+    },
+    "devices": {
+      "imported": "Device “{name}” imported",
+      "failed": "{name}: {error}",
+      "warning": {
+        "addressMoved": "{name}: its address was taken, so it answers elsewhere ({detail})",
+        "noSecrets": "{name}: the file carries no passwords — give it its community or passphrases before starting it"
+      }
+    },
     "loopbackHint": "Loopback only: 127.0.0.1 to 127.255.255.254, or ::1. On Linux and macOS, a port below 1024 needs administrator rights.",
     "field": {
       "name": "Name",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} no pudo iniciarse: {error}",
     "confirmDelete": "¿Eliminar?",
     "deleteTitle": "Eliminar este dispositivo",
+    "importDevices": "Importar dispositivos…",
+    "importDevicesTitle": "Añadir dispositivos simulados desde un archivo exportado por SnmpLens",
+    "exportAll": "Exportar todo…",
+    "exportAllTitle": "Escribir todos los dispositivos simulados en un archivo, para mover el banco de pruebas o compartirlo",
+    "exportDevice": "Exportar este dispositivo a un archivo",
+    "duplicate": "Duplicar este dispositivo",
+    "copyName": "{name} (copia)",
+    "duplicated": "«{name}» duplicado como «{copy}»",
+    "restart": "Reiniciar este dispositivo: uptime y contadores desde cero, y coldStart si envía uno",
+    "restarted": "{name} se reinició",
+    "export": {
+      "title": "Exportar {count, plural, one {# dispositivo} other {# dispositivos}}",
+      "hint": "Las contraseñas — comunidades y frases de paso — se quedan en el llavero de su sistema, salvo que las ponga en el archivo. Hágalo solo para entregar un banco de pruebas completo: quien tenga el archivo podrá leerlas.",
+      "without": "Sin contraseñas",
+      "with": "Con contraseñas",
+      "done": "Exportado a {path}"
+    },
+    "devices": {
+      "imported": "Dispositivo «{name}» importado",
+      "failed": "{name}: {error}",
+      "warning": {
+        "addressMoved": "{name}: su dirección estaba ocupada, así que responde en otra ({detail})",
+        "noSecrets": "{name}: el archivo no trae contraseñas — dele su comunidad o sus frases de paso antes de iniciarlo"
+      }
+    },
     "loopbackHint": "Solo loopback: de 127.0.0.1 a 127.255.255.254, o ::1. En Linux y macOS, un puerto inferior a 1024 requiere permisos de administrador.",
     "field": {
       "name": "Nombre",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} n'a pas pu démarrer : {error}",
     "confirmDelete": "Supprimer ?",
     "deleteTitle": "Supprimer cet appareil",
+    "importDevices": "Importer des appareils…",
+    "importDevicesTitle": "Ajouter des appareils simulés depuis un fichier exporté par SnmpLens",
+    "exportAll": "Tout exporter…",
+    "exportAllTitle": "Écrire tous les appareils simulés dans un fichier, pour déplacer le banc ou le transmettre",
+    "exportDevice": "Exporter cet appareil dans un fichier",
+    "duplicate": "Dupliquer cet appareil",
+    "copyName": "{name} (copie)",
+    "duplicated": "« {name} » dupliqué en « {copy} »",
+    "restart": "Redémarrer cet appareil : uptime et compteurs à zéro, et coldStart s’il en envoie un",
+    "restarted": "{name} a redémarré",
+    "export": {
+      "title": "Exporter {count, plural, one {# appareil} other {# appareils}}",
+      "hint": "Les mots de passe — communautés et phrases secrètes — restent dans le coffre de votre système, sauf si vous les mettez dans le fichier. Ne les y mettez que pour transmettre un banc complet : quiconque a le fichier peut les lire.",
+      "without": "Sans les mots de passe",
+      "with": "Avec les mots de passe",
+      "done": "Exporté vers {path}"
+    },
+    "devices": {
+      "imported": "Appareil « {name} » importé",
+      "failed": "{name} : {error}",
+      "warning": {
+        "addressMoved": "{name} : son adresse était prise, il répond donc ailleurs ({detail})",
+        "noSecrets": "{name} : le fichier ne contient pas de mots de passe — donnez-lui sa communauté ou ses phrases secrètes avant de le démarrer"
+      }
+    },
     "loopbackHint": "Bouclage uniquement : de 127.0.0.1 à 127.255.255.254, ou ::1. Sous Linux et macOS, un port inférieur à 1024 exige des droits d'administrateur.",
     "field": {
       "name": "Nom",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} 未能启动：{error}",
     "confirmDelete": "删除？",
     "deleteTitle": "删除此设备",
+    "importDevices": "导入设备…",
+    "importDevicesTitle": "从 SnmpLens 导出的文件添加模拟设备",
+    "exportAll": "全部导出…",
+    "exportAllTitle": "将所有模拟设备写入文件，以便迁移或分享测试环境",
+    "exportDevice": "将此设备导出到文件",
+    "duplicate": "复制此设备",
+    "copyName": "{name}（副本）",
+    "duplicated": "已将“{name}”复制为“{copy}”",
+    "restart": "重启此设备：运行时间和计数器从零开始，如会发送 coldStart 则发送",
+    "restarted": "{name} 已重启",
+    "export": {
+      "title": "导出 {count, plural, other {# 台设备}}",
+      "hint": "密码（团体名和口令）保存在系统钥匙串中，除非您把它们写入文件。仅在需要交付完整测试环境时才这样做：拿到文件的人都能读取它们。",
+      "without": "不含密码",
+      "with": "包含密码",
+      "done": "已导出到 {path}"
+    },
+    "devices": {
+      "imported": "设备“{name}”已导入",
+      "failed": "{name}：{error}",
+      "warning": {
+        "addressMoved": "{name}：其地址已被占用，因此改在别处应答（{detail}）",
+        "noSecrets": "{name}：文件中不含密码——启动前请为其设置团体名或口令"
+      }
+    },
     "loopbackHint": "仅限回环地址：127.0.0.1 至 127.255.255.254，或 ::1。在 Linux 和 macOS 上，低于 1024 的端口需要管理员权限。",
     "field": {
       "name": "名称",

--- a/frontend/src/stores/simulatorStore.js
+++ b/frontend/src/stores/simulatorStore.js
@@ -15,6 +15,10 @@ import {
   SimulatorRecordDevice,
   SimulatorCancelRecording,
   SimulatorExportModelDialog,
+  ImportSimulatedDevicesDialog,
+  SimulatorExportDevicesDialog,
+  SimulatorDuplicateDevice,
+  SimulatorRestartDevice,
   TrapListenerEngineID,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
@@ -103,6 +107,16 @@ function createSimulatorStore() {
     stopRecording: () => SimulatorCancelRecording(),
     /** Writes a custom model to a ZIP the user names; resolves to where, or '' when cancelled. */
     exportModel: async (id) => (await SimulatorExportModelDialog(id)) || '',
+    /** Asks for files of simulated devices and imports them; resolves to what became of each device. */
+    importDevices: async () => (await ImportSimulatedDevicesDialog()) || [],
+    /**
+     * Writes devices — those named, or every one — to a file the user names,
+     * their passwords only when withSecrets says so; resolves to where, or ''
+     * when cancelled.
+     */
+    exportDevices: async (ids, withSecrets) => (await SimulatorExportDevicesDialog(ids || [], !!withSecrets)) || '',
+    duplicate: (id, name) => SimulatorDuplicateDevice(id, name),
+    restart: (id) => SimulatorRestartDevice(id),
     /** The engine ID SnmpLens's own trap listener stands for, in hex. */
     listenerEngineId: async () => (await TrapListenerEngineID()) || '',
   };

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -379,6 +379,26 @@ export function firstImported(results) {
   return (results || []).find((r) => r.success)?.modelId || '';
 }
 
+/**
+ * What to say about an import of simulated devices, as i18n keys: a line per
+ * device imported or refused — or for the file, when it was refused whole —
+ * and one per warning about a device imported anyway.
+ */
+export function deviceImportReport(results) {
+  const out = [];
+  for (const r of results || []) {
+    if (!r.success) {
+      out.push({ key: 'simulator.devices.failed', values: { name: r.name, error: r.error }, level: 'error' });
+      continue;
+    }
+    out.push({ key: 'simulator.devices.imported', values: { name: r.name }, level: 'success' });
+    for (const w of r.warnings || []) {
+      out.push({ key: `simulator.devices.warning.${w.key}`, values: { name: r.name, detail: w.detail }, level: 'warning' });
+    }
+  }
+  return out;
+}
+
 /** The categories a recorded model may be filed under: Go's customCategories. */
 export const CUSTOM_CATEGORIES = Object.keys(CATEGORY_ICONS);
 

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -66,6 +66,7 @@ const {
   devicesOfModel,
   importReport,
   firstImported,
+  deviceImportReport,
   CUSTOM_CATEGORIES,
   recordableTargets,
   recordRequest,
@@ -432,5 +433,36 @@ const goCategories = [...customCategories].sort();
 check('the categories a recording offers are those Go accepts',
   goCategories.length > 0 && JSON.stringify([...CUSTOM_CATEGORIES].sort()) === JSON.stringify(goCategories),
   `${CUSTOM_CATEGORIES} vs ${goCategories}`);
+
+// An import of simulated devices is reported device by device, each warning
+// after its device; a file refused whole is one line, under its own name.
+const benchLines = deviceImportReport([
+  { name: 'core-01', success: true, id: 'a', warnings: [{ key: 'addressMoved', detail: '127.0.0.2:161 → 127.0.0.3:161' }] },
+  { name: 'gone', success: false, error: '"custom:x" is not a device model', warnings: [] },
+  { name: 'edge-01', success: true, id: 'b', warnings: [{ key: 'noSecrets', detail: '' }] },
+]);
+check('an import of devices is reported device by device, each warning after its device',
+  benchLines.map((l) => `${l.key}:${l.level}`).join(' ') ===
+  'simulator.devices.imported:success simulator.devices.warning.addressMoved:warning simulator.devices.failed:error ' +
+  'simulator.devices.imported:success simulator.devices.warning.noSecrets:warning',
+  JSON.stringify(benchLines));
+
+// Every warning Go gives about a device imported has its sentence.
+const benchGo = readFileSync(new URL('../../app_simbench.go', import.meta.url), 'utf8');
+const benchKeys = new Set([...benchGo.matchAll(/Key: "([A-Za-z]+)"/g)].map((m) => m[1]));
+check('the warnings a device import gives were found in app_simbench.go', benchKeys.size >= 2, [...benchKeys].join());
+for (const key of benchKeys) {
+  check(`en.json says simulator.devices.warning.${key}`, Boolean(en.simulator?.devices?.warning?.[key]));
+}
+for (const key of ['importDevices', 'importDevicesTitle', 'exportAll', 'exportAllTitle', 'exportDevice', 'duplicate',
+  'copyName', 'duplicated', 'restart', 'restarted']) {
+  check(`en.json says simulator.${key}`, Boolean(en.simulator?.[key]));
+}
+for (const key of ['title', 'hint', 'without', 'with', 'done']) {
+  check(`en.json says simulator.export.${key}`, Boolean(en.simulator?.export?.[key]));
+}
+for (const key of ['imported', 'failed']) {
+  check(`en.json says simulator.devices.${key}`, Boolean(en.simulator?.devices?.[key]));
+}
 
 process.exit(failures ? 1 : 0);

--- a/pkg/simulator/devicefile.go
+++ b/pkg/simulator/devicefile.go
@@ -1,0 +1,151 @@
+package simulator
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// A file of simulated devices is how a bench moves from one machine to another,
+// or is passed on: one device or several, with or without their secrets — and
+// saying which. It is read as a model file is, because somebody else may have
+// written it: what it says it is first, then all of it and strictly. Each device
+// in it is then checked as one typed in is (Device.Validate), the loopback rule
+// included, by whoever gives it an ID and an engine.
+
+const (
+	// DeviceFileKind is what a file of simulated devices says it is.
+	DeviceFileKind = "snmplens-simulated-devices"
+	// DeviceFileFormat is the format version this package reads.
+	DeviceFileFormat = 1
+	// MaxDeviceFileBytes and MaxFileDevices bound a file: a bench is a few
+	// dozen devices at most.
+	MaxDeviceFileBytes = 1 << 20
+	MaxFileDevices     = 64
+)
+
+// What a file of devices says of their secrets.
+const (
+	SecretsIncluded = "included"
+	SecretsOmitted  = "omitted"
+)
+
+// DeviceFile is simulated devices as a file holds them.
+type DeviceFile struct {
+	Kind          string `json:"kind"`
+	FormatVersion int    `json:"formatVersion"`
+	// Secrets says whether the communities and passphrases are in the file
+	// (SecretsIncluded) or were left out (SecretsOmitted), so that nobody passes
+	// a file on believing it holds none when it does.
+	Secrets string       `json:"secrets"`
+	Devices []FileDevice `json:"devices"`
+}
+
+// FileDevice is a device as a file holds it: what makes it the device it is,
+// and nothing of what makes it this machine's — its ID, its engine and its
+// boots, which a device imported is given anew. Two imports of one file are
+// two devices, with two engines no manager confuses.
+type FileDevice struct {
+	Name      string   `json:"name"`
+	Model     string   `json:"model"`
+	Address   string   `json:"address"`
+	Port      int      `json:"port"`
+	Versions  []string `json:"versions"`
+	Community string   `json:"community,omitempty"`
+	Users     []User   `json:"users,omitempty"`
+	Traps     Traps    `json:"traps"`
+}
+
+// ExportDevices is the file holding devices, their secrets in it or not.
+func ExportDevices(devices []Device, withSecrets bool) ([]byte, error) {
+	f := DeviceFile{Kind: DeviceFileKind, FormatVersion: DeviceFileFormat, Secrets: SecretsOmitted,
+		Devices: make([]FileDevice, len(devices))}
+	if withSecrets {
+		f.Secrets = SecretsIncluded
+	}
+	for i, d := range devices {
+		if !withSecrets {
+			d = d.WithoutSecrets()
+		}
+		traps := d.Traps.clone()
+		if traps.Destinations == nil {
+			traps.Destinations = []Destination{}
+		}
+		if traps.Schedules == nil {
+			traps.Schedules = []Schedule{}
+		}
+		f.Devices[i] = FileDevice{Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
+			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps}
+	}
+	raw, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(raw, '\n'), nil
+}
+
+// ParseDeviceFile reads a file of simulated devices: what it says it is, then
+// all of it, refusing a field the format does not define.
+func ParseDeviceFile(raw []byte) (DeviceFile, error) {
+	if len(raw) > MaxDeviceFileBytes {
+		return DeviceFile{}, fmt.Errorf("a file of devices is at most %d KB", MaxDeviceFileBytes>>10)
+	}
+	raw = bytes.TrimPrefix(raw, bom)
+	var head struct {
+		Kind          string `json:"kind"`
+		FormatVersion int    `json:"formatVersion"`
+	}
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&head); err != nil {
+		return DeviceFile{}, jsonProblem(raw, err)
+	}
+	if head.Kind != DeviceFileKind {
+		return DeviceFile{}, fmt.Errorf("this is not a file of simulated devices: its \"kind\" is %q, and one's is %q",
+			head.Kind, DeviceFileKind)
+	}
+	if head.FormatVersion != DeviceFileFormat {
+		return DeviceFile{}, fmt.Errorf("format version %d: this version of SnmpLens reads version %d",
+			head.FormatVersion, DeviceFileFormat)
+	}
+	var f DeviceFile
+	if err := decodeStrict(raw, &f); err != nil {
+		return DeviceFile{}, err
+	}
+	if f.Secrets != SecretsIncluded && f.Secrets != SecretsOmitted {
+		return DeviceFile{}, fmt.Errorf("\"secrets\" says whether the passwords are in the file: %q or %q",
+			SecretsIncluded, SecretsOmitted)
+	}
+	switch {
+	case len(f.Devices) == 0:
+		return DeviceFile{}, errors.New("the file holds no device")
+	case len(f.Devices) > MaxFileDevices:
+		return DeviceFile{}, fmt.Errorf("the file holds %d devices, and one is read with at most %d", len(f.Devices), MaxFileDevices)
+	}
+	return f, nil
+}
+
+// Device is the device fd describes, yet to be given an ID and an engine.
+func (fd FileDevice) Device() Device {
+	return Device{Name: strings.TrimSpace(fd.Name), Model: fd.Model, Address: strings.TrimSpace(fd.Address),
+		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community,
+		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone()}
+}
+
+// ValidateWithoutSecrets is Validate for a device whose secrets are yet to be
+// given: everything else about it is checked, and a secret it lacks is not an
+// error. A device imported from a file that left its secrets out is checked so,
+// and kept; it starts once it is given them.
+func (d Device) ValidateWithoutSecrets() error {
+	const standIn = "stand-in-secret"
+	c := d.WithoutSecrets()
+	c.Community = standIn
+	for i := range c.Users {
+		c.Users[i].AuthPass, c.Users[i].PrivPass = standIn, standIn
+	}
+	for i := range c.Traps.Destinations {
+		c.Traps.Destinations[i].Community = standIn
+	}
+	return c.Validate()
+}

--- a/pkg/simulator/devicefile_test.go
+++ b/pkg/simulator/devicefile_test.go
@@ -1,0 +1,69 @@
+package simulator
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// A bench written to a file reads back as the same devices, without the ID, the
+// engine and the boots that are this machine's; its secrets are in it when they
+// were asked for and absent otherwise, and the file says which.
+func TestADeviceFileRoundTrips(t *testing.T) {
+	d := Device{ID: "0123456789abcdef", Name: "core-01", Model: "linux-server", Address: "127.0.0.2", Port: 1161,
+		Versions: []string{"v2c", "v3"}, Community: "s3cret-community",
+		Users: []User{{Name: "ops", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "auth-pass-1",
+			PrivProto: "AES", PrivPass: "priv-pass-1"}},
+		EngineID: "8000000903001122334455", EngineBoots: 7,
+		Traps: Traps{Destinations: []Destination{{ID: "d1", Host: "192.0.2.50", Port: 162, Version: "v2c",
+			Community: "trap-s3cret"}}, OnStart: true, Schedules: []Schedule{}}}
+	for _, with := range []bool{true, false} {
+		raw, err := ExportDevices([]Device{d}, with)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, secret := range []string{"s3cret-community", "auth-pass-1", "priv-pass-1", "trap-s3cret"} {
+			if bytes.Contains(raw, []byte(secret)) != with {
+				t.Errorf("with secrets %v, the file holding %q is %v", with, secret, !with)
+			}
+		}
+		for _, mine := range []string{d.ID, d.EngineID, `"engineBoots"`} {
+			if bytes.Contains(raw, []byte(mine)) {
+				t.Errorf("the file holds %s, which is this machine's", mine)
+			}
+		}
+		f, err := ParseDeviceFile(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := map[bool]string{true: SecretsIncluded, false: SecretsOmitted}[with]; f.Secrets != want {
+			t.Errorf("the file says its secrets are %q, want %q", f.Secrets, want)
+		}
+		want := d
+		want.ID, want.EngineID, want.EngineBoots = "", "", 0
+		if !with {
+			want = want.WithoutSecrets()
+		}
+		if got := f.Devices[0].Device(); !reflect.DeepEqual(got, want) {
+			t.Errorf("read back as\n%+v\nwant\n%+v", got, want)
+		}
+	}
+}
+
+// A device whose secrets are yet to be given is refused by Validate and passes
+// ValidateWithoutSecrets, which still holds it to everything else.
+func TestADeviceIsCheckedWithoutItsSecrets(t *testing.T) {
+	d := Device{Name: "x", Model: "linux-server", Address: "127.0.0.2", Port: 1161, Versions: []string{"v2c", "v3"},
+		Users:    []User{{Name: "ops", SecLevel: "AuthPriv", AuthProto: "SHA256", PrivProto: "AES"}},
+		EngineID: "8000000903aabbccddeeff"}
+	if d.Validate() == nil {
+		t.Error("a device with neither community nor passphrases was valid")
+	}
+	if err := d.ValidateWithoutSecrets(); err != nil {
+		t.Errorf("without its secrets: %v", err)
+	}
+	d.Address = "192.0.2.1"
+	if d.ValidateWithoutSecrets() == nil {
+		t.Error("the loopback rule was not held")
+	}
+}

--- a/pkg/simulator/record.go
+++ b/pkg/simulator/record.go
@@ -157,10 +157,14 @@ var latinFolds = map[rune]string{
 	'ù': "u", 'ú': "u", 'û': "u", 'ü': "u", 'ý': "y", 'ÿ': "y", 'æ': "ae", 'œ': "oe", 'ß': "ss",
 }
 
-// ModelSlug makes a custom model's id from a name: lower-case letters and
-// digits, one hyphen for whatever runs between them, the accents of a Latin
-// name taken off rather than made into hyphens.
-func ModelSlug(name string) string {
+// ModelSlug makes a custom model's id from a name (Slug).
+func ModelSlug(name string) string { return Slug(name, "recorded-device") }
+
+// Slug makes an id, or a file name, from a name: lower-case letters and digits,
+// one hyphen for whatever runs between them, the accents of a Latin name taken
+// off rather than made into hyphens — and fallback for a name with nothing of
+// the kind, one in Chinese among them.
+func Slug(name, fallback string) string {
 	var b strings.Builder
 	gap := false
 	for _, r := range strings.ToLower(name) {
@@ -182,7 +186,7 @@ func ModelSlug(name string) string {
 		slug = strings.TrimRight(slug[:48], "-")
 	}
 	if slug == "" {
-		return "recorded-device"
+		return fallback
 	}
 	return slug
 }


### PR DESCRIPTION
Step 6 of the simulator plan, first part: a bench of simulated devices moves as a file, and a device can be duplicated or restarted. The second part — faults (latency, loss, a mute device, `tooBig`/`genErr`, fast counter wraps) and a fuller editor — follows in its own PR.

## What

- **Export all…** in the simulator's footer, or the export button on a device, writes JSON. SnmpLens **asks every time** whether to put the passwords — communities and passphrases — in the file, as was decided when the simulator was planned: they live in the system keychain, and a file holding them can be read by anyone who has it.
- **Import devices…** reads such files back.
- **Duplicate** copies a device, passwords included, to an address of its own. **Restart** (running devices) is a stop and a start: uptime and counters from zero, the boots one higher — which tells a manager holding the engine's clock to resynchronise — and coldStart if the device sends one when it starts.

## The file

```json
{
  "kind": "snmplens-simulated-devices",
  "formatVersion": 1,
  "secrets": "omitted",
  "devices": [
    {
      "name": "core-sw-01",
      "model": "cisco-catalyst-48",
      "address": "127.0.0.21",
      "port": 161,
      "versions": ["v2c", "v3"],
      "users": [{ "name": "noc-ro", "secLevel": "AuthPriv", "authProto": "SHA256", "authPass": "", "privProto": "AES", "privPass": "" }],
      "traps": { "destinations": [], "onStart": true, "onAuthFailure": false, "schedules": [] }
    }
  ]
}
```

- `"secrets"` says whether the passwords are in the file, so nobody passes one on believing it holds none. A file holding them is written 0600.
- A file never holds what is this machine's: the device's ID, engine ID and boots. Two imports of one file are two devices, with two engines no manager confuses.

## Import rules

- Read as a model file is: `kind` and `formatVersion` first, then strictly (an unknown field is refused, with its position), at most 64 devices and 1 MB.
- Every device is made **new**: an ID, an engine ID and, when the address it names is already taken, the next free one `suggestAddress` gives — said in a warning (`addressMoved`).
- A device that cannot be made here — a custom model this machine does not have, an address off loopback — is **refused on its own**; the others are kept.
- A file whose passwords were left out: any it holds anyway are ignored (the file's word is believed), its devices are checked for everything but their secrets (`ValidateWithoutSecrets`) and kept, with a warning (`noSecrets`). Starting one fails naming what it lacks until the editor gives it; a device that needs no secret gets no warning.

## Tests

- `pkg/simulator`: a file round-trips with and without secrets, never carrying the ID, engine or boots; `ValidateWithoutSecrets` still holds the loopback rule.
- App: export with and without passwords (and a device that is gone); a bench imported as new devices that answer, one moved off a taken address; a bench without passwords imported, refused at start, then completed and started; a file refused whole (wrong kind, version, unknown field, bad `secrets`, no device, not JSON) and a device refused on its own (unknown model, off loopback) beside one kept; duplicate and restart.
- `simulator.test.mjs`: the import report, device by device; every warning Go gives has its sentence.

Gates run locally: `go vet`, `staticcheck` 0.8.1, `go test -race ./...`, `npm test`, `svelte-check`, the Vite build. The demo refuses the four new calls. New strings in the five locales; README and CLAUDE.md describe it.
