### PR TITLE
Make a simulated device misbehave on demand, and give it its own identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -606,7 +606,8 @@ file and the marshalled list for the secret values themselves. The two listing c
 `NewEngineID`: the model's vendor in the MAC format, the MAC drawn from the ID), and an edit keeps both, and the
 boot count, whatever the renderer sends — the engine ID is what managers localise their keys to, and the count is
 what keeps a previous run's messages out of the time window. Every start raises the count and WRITES it before
-the device answers. A running device that is edited restarts; nothing starts by itself at launch. The header's
+the device answers. A running device that is edited restarts; nothing starts by itself at launch unless it is set
+to (`AutoStart`). The header's
 status and the modal read `simulatorStore`, which Go refreshes with `simulator:changed`.
 
 **A model is a vocabulary, not prose.** `simulator.Models()` serves an ID, a category and the notifications; the
@@ -698,6 +699,18 @@ its passwords were left out has any it holds anyway ignored — what a file says
 its devices are checked by `ValidateWithoutSecrets`, everything but the secrets, and KEPT without them: starting one
 fails naming what it lacks until the editor gives it. Duplicating is the same making of a new device, from a device
 and with its passwords; restarting is a stop and a start, so the boots rise and coldStart goes out as on any start.
+
+**Faults are applied to the running agent, never by a restart** (`faults.go`). A test of reachability, of the
+overload guardrail or of the rate across a wrap watches the uptime and counters a restart would reset, so
+`SimulatorSetFaults` goes through `Fleet.SetFaults` to the live agent, and the editor's save KEEPS the faults it does
+not show. Loss and mute drop the datagram before the agent counts anything, as a lossy link would; a mute device still
+sends its notifications. Latency answers through `time.AfterFunc` rather than sleeping in the one serving goroutine,
+so a slow device stays slow without becoming a stuck one. An error is injected in `process`, the path v1, v2c and v3
+share, and counted in the snmp group like any answer. Counters sped up run through a WARP carried by the request's
+clock: the counter-seconds at the moment the speed changed, and the new speed from there — so a speed change turns a
+counter faster or slower and never makes it jump or go back, either of which a manager reads as a wrap
+(`TestCountersChangeSpeedWithoutJumping`). Gauges keep real time. A device's own location and contact take the place
+of its model's in `addSystem`, and `AutoStart` is opt-in per device, started once the secret store is open.
 
 **What only a notification carries** (`Object.NotifyOnly`). An iDRAC alert carries eleven objects its MIB makes
 accessible-for-notify (RFC 2578 7.3) — a message ID, the message, the service tag — and no request may read them.

--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ The **Simulator** indicator in the header opens the simulated devices: SNMP agen
 
 A bench moves as a file. **Export all…**, or a device's export button, writes JSON, and SnmpLens asks every time whether to put the passwords in it — the communities and passphrases, which otherwise stay in the system keychain. The file says which (`"secrets": "included"` or `"omitted"`). **Import devices…** makes each device new on this machine: its own ID and engine ID, and another address when its own is taken. A device that cannot be made here — of a custom model that is not installed, say — is refused on its own; devices imported without their passwords start once they are given them in the editor.
 
+**Faults** make a device misbehave while it runs, without restarting it — its uptime and counters are what a fault is tested against: a latency (with jitter), a share of requests lost, a device that answers nothing at all, a share answered with `genErr` or `tooBig`, and counters running 10, 100 or 1000 times faster, so that a Counter32 wraps in minutes. They are what SnmpLens's reachability alerts, overload guardrail and counter-wrap arithmetic are tested against, and they are kept with the device. A device can also be given its own sysLocation and sysContact, and set to start with SnmpLens.
+
 ---
 
 ## Custom Simulator Models

--- a/app.go
+++ b/app.go
@@ -147,9 +147,11 @@ func (a *App) startup(ctx context.Context) {
 		log.Printf("Secret storage backend: %s", store.Backend())
 	}
 
-	// The simulated devices are read, not started: a device answers only once
-	// someone starts it in this session.
+	// The simulated devices are read, and those set to start with the
+	// application are started — after the secret store, which holds their
+	// communities and passphrases. The others answer once someone starts them.
 	a.sim = newSimulatorService(filepath.Join(configDir, "SnmpLens"))
+	a.startAutoSimulated()
 
 	// The trap listener's engine ID, before initBackgroundMode can start the
 	// listener: a device sending it SNMPv3 INFORMs is configured with it.

--- a/app_simfaults_test.go
+++ b/app_simfaults_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/simulator"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Faults are set on a running device without restarting it, kept with it — an
+// edit in the editor keeps them — and cleared the same way.
+func TestFaultsAreSetWithoutARestart(t *testing.T) {
+	a, _ := simApp(t)
+	saved := startSimulated(t, a, simDevice())
+	boots := listedDevice(a, saved.ID).EngineBoots
+	if err := a.SimulatorSetFaults(saved.ID, simulator.Faults{Mute: true}); err != nil {
+		t.Fatal(err)
+	}
+	g := &gosnmp.GoSNMP{Target: saved.Address, Port: uint16(saved.Port), Community: simDevice().Community,
+		Version: gosnmp.Version2c, Timeout: 300 * time.Millisecond}
+	if err := g.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer g.Conn.Close()
+	if _, err := g.Get([]string{".1.3.6.1.2.1.1.5.0"}); err == nil {
+		t.Error("a mute device answered")
+	}
+	now := listedDevice(a, saved.ID)
+	if !now.Running || now.EngineBoots != boots || !now.Faults.Mute {
+		t.Errorf("after the fault: running %v, boots %d after %d, faults %+v", now.Running, now.EngineBoots, boots, now.Faults)
+	}
+	if again := newSimulatorService(filepath.Dir(a.sim.path)); !again.devices[0].Faults.Mute {
+		t.Error("the fault was not kept with the device")
+	}
+
+	d := simDevice()
+	d.ID, d.Address, d.Port = saved.ID, saved.Address, saved.Port
+	d.Traps.Destinations[0].ID = now.Traps.Destinations[0].ID
+	if _, err := a.SimulatorSaveDevice(d); err != nil {
+		t.Fatal(err)
+	}
+	if !listedDevice(a, saved.ID).Faults.Mute {
+		t.Error("an edit cleared the faults")
+	}
+	if err := a.SimulatorSetFaults(saved.ID, simulator.Faults{}); err != nil {
+		t.Fatal(err)
+	}
+	if v := simGet(t, listedDevice(a, saved.ID), simDevice().Community, ".1.3.6.1.2.1.1.5.0"); string(v.Value.([]byte)) != "srv-01" {
+		t.Errorf("cleared, the device answers %v", v.Value)
+	}
+	if err := a.SimulatorSetFaults(saved.ID, simulator.Faults{LossPercent: 101}); err == nil {
+		t.Error("a loss of 101 % was set")
+	}
+}
+
+// A device answers with the location and contact it was given, in place of its
+// model's; one given none answers its model's.
+func TestADeviceHasItsOwnLocationAndContact(t *testing.T) {
+	a, _ := simApp(t)
+	d := simDevice()
+	d.Location, d.Contact = "Lab, rack B4", "noc@lab.example"
+	own := startSimulated(t, a, d)
+	if v := simGet(t, own, d.Community, ".1.3.6.1.2.1.1.6.0"); string(v.Value.([]byte)) != "Lab, rack B4" {
+		t.Errorf("sysLocation: %v", v.Value)
+	}
+	if v := simGet(t, own, d.Community, ".1.3.6.1.2.1.1.4.0"); string(v.Value.([]byte)) != "noc@lab.example" {
+		t.Errorf("sysContact: %v", v.Value)
+	}
+	models := startSimulated(t, a, simDevice())
+	if v := simGet(t, models, d.Community, ".1.3.6.1.2.1.1.6.0"); len(v.Value.([]byte)) == 0 || string(v.Value.([]byte)) == "Lab, rack B4" {
+		t.Errorf("a device given no location answers %q", v.Value)
+	}
+}
+
+// A device set to start with the application starts with it, and one that is
+// not does not.
+func TestADeviceStartsWithTheApplication(t *testing.T) {
+	a, store := simApp(t)
+	auto := simDevice()
+	auto.AutoStart, auto.Address, auto.Port = true, "127.0.0.1", freeSimPort(t)
+	autoSaved, err := a.SimulatorSaveDevice(auto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manual := simDevice()
+	manual.Address, manual.Port = "127.0.0.1", freeSimPort(t)
+	if manual.Port == auto.Port {
+		manual.Port++
+	}
+	manualSaved, err := a.SimulatorSaveDevice(manual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &App{secrets: store, sim: newSimulatorService(filepath.Dir(a.sim.path))}
+	t.Cleanup(b.sim.fleet.StopAll)
+	b.startAutoSimulated()
+	if !listedDevice(b, autoSaved.ID).Running || listedDevice(b, manualSaved.ID).Running {
+		t.Errorf("after startup: %+v", b.ListSimulatedDevices())
+	}
+}

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -132,6 +132,12 @@ type SimulatedDevice struct {
 	// Packets is what the device has received since it started.
 	Packets uint32         `json:"packets"`
 	Traps   SimulatedTraps `json:"traps"`
+	// Location, Contact and AutoStart are the device's own settings, and
+	// Faults what it is made to do wrong. None of it is a secret.
+	Location  string           `json:"location"`
+	Contact   string           `json:"contact"`
+	AutoStart bool             `json:"autoStart"`
+	Faults    simulator.Faults `json:"faults"`
 }
 
 // SimulatedTraps is what a simulated device sends, as the list shows it: the
@@ -197,6 +203,7 @@ func (s *simulatorService) view(d simulator.Device) SimulatedDevice {
 		Versions: slices.Clone(d.Versions), Users: users,
 		EngineID: d.EngineID, EngineBoots: d.EngineBoots,
 		Running: running, Packets: stats.Packets, Traps: traps,
+		Location: d.Location, Contact: d.Contact, AutoStart: d.AutoStart, Faults: d.Faults,
 	}
 }
 
@@ -336,7 +343,8 @@ func (a *App) SimulatorSaveDevice(d simulator.Device) (SimulatedDevice, error) {
 	} else if i = s.index(d.ID); i < 0 {
 		return SimulatedDevice{}, fmt.Errorf("there is no simulated device %q", d.ID)
 	} else {
-		d.EngineID, d.EngineBoots = s.devices[i].EngineID, s.devices[i].EngineBoots
+		// The faults too: they are set while the device runs, never in the editor.
+		d.EngineID, d.EngineBoots, d.Faults = s.devices[i].EngineID, s.devices[i].EngineBoots, s.devices[i].Faults
 	}
 	if err := d.Validate(); err != nil {
 		return SimulatedDevice{}, err
@@ -437,6 +445,62 @@ func (a *App) SimulatorStopDevice(id string) error {
 		a.emitSimulatorChanged()
 	}
 	return nil
+}
+
+// SimulatorSetFaults changes what a simulated device does wrong, at once and
+// without restarting it — its uptime and counters are what a fault is tested
+// against — and keeps it with the device, for its next start as well.
+func (a *App) SimulatorSetFaults(id string, f simulator.Faults) error {
+	s := a.sim
+	if s == nil {
+		return errNoSimulator
+	}
+	if err := f.Check(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.index(id)
+	if i < 0 {
+		return fmt.Errorf("there is no simulated device %q", id)
+	}
+	next := slices.Clone(s.devices)
+	next[i].Faults = f
+	if err := s.write(next); err != nil {
+		return fmt.Errorf("saving the simulated devices: %w", err)
+	}
+	s.devices = next
+	if err := s.fleet.SetFaults(id, f); err != nil && !errors.Is(err, simulator.ErrNotRunning) {
+		return err
+	}
+	a.emitSimulatorChanged()
+	return nil
+}
+
+// startAutoSimulated starts the devices that start with the application, once
+// the credential store is open. One that will not start is logged and left
+// stopped, and the others start.
+func (a *App) startAutoSimulated() {
+	s := a.sim
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	started := false
+	for i, d := range s.devices {
+		if !d.AutoStart {
+			continue
+		}
+		if err := a.startSimulatedLocked(s, i); err != nil {
+			log.Printf("simulator: %s did not start with the application: %v", d.Name, err)
+			continue
+		}
+		started = true
+	}
+	if started {
+		a.emitSimulatorChanged()
+	}
 }
 
 // SimulatorSendTrap has a running simulated device send a notification now to

--- a/frontend/screenshots/bridge/dynamic.js
+++ b/frontend/screenshots/bridge/dynamic.js
@@ -409,6 +409,7 @@ const DEMO_ONLY = {
   SimulatorExportDevicesDialog: 'Exporting simulated devices opens the operating system’s file dialog and writes a file.',
   SimulatorDuplicateDevice: 'Duplicating a simulated device writes the copy to your configuration directory, and its passwords to the system keychain.',
   SimulatorRestartDevice: 'Restarting a simulated device opens a UDP socket on this machine.',
+  SimulatorSetFaults: 'Faults are applied to a simulated device running on this machine, and kept in your configuration directory.',
 };
 
 for (const [name, why] of Object.entries(DEMO_ONLY)) {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -10,10 +10,12 @@
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
     modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets, deviceImportReport,
+    deviceGroups, faultChips, categoryIcon,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
   import ModelIcon from './simulator/ModelIcon.svelte';
+  import FaultsPanel from './simulator/FaultsPanel.svelte';
   import Icon from './Icon.svelte';
 
   /**
@@ -386,6 +388,25 @@
       simulatorStore.refresh().catch(() => {});
     }
   }
+
+  /** The device whose faults are open, or null. */
+  let faultsOpen = null;
+
+  // Applied at once, without a restart: the device keeps its uptime and its
+  // counters, which are what a fault is tested against.
+  async function applyFaults(device, faults) {
+    busy = { ...busy, [device.id]: true };
+    try {
+      await simulatorStore.setFaults(device.id, faults);
+      const key = faultChips(faults).length ? 'simulator.faults.applied' : 'simulator.faults.cleared';
+      notificationStore.add($_(key, { values: { name: device.name } }), 'success');
+      await simulatorStore.refresh();
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+    }
+  }
 </script>
 
 <svelte:window on:keydown={onWindowKey} />
@@ -435,6 +456,19 @@
           </div>
         </div>
         <p class="hint"><Icon name="shield-check" size={14} /> {$_('simulator.loopbackHint')}</p>
+        <div class="grid identity-fields">
+          <div class="form-group">
+            <label for="sim-location">{$_('simulator.field.location')}</label>
+            <input id="sim-location" type="text" maxlength="255" placeholder={$_('simulator.field.modelDefault')}
+              bind:value={editing.location} />
+          </div>
+          <div class="form-group">
+            <label for="sim-contact">{$_('simulator.field.contact')}</label>
+            <input id="sim-contact" type="text" maxlength="255" placeholder={$_('simulator.field.modelDefault')}
+              bind:value={editing.contact} />
+          </div>
+        </div>
+        <label class="check autostart"><input type="checkbox" bind:checked={editing.autoStart} /> {$_('simulator.field.autoStart')}</label>
 
         <fieldset class="versions">
           <legend>{$_('simulator.field.versions')}</legend>
@@ -617,8 +651,12 @@
             <p>{$_('simulator.empty')}</p>
           </div>
         {:else}
+          {#each deviceGroups($simulatorStore.devices, $simulatorStore.models) as group (group.category)}
+          <h4 class="category-title">
+            <Icon name={categoryIcon(group.category)} size={14} /> {$_(`simulator.category.${group.category}`)}
+          </h4>
           <ul class="devices">
-            {#each $simulatorStore.devices as d (d.id)}
+            {#each group.devices as d (d.id)}
               {@const activity = trapActivity(d.traps)}
               {@const model = modelOf($simulatorStore.models, d.model)}
               <li class="device" class:running={d.running}>
@@ -649,6 +687,10 @@
                         {/if}
                       </span>
                     {/if}
+                    {#each faultChips(d.faults) as c (c.key)}
+                      <span class="chip fault">{$_(`simulator.faults.chip.${c.key}`, { values: c.values })}</span>
+                    {/each}
+                    {#if d.autoStart}<span class="chip">{$_('simulator.autoStartChip')}</span>{/if}
                   </span>
                 </div>
                 <div class="actions">
@@ -673,6 +715,11 @@
                   <button class="btn tertiary btn-small" title={$_('simulator.addAsTargetTitle')} on:click={() => addAsTarget(d)}>
                     <Icon name="target" size={13} /> {$_('simulator.addAsTarget')}
                   </button>
+                  <button class="icon-btn" class:active={faultChips(d.faults).length > 0} aria-expanded={faultsOpen === d.id}
+                    title={$_('simulator.faults.button')} aria-label={$_('simulator.faults.button')}
+                    on:click={() => (faultsOpen = faultsOpen === d.id ? null : d.id)}>
+                    <Icon name="zap" size={14} />
+                  </button>
                   {#if d.running}
                     <button class="icon-btn" disabled={busy[d.id]} title={$_('simulator.restart')} aria-label={$_('simulator.restart')}
                       on:click={() => restart(d)}>
@@ -695,9 +742,14 @@
                     {#if confirmDelete === d.id}{$_('simulator.confirmDelete')}{:else}<Icon name="trash-2" size={14} />{/if}
                   </button>
                 </div>
+                {#if faultsOpen === d.id}
+                  <FaultsPanel faults={d.faults} idPrefix="sim-faults-{d.id}" busy={busy[d.id]}
+                    on:apply={(e) => applyFaults(d, e.detail)} on:close={() => (faultsOpen = null)} />
+                {/if}
               </li>
             {/each}
           </ul>
+          {/each}
         {/if}
       </div>
       <footer class="sim-footer">
@@ -887,6 +939,41 @@
   .icon-btn:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+  }
+
+  .icon-btn.active {
+    color: var(--warning-color);
+    border-color: var(--warning-border);
+  }
+
+  .device {
+    flex-wrap: wrap;
+  }
+
+  .category-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 14px 0 8px;
+    font-size: 0.85em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+  }
+
+  .chip.fault {
+    background-color: var(--warning-subtle);
+    color: var(--warning-color);
+  }
+
+  .identity-fields {
+    margin-top: 12px;
+  }
+
+  .autostart {
+    margin-top: 10px;
+    font-size: 0.9em;
   }
 
   .export-choice {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1311,6 +1311,7 @@
     "duplicated": "„{name}“ als „{copy}“ dupliziert",
     "restart": "Dieses Gerät neu starten: Uptime und Zähler ab null, und coldStart, falls es einen sendet",
     "restarted": "{name} wurde neu gestartet",
+    "autoStartChip": "startet mit SnmpLens",
     "export": {
       "title": "{count, plural, one {# Gerät} other {# Geräte}} exportieren",
       "hint": "Die Passwörter — Communities und Passphrasen — bleiben im Schlüsselbund Ihres Systems, es sei denn, Sie legen sie in die Datei. Tun Sie das nur, um eine vollständige Testumgebung weiterzugeben: Wer die Datei hat, kann sie lesen.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}: Die Datei enthält keine Passwörter — geben Sie ihm seine Community oder Passphrasen, bevor Sie es starten"
       }
     },
+    "faults": {
+      "button": "Fehler: dieses Gerät fehlerhaft verhalten lassen",
+      "hint": "Sofort angewendet, ohne das Gerät neu zu starten: Seine Uptime und Zähler sind das, woran ein Fehler getestet wird. Wird mit dem Gerät gespeichert.",
+      "mute": "Stumm: beantwortet nichts (Benachrichtigungen werden weiter gesendet)",
+      "latency": "Latenz",
+      "jitter": "Jitter",
+      "loss": "Verlust",
+      "error": "Fehlerantworten",
+      "errorNone": "Keine",
+      "counters": "Zähler",
+      "apply": "Anwenden",
+      "clear": "Alle entfernen",
+      "applied": "Fehler von {name} angewendet",
+      "cleared": "{name} verhält sich wieder normal",
+      "chip": {
+        "mute": "stumm",
+        "latency": "Latenz {ms} ms",
+        "latencyJitter": "Latenz {ms} ± {jitter} ms",
+        "loss": "Verlust {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "Zähler ×{speed}"
+      }
+    },
     "loopbackHint": "Nur Loopback: 127.0.0.1 bis 127.255.255.254 oder ::1. Unter Linux und macOS erfordert ein Port unter 1024 Administratorrechte.",
     "field": {
       "name": "Name",
@@ -1334,7 +1358,11 @@
       "port": "Port",
       "versions": "SNMP-Versionen",
       "community": "Community",
-      "v3": "SNMPv3-Benutzer"
+      "v3": "SNMPv3-Benutzer",
+      "location": "Standort (sysLocation)",
+      "contact": "Kontakt (sysContact)",
+      "modelDefault": "Der des Modells",
+      "autoStart": "Mit SnmpLens starten"
     },
     "problem": {
       "nameRequired": "Geben Sie dem Gerät einen Namen.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1311,6 +1311,7 @@
     "duplicated": "“{name}” duplicated as “{copy}”",
     "restart": "Restart this device: uptime and counters from zero, and coldStart if it sends one",
     "restarted": "{name} restarted",
+    "autoStartChip": "starts with SnmpLens",
     "export": {
       "title": "Export {count, plural, one {# device} other {# devices}}",
       "hint": "The passwords — communities and passphrases — stay in your system’s keychain unless you put them in the file. Put them in only to hand over a complete bench: anyone who has the file can read them.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}: the file carries no passwords — give it its community or passphrases before starting it"
       }
     },
+    "faults": {
+      "button": "Faults: make this device misbehave",
+      "hint": "Applied at once, without restarting the device: its uptime and counters are what a fault is tested against. Kept with the device.",
+      "mute": "Mute: answer nothing (notifications are still sent)",
+      "latency": "Latency",
+      "jitter": "Jitter",
+      "loss": "Loss",
+      "error": "Errors",
+      "errorNone": "None",
+      "counters": "Counters",
+      "apply": "Apply",
+      "clear": "Clear all",
+      "applied": "Faults of {name} applied",
+      "cleared": "{name} does nothing wrong any more",
+      "chip": {
+        "mute": "mute",
+        "latency": "latency {ms} ms",
+        "latencyJitter": "latency {ms} ± {jitter} ms",
+        "loss": "loss {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "counters ×{speed}"
+      }
+    },
     "loopbackHint": "Loopback only: 127.0.0.1 to 127.255.255.254, or ::1. On Linux and macOS, a port below 1024 needs administrator rights.",
     "field": {
       "name": "Name",
@@ -1334,7 +1358,11 @@
       "port": "Port",
       "versions": "SNMP versions",
       "community": "Community",
-      "v3": "SNMPv3 users"
+      "v3": "SNMPv3 users",
+      "location": "Location (sysLocation)",
+      "contact": "Contact (sysContact)",
+      "modelDefault": "The model’s own",
+      "autoStart": "Start with SnmpLens"
     },
     "problem": {
       "nameRequired": "Give the device a name.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1311,6 +1311,7 @@
     "duplicated": "«{name}» duplicado como «{copy}»",
     "restart": "Reiniciar este dispositivo: uptime y contadores desde cero, y coldStart si envía uno",
     "restarted": "{name} se reinició",
+    "autoStartChip": "se inicia con SnmpLens",
     "export": {
       "title": "Exportar {count, plural, one {# dispositivo} other {# dispositivos}}",
       "hint": "Las contraseñas — comunidades y frases de paso — se quedan en el llavero de su sistema, salvo que las ponga en el archivo. Hágalo solo para entregar un banco de pruebas completo: quien tenga el archivo podrá leerlas.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}: el archivo no trae contraseñas — dele su comunidad o sus frases de paso antes de iniciarlo"
       }
     },
+    "faults": {
+      "button": "Fallos: hacer que este dispositivo falle",
+      "hint": "Se aplican al momento, sin reiniciar el dispositivo: su uptime y sus contadores son contra lo que se prueba un fallo. Se guardan con el dispositivo.",
+      "mute": "Mudo: no responde a nada (las notificaciones siguen enviándose)",
+      "latency": "Latencia",
+      "jitter": "Variación",
+      "loss": "Pérdida",
+      "error": "Errores",
+      "errorNone": "Ninguno",
+      "counters": "Contadores",
+      "apply": "Aplicar",
+      "clear": "Quitar todos",
+      "applied": "Fallos de {name} aplicados",
+      "cleared": "{name} ya no falla",
+      "chip": {
+        "mute": "mudo",
+        "latency": "latencia {ms} ms",
+        "latencyJitter": "latencia {ms} ± {jitter} ms",
+        "loss": "pérdida {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "contadores ×{speed}"
+      }
+    },
     "loopbackHint": "Solo loopback: de 127.0.0.1 a 127.255.255.254, o ::1. En Linux y macOS, un puerto inferior a 1024 requiere permisos de administrador.",
     "field": {
       "name": "Nombre",
@@ -1334,7 +1358,11 @@
       "port": "Puerto",
       "versions": "Versiones SNMP",
       "community": "Comunidad",
-      "v3": "Usuarios SNMPv3"
+      "v3": "Usuarios SNMPv3",
+      "location": "Ubicación (sysLocation)",
+      "contact": "Contacto (sysContact)",
+      "modelDefault": "La del modelo",
+      "autoStart": "Iniciar con SnmpLens"
     },
     "problem": {
       "nameRequired": "Dé un nombre al dispositivo.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1311,6 +1311,7 @@
     "duplicated": "« {name} » dupliqué en « {copy} »",
     "restart": "Redémarrer cet appareil : uptime et compteurs à zéro, et coldStart s’il en envoie un",
     "restarted": "{name} a redémarré",
+    "autoStartChip": "démarre avec SnmpLens",
     "export": {
       "title": "Exporter {count, plural, one {# appareil} other {# appareils}}",
       "hint": "Les mots de passe — communautés et phrases secrètes — restent dans le coffre de votre système, sauf si vous les mettez dans le fichier. Ne les y mettez que pour transmettre un banc complet : quiconque a le fichier peut les lire.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name} : le fichier ne contient pas de mots de passe — donnez-lui sa communauté ou ses phrases secrètes avant de le démarrer"
       }
     },
+    "faults": {
+      "button": "Pannes : faire dysfonctionner cet appareil",
+      "hint": "Appliquées tout de suite, sans redémarrer l’appareil : son uptime et ses compteurs sont ce contre quoi une panne se teste. Gardées avec l’appareil.",
+      "mute": "Muet : ne répond à rien (les notifications partent toujours)",
+      "latency": "Latence",
+      "jitter": "Gigue",
+      "loss": "Perte",
+      "error": "Erreurs",
+      "errorNone": "Aucune",
+      "counters": "Compteurs",
+      "apply": "Appliquer",
+      "clear": "Tout effacer",
+      "applied": "Pannes de {name} appliquées",
+      "cleared": "{name} ne dysfonctionne plus",
+      "chip": {
+        "mute": "muet",
+        "latency": "latence {ms} ms",
+        "latencyJitter": "latence {ms} ± {jitter} ms",
+        "loss": "perte {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "compteurs ×{speed}"
+      }
+    },
     "loopbackHint": "Bouclage uniquement : de 127.0.0.1 à 127.255.255.254, ou ::1. Sous Linux et macOS, un port inférieur à 1024 exige des droits d'administrateur.",
     "field": {
       "name": "Nom",
@@ -1334,7 +1358,11 @@
       "port": "Port",
       "versions": "Versions SNMP",
       "community": "Communauté",
-      "v3": "Utilisateurs SNMPv3"
+      "v3": "Utilisateurs SNMPv3",
+      "location": "Emplacement (sysLocation)",
+      "contact": "Contact (sysContact)",
+      "modelDefault": "Celui du modèle",
+      "autoStart": "Démarrer avec SnmpLens"
     },
     "problem": {
       "nameRequired": "Donnez un nom à l'appareil.",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1311,6 +1311,7 @@
     "duplicated": "已将“{name}”复制为“{copy}”",
     "restart": "重启此设备：运行时间和计数器从零开始，如会发送 coldStart 则发送",
     "restarted": "{name} 已重启",
+    "autoStartChip": "随 SnmpLens 启动",
     "export": {
       "title": "导出 {count, plural, other {# 台设备}}",
       "hint": "密码（团体名和口令）保存在系统钥匙串中，除非您把它们写入文件。仅在需要交付完整测试环境时才这样做：拿到文件的人都能读取它们。",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}：文件中不含密码——启动前请为其设置团体名或口令"
       }
     },
+    "faults": {
+      "button": "故障：让此设备出现异常",
+      "hint": "立即生效，无需重启设备：故障正是针对其运行时间和计数器进行测试的。故障设置随设备保存。",
+      "mute": "静默：不响应任何请求（通知仍会发送）",
+      "latency": "延迟",
+      "jitter": "抖动",
+      "loss": "丢包",
+      "error": "错误",
+      "errorNone": "无",
+      "counters": "计数器",
+      "apply": "应用",
+      "clear": "全部清除",
+      "applied": "已应用 {name} 的故障",
+      "cleared": "{name} 已恢复正常",
+      "chip": {
+        "mute": "静默",
+        "latency": "延迟 {ms} ms",
+        "latencyJitter": "延迟 {ms} ± {jitter} ms",
+        "loss": "丢包 {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "计数器 ×{speed}"
+      }
+    },
     "loopbackHint": "仅限回环地址：127.0.0.1 至 127.255.255.254，或 ::1。在 Linux 和 macOS 上，低于 1024 的端口需要管理员权限。",
     "field": {
       "name": "名称",
@@ -1334,7 +1358,11 @@
       "port": "端口",
       "versions": "SNMP 版本",
       "community": "团体名",
-      "v3": "SNMPv3 用户"
+      "v3": "SNMPv3 用户",
+      "location": "位置（sysLocation）",
+      "contact": "联系人（sysContact）",
+      "modelDefault": "使用型号的默认值",
+      "autoStart": "随 SnmpLens 启动"
     },
     "problem": {
       "nameRequired": "请为设备命名。",

--- a/frontend/src/simulator/FaultsPanel.svelte
+++ b/frontend/src/simulator/FaultsPanel.svelte
@@ -1,0 +1,161 @@
+<script>
+  import { _ } from 'svelte-i18n';
+  import { createEventDispatcher } from 'svelte';
+  import Icon from '../Icon.svelte';
+  import { COUNTER_SPEEDS, MAX_LATENCY_MS, blankFaults, editableFaults, faultsPayload } from '../utils/simulator.js';
+
+  /**
+   * What a device is made to do wrong. Applied at once and without a restart —
+   * the device keeps the uptime and the counters a fault is tested against —
+   * and kept with it. The modal applies; this asks.
+   */
+  /** The device's faults, as the list gives them. */
+  export let faults = null;
+  /** Keeps the fields' ids unique when more than one panel is open. */
+  export let idPrefix = 'sim-faults';
+  export let busy = false;
+
+  const dispatch = createEventDispatcher();
+  let form = editableFaults(faults);
+
+  function clearAll() {
+    form = blankFaults();
+    dispatch('apply', faultsPayload(form));
+  }
+</script>
+
+<div class="faults">
+  <p class="hint"><Icon name="zap" size={14} /> {$_('simulator.faults.hint')}</p>
+  <label class="check">
+    <input type="checkbox" bind:checked={form.mute} /> {$_('simulator.faults.mute')}
+  </label>
+  <div class="fields">
+    <div class="field">
+      <label for="{idPrefix}-latency">{$_('simulator.faults.latency')}</label>
+      <span class="inputs">
+        <input id="{idPrefix}-latency" type="number" min="0" max={MAX_LATENCY_MS} step="50" bind:value={form.latencyMs} />
+        <span class="unit">ms ±</span>
+        <input id="{idPrefix}-jitter" type="number" min="0" max={MAX_LATENCY_MS} step="50" bind:value={form.jitterMs}
+          aria-label={$_('simulator.faults.jitter')} title={$_('simulator.faults.jitter')} />
+        <span class="unit">ms</span>
+      </span>
+    </div>
+    <div class="field">
+      <label for="{idPrefix}-loss">{$_('simulator.faults.loss')}</label>
+      <span class="inputs">
+        <input id="{idPrefix}-loss" type="number" min="0" max="100" bind:value={form.lossPercent} />
+        <span class="unit">%</span>
+      </span>
+    </div>
+    <div class="field">
+      <label for="{idPrefix}-error">{$_('simulator.faults.error')}</label>
+      <span class="inputs">
+        <select id="{idPrefix}-error" bind:value={form.error}>
+          <option value="">{$_('simulator.faults.errorNone')}</option>
+          <option value="genErr">genErr</option>
+          <option value="tooBig">tooBig</option>
+        </select>
+        {#if form.error}
+          <input id="{idPrefix}-error-share" type="number" min="1" max="100" bind:value={form.errorPercent}
+            aria-label={$_('simulator.faults.error')} />
+          <span class="unit">%</span>
+        {/if}
+      </span>
+    </div>
+    <div class="field">
+      <label for="{idPrefix}-counters">{$_('simulator.faults.counters')}</label>
+      <span class="inputs">
+        <select id="{idPrefix}-counters" bind:value={form.counterSpeed}>
+          {#each COUNTER_SPEEDS as s (s)}<option value={s}>×{s}</option>{/each}
+        </select>
+      </span>
+    </div>
+  </div>
+  <div class="foot">
+    <button type="button" class="btn secondary btn-small" on:click={() => dispatch('close')}>{$_('common.close')}</button>
+    <button type="button" class="btn secondary btn-small" disabled={busy} on:click={clearAll}>{$_('simulator.faults.clear')}</button>
+    <button type="button" class="btn btn-small" disabled={busy} on:click={() => dispatch('apply', faultsPayload(form))}>
+      {$_('simulator.faults.apply')}
+    </button>
+  </div>
+</div>
+
+<style>
+  .faults {
+    flex-basis: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 8px;
+    padding: 10px 12px;
+    background-color: var(--bg-color);
+    border: 1px solid var(--warning-border);
+    border-radius: 6px;
+  }
+
+  .hint {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.82em;
+    line-height: 1.4;
+    color: var(--text-muted);
+  }
+
+  .check {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+    cursor: pointer;
+  }
+
+  .fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 10px 16px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .field label {
+    font-size: 0.85em;
+    color: var(--text-light);
+  }
+
+  .inputs {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .inputs input {
+    width: 80px;
+  }
+
+  input,
+  select {
+    padding: 5px 8px;
+    background-color: var(--bg-lighter-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+  }
+
+  .unit {
+    font-size: 0.85em;
+    color: var(--text-muted);
+  }
+
+  .foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>

--- a/frontend/src/stores/simulatorStore.js
+++ b/frontend/src/stores/simulatorStore.js
@@ -19,6 +19,7 @@ import {
   SimulatorExportDevicesDialog,
   SimulatorDuplicateDevice,
   SimulatorRestartDevice,
+  SimulatorSetFaults,
   TrapListenerEngineID,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
@@ -117,6 +118,8 @@ function createSimulatorStore() {
     exportDevices: async (ids, withSecrets) => (await SimulatorExportDevicesDialog(ids || [], !!withSecrets)) || '',
     duplicate: (id, name) => SimulatorDuplicateDevice(id, name),
     restart: (id) => SimulatorRestartDevice(id),
+    /** Changes what a device does wrong, at once and without restarting it. */
+    setFaults: (id, faults) => SimulatorSetFaults(id, faults),
     /** The engine ID SnmpLens's own trap listener stands for, in hex. */
     listenerEngineId: async () => (await TrapListenerEngineID()) || '',
   };

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -85,6 +85,9 @@ export function blankDevice(model, suggestion) {
     community: 'public',
     users: [blankV3()],
     traps: blankTraps(),
+    location: '',
+    contact: '',
+    autoStart: false,
   };
 }
 
@@ -111,6 +114,9 @@ export function editableDevice(view, creds) {
     versions: [...(view.versions || [])],
     community: creds?.community || '',
     users: users.length ? users : [blankV3()],
+    location: view.location || '',
+    contact: view.contact || '',
+    autoStart: !!view.autoStart,
     traps: {
       destinations: (view.traps?.destinations || []).map((t) => ({
         id: t.id,
@@ -231,6 +237,9 @@ export function devicePayload(d) {
           privPass: u.privPass,
         }))
       : [],
+    location: (d.location || '').trim(),
+    contact: (d.contact || '').trim(),
+    autoStart: !!d.autoStart,
     engineId: '',
     engineBoots: 0,
     // Each destination with only what its version uses, as the users are.
@@ -397,6 +406,79 @@ export function deviceImportReport(results) {
     }
   }
   return out;
+}
+
+/** The speeds a device's counters can run at, and the longest latency, as pkg/simulator bounds them. */
+export const COUNTER_SPEEDS = [1, 10, 100, 1000];
+export const MAX_LATENCY_MS = 10000;
+
+/** A device doing nothing wrong. */
+export function blankFaults() {
+  return { latencyMs: 0, jitterMs: 0, lossPercent: 0, mute: false, error: '', errorPercent: 0, counterSpeed: 1 };
+}
+
+/**
+ * A device's faults in the panel's shape: an error, once chosen, answers every
+ * request until a share is given.
+ */
+export function editableFaults(f) {
+  return {
+    ...blankFaults(),
+    ...(f || {}),
+    counterSpeed: Math.max(Number(f?.counterSpeed) || 1, 1),
+    errorPercent: f?.error ? f.errorPercent : 100,
+  };
+}
+
+/** The faults as SimulatorSetFaults takes them: whole numbers in bounds, and no share of errors without an error. */
+export function faultsPayload(f) {
+  const whole = (v, lo, hi) => Math.min(Math.max(Math.round(Number(v) || 0), lo), hi);
+  const error = f.error === 'tooBig' || f.error === 'genErr' ? f.error : '';
+  return {
+    latencyMs: whole(f.latencyMs, 0, MAX_LATENCY_MS),
+    jitterMs: whole(f.jitterMs, 0, MAX_LATENCY_MS),
+    lossPercent: whole(f.lossPercent, 0, 100),
+    mute: !!f.mute,
+    error,
+    errorPercent: error ? whole(f.errorPercent, 1, 100) : 0,
+    counterSpeed: COUNTER_SPEEDS.includes(Number(f.counterSpeed)) ? Number(f.counterSpeed) : 1,
+  };
+}
+
+/**
+ * What a device is made to do wrong, as the chips its row shows: i18n key
+ * suffixes (simulator.faults.chip.<key>) and what each sentence quotes.
+ */
+export function faultChips(f) {
+  const out = [];
+  if (!f) return out;
+  if (f.mute) out.push({ key: 'mute', values: {} });
+  if (f.latencyMs || f.jitterMs) {
+    out.push({ key: f.jitterMs ? 'latencyJitter' : 'latency', values: { ms: f.latencyMs, jitter: f.jitterMs } });
+  }
+  if (f.lossPercent) out.push({ key: 'loss', values: { percent: f.lossPercent } });
+  if (f.error) out.push({ key: 'error', values: { error: f.error, percent: f.errorPercent } });
+  if (f.counterSpeed > 1) out.push({ key: 'counters', values: { speed: f.counterSpeed } });
+  return out;
+}
+
+/**
+ * The devices grouped by their model's category, the categories in the order
+ * the catalogue gives them; a device of a model since deleted is filed under
+ * "other".
+ */
+export function deviceGroups(devices, models) {
+  const order = categoriesOf(models);
+  const rank = (c) => (order.includes(c) ? order.indexOf(c) : order.length);
+  const groups = new Map();
+  for (const d of devices || []) {
+    const category = modelOf(models, d.model)?.category || 'other';
+    if (!groups.has(category)) groups.set(category, []);
+    groups.get(category).push(d);
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => rank(a) - rank(b))
+    .map(([category, list]) => ({ category, devices: list }));
 }
 
 /** The categories a recorded model may be filed under: Go's customCategories. */

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -67,6 +67,12 @@ const {
   importReport,
   firstImported,
   deviceImportReport,
+  blankFaults,
+  editableFaults,
+  faultsPayload,
+  faultChips,
+  deviceGroups,
+  COUNTER_SPEEDS,
   CUSTOM_CATEGORIES,
   recordableTargets,
   recordRequest,
@@ -464,5 +470,52 @@ for (const key of ['title', 'hint', 'without', 'with', 'done']) {
 for (const key of ['imported', 'failed']) {
   check(`en.json says simulator.devices.${key}`, Boolean(en.simulator?.devices?.[key]));
 }
+
+/* --- faults ---------------------------------------------------------------- */
+
+// What the panel sends is exactly what Go's Faults reads, in bounds: a share of
+// errors only with an error, a counter speed Go accepts.
+const faultsGo = readFileSync(new URL('../../pkg/simulator/faults.go', import.meta.url), 'utf8');
+const faultTags = goTags(faultsGo, 'Faults').sort();
+const sentFaults = faultsPayload({ latencyMs: '250.4', jitterMs: 99999, lossPercent: -5, mute: 1, error: 'genErr', errorPercent: 0, counterSpeed: '100' });
+check('the faults sent are what Go reads, and nothing else',
+  faultTags.length === 7 && JSON.stringify(Object.keys(sentFaults).sort()) === JSON.stringify(faultTags),
+  `${Object.keys(sentFaults).sort()} vs ${faultTags}`);
+check('and in bounds',
+  sentFaults.latencyMs === 250 && sentFaults.jitterMs === 10000 && sentFaults.lossPercent === 0 && sentFaults.mute === true &&
+  sentFaults.errorPercent === 1 && sentFaults.counterSpeed === 100, JSON.stringify(sentFaults));
+check('no share of errors without an error, and an unknown speed is 1',
+  faultsPayload({ ...blankFaults(), errorPercent: 40, error: 'noSuchName', counterSpeed: 7 }).errorPercent === 0 &&
+  faultsPayload({ ...blankFaults(), counterSpeed: 7 }).counterSpeed === 1);
+check('the speeds offered are those Go accepts',
+  JSON.stringify(COUNTER_SPEEDS) === JSON.stringify([...faultsGo.matchAll(/counterSpeeds = \[\]int\{([^}]*)\}/g)][0][1]
+    .split(',').map((s) => Number(s.trim())).filter((n) => n > 0)));
+check('an error chosen in the panel answers every request until a share is given',
+  editableFaults({ ...blankFaults(), error: '' }).errorPercent === 100 &&
+  editableFaults({ ...blankFaults(), error: 'tooBig', errorPercent: 30 }).errorPercent === 30);
+const chips = faultChips({ latencyMs: 500, jitterMs: 100, lossPercent: 10, mute: true, error: 'tooBig', errorPercent: 20, counterSpeed: 1000 });
+check('a device doing everything wrong says so, fault by fault',
+  chips.map((c) => c.key).join() === 'mute,latencyJitter,loss,error,counters' && faultChips(blankFaults()).length === 0,
+  JSON.stringify(chips));
+for (const key of ['button', 'hint', 'mute', 'latency', 'jitter', 'loss', 'error', 'errorNone', 'counters', 'apply', 'clear', 'applied', 'cleared']) {
+  check(`en.json says simulator.faults.${key}`, Boolean(en.simulator?.faults?.[key]));
+}
+for (const key of ['mute', 'latency', 'latencyJitter', 'loss', 'error', 'counters']) {
+  check(`en.json says simulator.faults.chip.${key}`, Boolean(en.simulator?.faults?.chip?.[key]));
+}
+for (const key of ['location', 'contact', 'modelDefault', 'autoStart']) {
+  check(`en.json says simulator.field.${key}`, Boolean(en.simulator?.field?.[key]));
+}
+
+// The list files each device under its model's category, in the catalogue's
+// order, and a device of a model since deleted under "other".
+const groupModels = [{ id: 'linux-server', category: 'server' }, { id: 'cisco-catalyst-24', category: 'network' }];
+const filed = deviceGroups([
+  { id: '1', model: 'cisco-catalyst-24' }, { id: '2', model: 'custom:gone' }, { id: '3', model: 'linux-server' },
+  { id: '4', model: 'linux-server' },
+], groupModels);
+check('devices are grouped by category, in the catalogue order',
+  filed.map((g) => `${g.category}:${g.devices.map((d) => d.id).join('+')}`).join(' ') === 'server:3+4 network:1 other:2',
+  JSON.stringify(filed));
 
 process.exit(failures ? 1 : 0);

--- a/pkg/simulator/agent.go
+++ b/pkg/simulator/agent.go
@@ -50,6 +50,8 @@ type Config struct {
 	Notifications []Notification
 	// Traps is where the agent sends them, and when.
 	Traps Traps
+	// Faults are what the agent is made to do wrong; see Faults.
+	Faults Faults
 }
 
 // Stats counts what an agent did with what it received — most of all what it
@@ -113,6 +115,11 @@ type Agent struct {
 	started time.Time
 
 	stats counters
+
+	// faults is what the agent is made to do wrong (faults.go), read on every
+	// message; faultMu serialises changing it, which moves the counters' warp.
+	faults  atomic.Pointer[faultState]
+	faultMu sync.Mutex
 }
 
 // NewAgent checks cfg and prepares an agent; Start makes it answer.
@@ -167,6 +174,10 @@ func NewAgent(cfg Config) (*Agent, error) {
 	if a.notify, err = newNotifier(a, cfg); err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
+	if err := cfg.Faults.Check(); err != nil {
+		return nil, fmt.Errorf("simulator: faults: %w", err)
+	}
+	a.faults.Store(&faultState{faults: cfg.Faults})
 	return a, nil
 }
 
@@ -200,6 +211,12 @@ func (a *Agent) Start() error {
 	a.conn = conn
 	a.done = make(chan struct{})
 	a.started = time.Now()
+	// Counters made to run fast run so from the start.
+	if fs := a.faults.Load(); fs != nil {
+		a.faultMu.Lock()
+		a.setFaultsLocked(fs.faults, a.started, a.started)
+		a.faultMu.Unlock()
+	}
 	go a.serve(conn, a.started, a.done)
 	if a.notify != nil {
 		a.notify.start()
@@ -279,7 +296,23 @@ func (a *Agent) serve(conn *net.UDPConn, started time.Time, done chan struct{}) 
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}
-		if out := a.handle(buf[:n], clock{started: started, now: time.Now(), stats: &a.stats}); out != nil {
+		fs := a.faults.Load()
+		if fs != nil && fs.faults.drops(roll()) {
+			// Lost on the way: the agent never sees it, and counts nothing.
+			continue
+		}
+		c := clock{started: started, now: time.Now(), stats: &a.stats}
+		if fs != nil {
+			c.warp = fs.warp
+		}
+		out := a.handle(buf[:n], c)
+		switch {
+		case out == nil:
+		case fs != nil && (fs.faults.LatencyMs > 0 || fs.faults.JitterMs > 0):
+			// Late, and without holding up the messages after it: a slow
+			// device, not a stuck one.
+			time.AfterFunc(fs.faults.delay(draw()), func() { _, _ = conn.WriteToUDPAddrPort(out, from) })
+		default:
 			_, _ = conn.WriteToUDPAddrPort(out, from)
 		}
 	}

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -40,6 +40,15 @@ type Device struct {
 	EngineBoots uint32 `json:"engineBoots"`
 	// Traps is what the device sends, where to and when.
 	Traps Traps `json:"traps"`
+	// Location and Contact are the device's sysLocation and sysContact, in
+	// place of its model's when they are given.
+	Location string `json:"location"`
+	Contact  string `json:"contact"`
+	// AutoStart starts the device with the application.
+	AutoStart bool `json:"autoStart"`
+	// Faults are what the device is made to do wrong: changed while it runs
+	// (Fleet.SetFaults), and kept with it.
+	Faults Faults `json:"faults"`
 }
 
 // Listen is the address the device answers on, in the form CheckListen reads.
@@ -107,6 +116,12 @@ func (d Device) Validate() error {
 	}
 	if err := d.Traps.check(users, m.catalogue()); err != nil {
 		return err
+	}
+	if len(d.Location) > 255 || len(d.Contact) > 255 {
+		return errors.New("a device's location and contact are at most 255 octets")
+	}
+	if err := d.Faults.Check(); err != nil {
+		return fmt.Errorf("faults: %w", err)
 	}
 	if id, err := hex.DecodeString(d.EngineID); err != nil || len(id) < 5 || len(id) > 32 {
 		return errors.New("a device's engine ID is 5 to 32 octets, in hex")
@@ -223,14 +238,16 @@ func (d Device) config() (Config, error) {
 		return Config{}, fmt.Errorf("engine ID: %w", err)
 	}
 	return Config{
-		Listen:        d.Listen(),
-		Versions:      d.Versions,
-		Community:     d.Community,
-		Users:         d.Users,
-		EngineID:      engineID,
-		EngineBoots:   d.EngineBoots,
-		Objects:       m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID)}),
+		Listen:      d.Listen(),
+		Versions:    d.Versions,
+		Community:   d.Community,
+		Users:       d.Users,
+		EngineID:    engineID,
+		EngineBoots: d.EngineBoots,
+		Objects: m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID),
+			Location: strings.TrimSpace(d.Location), Contact: strings.TrimSpace(d.Contact)}),
 		Notifications: m.catalogue(),
 		Traps:         d.Traps.clone(),
+		Faults:        d.Faults,
 	}, nil
 }

--- a/pkg/simulator/devicefile.go
+++ b/pkg/simulator/devicefile.go
@@ -57,6 +57,8 @@ type FileDevice struct {
 	Community string   `json:"community,omitempty"`
 	Users     []User   `json:"users,omitempty"`
 	Traps     Traps    `json:"traps"`
+	Location  string   `json:"location,omitempty"`
+	Contact   string   `json:"contact,omitempty"`
 }
 
 // ExportDevices is the file holding devices, their secrets in it or not.
@@ -78,7 +80,8 @@ func ExportDevices(devices []Device, withSecrets bool) ([]byte, error) {
 			traps.Schedules = []Schedule{}
 		}
 		f.Devices[i] = FileDevice{Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
-			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps}
+			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps,
+			Location: d.Location, Contact: d.Contact}
 	}
 	raw, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
@@ -130,7 +133,8 @@ func ParseDeviceFile(raw []byte) (DeviceFile, error) {
 func (fd FileDevice) Device() Device {
 	return Device{Name: strings.TrimSpace(fd.Name), Model: fd.Model, Address: strings.TrimSpace(fd.Address),
 		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community,
-		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone()}
+		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone(),
+		Location: strings.TrimSpace(fd.Location), Contact: strings.TrimSpace(fd.Contact)}
 }
 
 // ValidateWithoutSecrets is Validate for a device whose secrets are yet to be

--- a/pkg/simulator/faults.go
+++ b/pkg/simulator/faults.go
@@ -1,0 +1,164 @@
+package simulator
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Faults are what a simulated device is made to do wrong, so that SnmpLens can
+// be tested against it: a reachability alert against a device that stops
+// answering, the overload guardrail against one that answers slowly, the rate
+// derived across a counter's wrap against one whose counters run fast. They are
+// changed while the device runs (Agent.SetFaults) — restarting it would throw
+// away the uptime and the counters a test is watching — and kept with it.
+type Faults struct {
+	// LatencyMs delays every answer, and JitterMs adds up to as much again at
+	// random.
+	LatencyMs int `json:"latencyMs"`
+	JitterMs  int `json:"jitterMs"`
+	// LossPercent of the requests are lost before the agent sees them, as a
+	// lossy link loses them.
+	LossPercent int `json:"lossPercent"`
+	// Mute answers nothing: a device that has stopped answering. What it sends
+	// — its notifications — it still sends.
+	Mute bool `json:"mute"`
+	// Error answers ErrorPercent of the requests with that error instead of
+	// their answer: FaultTooBig or FaultGenErr.
+	Error        string `json:"error"`
+	ErrorPercent int    `json:"errorPercent"`
+	// CounterSpeed runs the counters that many times faster — 1 (or 0), 10, 100
+	// or 1000 — so that a Counter32 wraps in minutes rather than in days.
+	CounterSpeed int `json:"counterSpeed"`
+}
+
+// MaxLatencyMs bounds a latency and its jitter: past it, a manager has long
+// since given up.
+const MaxLatencyMs = 10000
+
+// The errors a device can be made to answer with.
+const (
+	FaultTooBig = "tooBig"
+	FaultGenErr = "genErr"
+)
+
+// counterSpeeds are the speeds a device's counters can run at; 0 is 1.
+var counterSpeeds = []int{0, 1, 10, 100, 1000}
+
+// Check reports the first thing wrong with f.
+func (f Faults) Check() error {
+	switch {
+	case f.LatencyMs < 0 || f.LatencyMs > MaxLatencyMs || f.JitterMs < 0 || f.JitterMs > MaxLatencyMs:
+		return fmt.Errorf("a latency and its jitter are 0 to %d ms", MaxLatencyMs)
+	case f.LossPercent < 0 || f.LossPercent > 100:
+		return errors.New("a loss is 0 to 100 %")
+	case f.Error != "" && f.Error != FaultTooBig && f.Error != FaultGenErr:
+		return fmt.Errorf("%q is not an error a device can be made to answer with: %s or %s", f.Error, FaultTooBig, FaultGenErr)
+	case f.Error != "" && (f.ErrorPercent < 1 || f.ErrorPercent > 100):
+		return errors.New("an error answers 1 to 100 % of the requests")
+	case f.Error == "" && f.ErrorPercent != 0:
+		return errors.New("a share of errors needs an error")
+	case !slices.Contains(counterSpeeds, f.CounterSpeed):
+		return fmt.Errorf("counters run at 1, 10, 100 or 1000 times their speed, not %d", f.CounterSpeed)
+	}
+	return nil
+}
+
+// speed is how many times faster the counters run.
+func (f Faults) speed() float64 { return float64(max(f.CounterSpeed, 1)) }
+
+// drops reports whether a request is lost, roll being drawn from [0, 100).
+func (f Faults) drops(roll int) bool { return f.Mute || roll < f.LossPercent }
+
+// errs reports whether a request is answered with the error, roll being drawn
+// from [0, 100).
+func (f Faults) errs(roll int) bool { return f.Error != "" && roll < f.ErrorPercent }
+
+// delay is how long an answer waits, share being drawn from [0, 1).
+func (f Faults) delay(share float64) time.Duration {
+	return time.Duration((float64(f.LatencyMs) + share*float64(f.JitterMs)) * float64(time.Millisecond))
+}
+
+// roll and draw are the chances a fault is decided by. Not a secret, so
+// math/rand's.
+func roll() int     { return rand.IntN(100) }
+func draw() float64 { return rand.Float64() }
+
+// warp is how far the counters had run, in the seconds they count, when their
+// speed last changed: they run on from there at the new speed. So a counter
+// made to run faster turns faster and never jumps, and one slowed down again
+// never goes back — a counter that went back would read as a wrap.
+type warp struct {
+	at    time.Time
+	base  float64 // the counters' seconds at `at`
+	speed float64
+}
+
+// counterSeconds is how far the counters have run at c: the time since the
+// agent started, or where its warp has taken them.
+func counterSeconds(c clock) float64 {
+	if c.warp == nil {
+		return elapsed(c)
+	}
+	return c.warp.base + c.now.Sub(c.warp.at).Seconds()*c.warp.speed
+}
+
+// faultState is the faults an agent runs with, and where its counters are.
+type faultState struct {
+	faults Faults
+	warp   *warp
+}
+
+// SetFaults changes what a running agent does wrong, from its next message on,
+// without restarting it.
+func (a *Agent) SetFaults(f Faults) error {
+	if err := f.Check(); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	started := a.started
+	a.mu.Unlock()
+	a.faultMu.Lock()
+	defer a.faultMu.Unlock()
+	if started.IsZero() {
+		// Start runs the counters from where the faults say.
+		a.faults.Store(&faultState{faults: f})
+		return nil
+	}
+	a.setFaultsLocked(f, time.Now(), started)
+	return nil
+}
+
+// setFaultsLocked keeps f, and moves the counters' warp on when their speed
+// changes, so that they run on from where they are at now. faultMu is held.
+func (a *Agent) setFaultsLocked(f Faults, now, started time.Time) {
+	next := &faultState{faults: f}
+	if prev := a.faults.Load(); prev != nil {
+		next.warp = prev.warp
+	}
+	switch speed := f.speed(); {
+	case next.warp == nil && speed == 1:
+	case next.warp == nil:
+		next.warp = &warp{at: now, base: now.Sub(started).Seconds(), speed: speed}
+	case next.warp.speed != speed:
+		next.warp = &warp{at: now, base: counterSeconds(clock{started: started, now: now, warp: next.warp}), speed: speed}
+	}
+	a.faults.Store(next)
+}
+
+// injectedError is the error the agent's faults answer a request with instead
+// of its answer, if they answer this one with one.
+func (a *Agent) injectedError(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket) (answer, bool) {
+	fs := a.faults.Load()
+	if fs == nil || !fs.faults.errs(roll()) {
+		return answer{}, false
+	}
+	if fs.faults.Error == FaultTooBig {
+		return tooBig(ver, req), true
+	}
+	return answer{vars: req.Variables, status: gosnmp.GenErr, index: errIndex(0, len(req.Variables))}, true
+}

--- a/pkg/simulator/faults_test.go
+++ b/pkg/simulator/faults_test.go
@@ -1,0 +1,124 @@
+package simulator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A fault is checked before it is applied: a share without its error, a speed
+// the counters cannot run at or a latency past any timeout is refused.
+func TestAFaultIsChecked(t *testing.T) {
+	for _, ok := range []Faults{{}, {LatencyMs: 500, JitterMs: 100}, {LossPercent: 100}, {Mute: true},
+		{Error: FaultGenErr, ErrorPercent: 30}, {Error: FaultTooBig, ErrorPercent: 100}, {CounterSpeed: 1000}} {
+		if err := ok.Check(); err != nil {
+			t.Errorf("%+v: %v", ok, err)
+		}
+	}
+	for _, bad := range []Faults{{LatencyMs: -1}, {LatencyMs: MaxLatencyMs + 1}, {JitterMs: MaxLatencyMs + 1},
+		{LossPercent: 101}, {Error: "noSuchName", ErrorPercent: 10}, {Error: FaultGenErr}, {ErrorPercent: 10},
+		{CounterSpeed: 7}} {
+		if bad.Check() == nil {
+			t.Errorf("%+v was accepted", bad)
+		}
+	}
+}
+
+// Whether a request is lost, or answered with an error, is a share of the
+// rolls; a mute device loses them all.
+func TestAFaultIsAShareOfTheRequests(t *testing.T) {
+	loss := Faults{LossPercent: 30}
+	errs := Faults{Error: FaultGenErr, ErrorPercent: 30}
+	for roll := 0; roll < 100; roll++ {
+		if loss.drops(roll) != (roll < 30) || errs.errs(roll) != (roll < 30) {
+			t.Fatalf("roll %d", roll)
+		}
+		if !(Faults{Mute: true}).drops(roll) || (Faults{}).drops(roll) || (Faults{}).errs(roll) {
+			t.Fatalf("roll %d: a mute device, or one doing nothing wrong", roll)
+		}
+	}
+}
+
+// Counters made to run faster turn faster from where they are, and slowed down
+// again they run on from there: never a jump and never a step back, either of
+// which would read as a wrap.
+func TestCountersChangeSpeedWithoutJumping(t *testing.T) {
+	a := &Agent{}
+	t0 := time.Now()
+	at := func(s float64) time.Time { return t0.Add(time.Duration(s * float64(time.Second))) }
+	seconds := func(s float64) float64 {
+		c := clock{started: t0, now: at(s)}
+		if fs := a.faults.Load(); fs != nil {
+			c.warp = fs.warp
+		}
+		return counterSeconds(c)
+	}
+	a.setFaultsLocked(Faults{}, t0, t0)
+	if got := seconds(10); got != 10 {
+		t.Fatalf("at 10 s the counters count %v", got)
+	}
+	a.setFaultsLocked(Faults{CounterSpeed: 100}, at(10), t0)
+	if got := seconds(10); got != 10 {
+		t.Errorf("sped up, the counters jumped to %v", got)
+	}
+	if got := seconds(11); got != 110 {
+		t.Errorf("a second at ×100 counts %v", got)
+	}
+	a.setFaultsLocked(Faults{LossPercent: 5, CounterSpeed: 100}, at(11), t0)
+	if got := seconds(12); got != 210 {
+		t.Errorf("another fault moved the counters: %v", got)
+	}
+	a.setFaultsLocked(Faults{}, at(12), t0)
+	if got := seconds(12); got != 210 {
+		t.Errorf("slowed down, the counters went to %v", got)
+	}
+	if got := seconds(13); got != 211 {
+		t.Errorf("a second at ×1 counts %v", got)
+	}
+}
+
+// A running device's faults change from its next message on: a mute device
+// answers nothing, one made to err answers with the error, a slow one late,
+// and one cleared answers again — none of it restarting it.
+func TestFaultsChangeWhileTheDeviceRuns(t *testing.T) {
+	a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public"})
+	g := manager(a, gosnmp.Version2c, "public")
+	g.Timeout = silent
+	connect(t, g)
+	set := func(f Faults) {
+		t.Helper()
+		if err := a.SetFaults(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	set(Faults{Mute: true})
+	if _, err := g.Get([]string{sysDescrOID}); err == nil {
+		t.Error("a mute device answered")
+	}
+	set(Faults{Error: FaultGenErr, ErrorPercent: 100})
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.GenErr {
+		t.Errorf("made to answer genErr: %v, %v", res, err)
+	}
+	set(Faults{Error: FaultTooBig, ErrorPercent: 100})
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.TooBig || len(res.Variables) != 0 {
+		t.Errorf("made to answer tooBig: %v, %v", res, err)
+	}
+	set(Faults{LatencyMs: 300})
+	g.Timeout = 3 * time.Second
+	start := time.Now()
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.NoError {
+		t.Errorf("a slow device: %v, %v", res, err)
+	}
+	if took := time.Since(start); took < 300*time.Millisecond {
+		t.Errorf("a device made to wait 300 ms answered in %v", took)
+	}
+	set(Faults{})
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.NoError {
+		t.Errorf("cleared: %v, %v", res, err)
+	}
+	if err := a.SetFaults(Faults{LossPercent: 101}); err == nil {
+		t.Error("a loss of 101 % was set")
+	}
+}

--- a/pkg/simulator/fleet.go
+++ b/pkg/simulator/fleet.go
@@ -88,6 +88,18 @@ func (f *Fleet) Notify(id, name string) ([]Delivery, error) {
 	return a.Notify(name)
 }
 
+// SetFaults changes what a running device does wrong, without restarting it;
+// see Agent.SetFaults.
+func (f *Fleet) SetFaults(id string, faults Faults) error {
+	f.mu.Lock()
+	a := f.agents[id]
+	f.mu.Unlock()
+	if a == nil {
+		return ErrNotRunning
+	}
+	return a.SetFaults(faults)
+}
+
 // Status reports whether a device is running, and its counters if it is.
 func (f *Fleet) Status(id string) (Stats, bool) {
 	f.mu.Lock()

--- a/pkg/simulator/model.go
+++ b/pkg/simulator/model.go
@@ -1,6 +1,7 @@
 package simulator
 
 import (
+	"cmp"
 	"slices"
 
 	"github.com/gosnmp/gosnmp"
@@ -31,6 +32,9 @@ type Identity struct {
 	// Seed decides how the device's values move, so two devices of one model
 	// do not move in step.
 	Seed uint64
+	// Location and Contact are the device's own sysLocation and sysContact,
+	// which take the place of its model's when they are given.
+	Location, Contact string
 }
 
 type model struct {
@@ -106,13 +110,14 @@ func (o *objects) addForNotify(oid string, t gosnmp.Asn1BER, r Reading) {
 
 // addSystem adds the system group (RFC 3418) as a model's agent answers it.
 // sysServices adds up the layers the device serves: 2 a bridge, 4 a router,
-// 8 end to end, 64 applications.
+// 8 end to end, 64 applications. The contact and location a device was given
+// take the place of its model's.
 func addSystem(o *objects, id Identity, descr, sysObjectID, contact, location string, services int) {
 	o.add("1.3.6.1.2.1.1.1.0", gosnmp.OctetString, Const(descr))
 	o.add("1.3.6.1.2.1.1.2.0", gosnmp.ObjectIdentifier, Const(sysObjectID))
 	o.add("1.3.6.1.2.1.1.3.0", gosnmp.TimeTicks, Uptime())
-	o.add("1.3.6.1.2.1.1.4.0", gosnmp.OctetString, Const(contact))
+	o.add("1.3.6.1.2.1.1.4.0", gosnmp.OctetString, Const(cmp.Or(id.Contact, contact)))
 	o.add("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, Const(id.Name))
-	o.add("1.3.6.1.2.1.1.6.0", gosnmp.OctetString, Const(location))
+	o.add("1.3.6.1.2.1.1.6.0", gosnmp.OctetString, Const(cmp.Or(id.Location, location)))
 	o.add("1.3.6.1.2.1.1.7.0", gosnmp.Integer, Const(services))
 }

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -515,6 +515,9 @@ func (nt *notifier) pick(name string) (Notification, bool) {
 func (nt *notifier) deliver(o *outbound, n Notification) error {
 	a := nt.a
 	c := clock{started: a.started, now: time.Now(), stats: &a.stats}
+	if fs := a.faults.Load(); fs != nil {
+		c.warp = fs.warp
+	}
 	g := &gosnmp.GoSNMP{
 		Target:    o.dial,
 		Port:      uint16(o.Port),

--- a/pkg/simulator/pdu.go
+++ b/pkg/simulator/pdu.go
@@ -36,7 +36,10 @@ func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock)
 	case gosnmp.SetRequest:
 		st.inSets.Add(1)
 	}
-	ans := a.dispatch(ver, req, c)
+	ans, injected := a.injectedError(ver, req)
+	if !injected {
+		ans = a.dispatch(ver, req, c)
+	}
 	if ans.status == gosnmp.NoError && req.PDUType != gosnmp.SetRequest {
 		st.inTotalReqVars.Add(uint32(len(ans.vars)))
 	}

--- a/pkg/simulator/tree.go
+++ b/pkg/simulator/tree.go
@@ -46,6 +46,9 @@ type clock struct {
 	// stats are the agent's own counters, which SNMPv2-MIB's snmp group and
 	// the USM statistics read (agentObjects); nil where no agent is answering.
 	stats *counters
+	// warp is where the counters are once a fault has changed their speed
+	// (faults.go); nil when none ever has.
+	warp *warp
 }
 
 // uptime is the time since the agent started, in hundredths of a second.

--- a/pkg/simulator/values.go
+++ b/pkg/simulator/values.go
@@ -110,7 +110,7 @@ func (c counter) count(t float64) uint64 {
 }
 
 func (c counter) read(k clock) any {
-	n := c.count(elapsed(k))
+	n := c.count(counterSeconds(k))
 	switch {
 	case c.wide:
 		return n


### PR DESCRIPTION
Stacked on #73 — review that one first; this diff is against its head.

Step 6 of the simulator plan, second part: the faults the plan describes, and the editor's identity fields.

## Faults

A **Faults** button (⚡) on each device opens a panel; what it sets is applied to the **running** agent at once, without a restart — a reachability alert, the overload guardrail or the rate across a counter wrap is tested against exactly the uptime and counters a restart would reset. Faults are kept with the device (and survive an edit in the editor, which does not show them), and the device's row shows each one as a chip.

| Fault | What the agent does |
| --- | --- |
| Latency ± jitter (0–10 000 ms) | Answers late, through `time.AfterFunc`: a slow device, not one that holds up every request behind the first |
| Loss (0–100 %) | Drops that share of the requests before counting anything, as a lossy link would |
| Mute | Answers nothing at all — notifications still go out |
| Error, share (1–100 %) | Answers that share with `genErr`, or `tooBig` (empty varbinds in v2c/v3, RFC 3416 4.2.1; the request's own in v1), in `process` — the path v1, v2c and v3 share |
| Counters ×10 / ×100 / ×1000 | Runs every counter that much faster, so a Counter32 wraps in minutes |

The counters' speed goes through a **warp** carried by each request's clock: the counter-seconds at the moment the speed changed, and the new speed from there. A speed change makes a counter turn faster or slower, never jump and never go back — either would read as a wrap to the very arithmetic the fault is there to test. Gauges keep real time; notifications read the same warped counters.

## A device's own identity

- **Location** and **Contact** in the editor: the device's sysLocation and sysContact, in place of its model's (`addSystem`, so built-in models, custom models and recorded packages alike). They travel in a bench file.
- **Start with SnmpLens**: per device and opt-in, started at launch once the secret store is open. Until now nothing started by itself; that stays the default.

## The list

Devices are grouped by their model's category, in the catalogue's order.

## Tests

- `pkg/simulator`: faults checked (bounds, a share without an error, an unknown speed); loss and errors as a share of the rolls; `TestCountersChangeSpeedWithoutJumping` (continuity through ×100 and back); `TestFaultsChangeWhileTheDeviceRuns` against a real agent — mute, genErr, tooBig, a 300 ms latency, cleared — none restarting it.
- App: faults set without a restart (boots unchanged), kept in `simulator.json`, kept through an editor save, cleared; a device's own location and contact answered; `AutoStart` starting one device and not another.
- `simulator.test.mjs`: the faults sent carry exactly `Faults`' JSON tags and stay in bounds; the offered speeds are Go's; the chips; the grouping.

Gates run locally: `go vet`, `staticcheck` 0.8.1, `go test -race ./...`, `npm test`, `svelte-check`, the Vite build. The demo refuses `SimulatorSetFaults`. New strings in the five locales; README and CLAUDE.md describe it.
