### PR TITLE
Let a simulated device be written to: SET, write access and RowStatus rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -686,6 +686,19 @@ apart, and `SimulatorCancelRecording` stops it with nothing kept. The request is
 model as a package FOLDER (`repackUnder`), its icon under the name the model gives it, which imports back as itself:
 that is how a recording is edited.
 
+**A bench moves as a file** (`app_simbench.go`, `pkg/simulator/devicefile.go`). A file of simulated devices holds one
+device or several as `FileDevice` — what makes the device the one it is, never its ID, engine ID or boots, so two
+imports of one file are two devices with two engines no manager confuses. The export ASKS every time whether to put
+the passwords in (the renderer's choice panel), writes `"secrets": "included"` or `"omitted"` into the file so nobody
+passes it on believing it holds none, and writes a file holding them 0600. The import is read as a model file is —
+`kind` and `formatVersion` first, then strictly — and makes every device NEW here: an ID, an engine and, when the
+address it names is taken, the one `suggestAddress` gives, said in a warning. A device that cannot be made here — a
+model this machine lacks, an address off loopback — is refused ON ITS OWN, and the others are kept. A file that says
+its passwords were left out has any it holds anyway ignored — what a file says of itself is what is believed — and
+its devices are checked by `ValidateWithoutSecrets`, everything but the secrets, and KEPT without them: starting one
+fails naming what it lacks until the editor gives it. Duplicating is the same making of a new device, from a device
+and with its passwords; restarting is a stop and a start, so the boots rise and coldStart goes out as on any start.
+
 **What only a notification carries** (`Object.NotifyOnly`). An iDRAC alert carries eleven objects its MIB makes
 accessible-for-notify (RFC 2578 7.3) — a message ID, the message, the service tag — and no request may read them.
 They are kept beside the tree rather than in it: a GET answers `noSuchObject`, a walk passes them by, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,9 +584,27 @@ the count: that is what makes a manager still holding the old clock resynchronis
 builds the MAC format a Cisco reports), since managers cache it and localise their keys to it.
 
 A request below the level its user is held to is answered `authorizationError` with nothing read, as a device
-configured `rouser NAME priv` answers. Only the default context exists. Nothing is writable yet: a SET is
-`notWritable`, or `noSuchName` in v1 (RFC 3584), where a Counter64 is invisible too — stepped over on GETNEXT,
-`noSuchName` on GET.
+configured `rouser NAME priv` answers. Only the default context exists. SNMPv1 cannot see a Counter64 (RFC 3584):
+it is stepped over on GETNEXT and `noSuchName` on GET.
+
+**A SET writes the running device and nothing else** (`set.go`). The write community — a secret, kept beside the
+community — or a v3 user with `Write` may SET. A manager that only reads is answered `noAccess`, as net-snmp answers
+a `rocommunity` or a `rouser`, or `noSuchName` in v1, and a community used so is counted in
+`snmpInBadCommunityUses`. What is written lives in the agent's tree until the device restarts, which is a new
+`Agent` built from its model again: nothing is saved, as a running configuration is not until someone saves it.
+Every varbind is checked before any is applied (RFC 3416 4.2.5), and the tree is REPLACED rather than edited — a
+copy with the changes, swapped in through an `atomic.Pointer` — because notifications read it from their own
+goroutines, and neither they nor a GETBULK may see a SET half-applied. The agent's own subtrees (the snmp group, the
+engine, the USM, the VACM) and an object only a notification carries are `notWritable`. A varbind naming an instance
+nothing answers CREATES it, if it would sit in the tree as an instance does: a leaf, under no instance and with none
+under it. Errors are v2c's, mapped for v1 by `v1Status` (RFC 3584 4.4).
+
+Rows need the MIB, and the agent has none: which column is a `RowStatus` is asked of `Config.RowStatus`, which
+`app.go` points at `mib.Service.RowStatusColumn`, so rows are created and destroyed as the LOADED MIBs describe
+them. `createAndGo` makes the row `active`, `createAndWait` `notInService`, `destroy` removes every instance of the
+row, and what RFC 2579 refuses is refused — a create on a row that exists, `active` on one that does not, and
+`notReady`, which is the agent's to say. The callback takes gosmi's lock once per varbind, on the agent's receive
+goroutine, holding nothing of the agent's while it waits.
 
 The protocol names are `pkg/snmp`'s (`MD5` to `SHA512`, `DES`, `AES` to `AES256C`), mapped again here so the
 package stays a leaf. `TestSnmpLensReadsTheSimulator` holds the two together by driving the SnmpLens client
@@ -746,8 +764,9 @@ again, and nothing would say why until somebody tried. The renderer lists models
 and not with the devices it polls every two seconds, since an icon crosses the bridge as a data URI.
 
 **A device becomes a target in the renderer** (`addDeviceAsTarget` in `utils/simulator.js`): the target in the
-list, and an override with its identifiers in the most secure version it answers — its FIRST user for v3, since a
-device may have several. The target is the device's address, with its port unless that is 161 (`targetOf`:
+list, and an override with its identifiers in the most secure version it answers — the ones that WRITE when it has
+any, since they read as well and a device on a bench is there to be written to: its first user with `Write` for v3,
+else its first, and its write community before its community. The target is the device's address, with its port unless that is 161 (`targetOf`:
 `127.0.0.1:1162`), because a target is what tells devices apart and on macOS — 127.0.0.1 alone unless aliases
 were added — the port is all that does. A port the target names wins over every port field, in Go
 (`netaddr.SplitTarget`) and in `getEffectiveSettings`, so the override leaves it out and `TargetOverrideForm`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -606,7 +606,8 @@ file and the marshalled list for the secret values themselves. The two listing c
 `NewEngineID`: the model's vendor in the MAC format, the MAC drawn from the ID), and an edit keeps both, and the
 boot count, whatever the renderer sends — the engine ID is what managers localise their keys to, and the count is
 what keeps a previous run's messages out of the time window. Every start raises the count and WRITES it before
-the device answers. A running device that is edited restarts; nothing starts by itself at launch. The header's
+the device answers. A running device that is edited restarts; nothing starts by itself at launch unless it is set
+to (`AutoStart`). The header's
 status and the modal read `simulatorStore`, which Go refreshes with `simulator:changed`.
 
 **A model is a vocabulary, not prose.** `simulator.Models()` serves an ID, a category and the notifications; the
@@ -698,6 +699,18 @@ its passwords were left out has any it holds anyway ignored — what a file says
 its devices are checked by `ValidateWithoutSecrets`, everything but the secrets, and KEPT without them: starting one
 fails naming what it lacks until the editor gives it. Duplicating is the same making of a new device, from a device
 and with its passwords; restarting is a stop and a start, so the boots rise and coldStart goes out as on any start.
+
+**Faults are applied to the running agent, never by a restart** (`faults.go`). A test of reachability, of the
+overload guardrail or of the rate across a wrap watches the uptime and counters a restart would reset, so
+`SimulatorSetFaults` goes through `Fleet.SetFaults` to the live agent, and the editor's save KEEPS the faults it does
+not show. Loss and mute drop the datagram before the agent counts anything, as a lossy link would; a mute device still
+sends its notifications. Latency answers through `time.AfterFunc` rather than sleeping in the one serving goroutine,
+so a slow device stays slow without becoming a stuck one. An error is injected in `process`, the path v1, v2c and v3
+share, and counted in the snmp group like any answer. Counters sped up run through a WARP carried by the request's
+clock: the counter-seconds at the moment the speed changed, and the new speed from there — so a speed change turns a
+counter faster or slower and never makes it jump or go back, either of which a manager reads as a wrap
+(`TestCountersChangeSpeedWithoutJumping`). Gauges keep real time. A device's own location and contact take the place
+of its model's in `addSystem`, and `AutoStart` is opt-in per device, started once the secret store is open.
 
 **What only a notification carries** (`Object.NotifyOnly`). An iDRAC alert carries eleven objects its MIB makes
 accessible-for-notify (RFC 2578 7.3) — a message ID, the message, the service tag — and no request may read them.

--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ The **Simulator** indicator in the header opens the simulated devices: SNMP agen
 
 A bench moves as a file. **Export all…**, or a device's export button, writes JSON, and SnmpLens asks every time whether to put the passwords in it — the communities and passphrases, which otherwise stay in the system keychain. The file says which (`"secrets": "included"` or `"omitted"`). **Import devices…** makes each device new on this machine: its own ID and engine ID, and another address when its own is taken. A device that cannot be made here — of a custom model that is not installed, say — is refused on its own; devices imported without their passwords start once they are given them in the editor.
 
+**Faults** make a device misbehave while it runs, without restarting it — its uptime and counters are what a fault is tested against: a latency (with jitter), a share of requests lost, a device that answers nothing at all, a share answered with `genErr` or `tooBig`, and counters running 10, 100 or 1000 times faster, so that a Counter32 wraps in minutes. They are what SnmpLens's reachability alerts, overload guardrail and counter-wrap arithmetic are tested against, and they are kept with the device. A device can also be given its own sysLocation and sysContact, and set to start with SnmpLens.
+
 ---
 
 ## Custom Simulator Models

--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ A bench moves as a file. **Export all…**, or a device's export button, writes 
 
 **Faults** make a device misbehave while it runs, without restarting it — its uptime and counters are what a fault is tested against: a latency (with jitter), a share of requests lost, a device that answers nothing at all, a share answered with `genErr` or `tooBig`, and counters running 10, 100 or 1000 times faster, so that a Counter32 wraps in minutes. They are what SnmpLens's reachability alerts, overload guardrail and counter-wrap arithmetic are tested against, and they are kept with the device. A device can also be given its own sysLocation and sysContact, and set to start with SnmpLens.
 
+**A device can be written to.** Give it a write community (v1 and v2c — a password, kept in the keychain like the community), or tick **Can write (SET)** on an SNMPv3 user, and a SET changes what it answers until it restarts, as a running configuration does until it is saved. A table row is created and destroyed through its `RowStatus`, as the MIBs loaded in SnmpLens describe it, so the row editor works against a simulated device as it does against a real one. A manager that only reads is answered `noAccess`, and **Add as target** uses the write access when the device has one. The editor is in three tabs — the device, its access, its notifications — and a tab holding something to fix is marked.
+
 ---
 
 ## Custom Simulator Models

--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ Everything SnmpLens writes lives in the user config directory:
 
 ---
 
+## Simulated Devices
+
+The **Simulator** indicator in the header opens the simulated devices: SNMP agents running on this machine, at loopback addresses only — `127.x.x.x` or `::1` — answering v1, v2c and v3 (the whole USM) from a catalogue of models, or from your own (below). A device can be started and stopped, **restarted** (uptime and counters from zero, and `coldStart` if it sends one on starting), **duplicated**, made to send any of its notifications on demand, and **added as a target** in one click, with its port and identifiers.
+
+A bench moves as a file. **Export all…**, or a device's export button, writes JSON, and SnmpLens asks every time whether to put the passwords in it — the communities and passphrases, which otherwise stay in the system keychain. The file says which (`"secrets": "included"` or `"omitted"`). **Import devices…** makes each device new on this machine: its own ID and engine ID, and another address when its own is taken. A device that cannot be made here — of a custom model that is not installed, say — is refused on its own; devices imported without their passwords start once they are given them in the editor.
+
+---
+
 ## Custom Simulator Models
 
 The simulator's catalogue can be extended with models of your own: a JSON file saying what a device answers, imported from the model picker (**Import models…**) on its own, or in a ZIP archive that also carries the model's icon — PNG, JPEG or GIF, up to 512 × 512 px. An archive may hold several models. A model imported again replaces the one kept, and the devices made from it restart.

--- a/app.go
+++ b/app.go
@@ -151,6 +151,9 @@ func (a *App) startup(ctx context.Context) {
 	// application are started — after the secret store, which holds their
 	// communities and passphrases. The others answer once someone starts them.
 	a.sim = newSimulatorService(filepath.Join(configDir, "SnmpLens"))
+	// Which column is a RowStatus is in the MIBs, and the agents have none: a
+	// row is created and destroyed as the loaded MIBs describe it.
+	a.sim.fleet.RowStatus = a.mibService.RowStatusColumn
 	a.startAutoSimulated()
 
 	// The trap listener's engine ID, before initBackgroundMode can start the

--- a/app.go
+++ b/app.go
@@ -147,9 +147,11 @@ func (a *App) startup(ctx context.Context) {
 		log.Printf("Secret storage backend: %s", store.Backend())
 	}
 
-	// The simulated devices are read, not started: a device answers only once
-	// someone starts it in this session.
+	// The simulated devices are read, and those set to start with the
+	// application are started — after the secret store, which holds their
+	// communities and passphrases. The others answer once someone starts them.
 	a.sim = newSimulatorService(filepath.Join(configDir, "SnmpLens"))
+	a.startAutoSimulated()
 
 	// The trap listener's engine ID, before initBackgroundMode can start the
 	// listener: a device sending it SNMPv3 INFORMs is configured with it.

--- a/app_simbench.go
+++ b/app_simbench.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"slices"
+	"strconv"
+	"strings"
+
+	"SnmpLens/pkg/secrets"
+	"SnmpLens/pkg/simulator"
+
+	"github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+// A bench of simulated devices as a file (pkg/simulator, DeviceFile): exported
+// with or without the passwords — the renderer asks, and the file says which —
+// and imported as NEW devices of this machine, each with an ID, an engine and,
+// when the address it names is taken, an address of its own. Duplicating a
+// device is the same making of a new one, from a device rather than a file.
+
+// SimulatorDeviceImportResult is what became of one device of a file.
+type SimulatorDeviceImportResult struct {
+	// Name is the device's, or the file's when the file as a whole was refused.
+	Name     string                  `json:"name"`
+	ID       string                  `json:"id,omitempty"`
+	Success  bool                    `json:"success"`
+	Error    string                  `json:"error,omitempty"`
+	Warnings []SimulatorModelWarning `json:"warnings"`
+}
+
+// SimulatorExportDevicesDialog writes simulated devices — those named, or every
+// one when none is — to a file the user names, with their passwords only when
+// withSecrets says so. It returns where the file went, or "" when the dialog was
+// cancelled.
+func (a *App) SimulatorExportDevicesDialog(ids []string, withSecrets bool) (string, error) {
+	data, name, err := a.exportDevices(ids, withSecrets)
+	if err != nil {
+		return "", err
+	}
+	if a.ctx == nil {
+		return "", fmt.Errorf("no window")
+	}
+	dest, err := runtime.SaveFileDialog(a.ctx, runtime.SaveDialogOptions{
+		Title:           "Export simulated devices",
+		DefaultFilename: name,
+		Filters:         []runtime.FileFilter{{DisplayName: "Simulated devices (JSON)", Pattern: "*.json"}},
+	})
+	if err != nil || dest == "" {
+		return "", err
+	}
+	if !strings.EqualFold(filepath.Ext(dest), ".json") {
+		dest += ".json"
+	}
+	// A file holding passwords is its owner's alone to read.
+	perm := os.FileMode(0o644)
+	if withSecrets {
+		perm = 0o600
+	}
+	if err := os.WriteFile(dest, data, perm); err != nil {
+		return "", fmt.Errorf("writing %s: %w", filepath.Base(dest), err)
+	}
+	return dest, nil
+}
+
+// exportDevices is the file the devices are exported as, and the name it is
+// offered under.
+func (a *App) exportDevices(ids []string, withSecrets bool) ([]byte, string, error) {
+	s := a.sim
+	if s == nil {
+		return nil, "", errNoSimulator
+	}
+	s.mu.Lock()
+	var chosen []simulator.Device
+	for _, d := range s.devices {
+		if len(ids) == 0 || slices.Contains(ids, d.ID) {
+			chosen = append(chosen, d)
+		}
+	}
+	s.mu.Unlock()
+	switch {
+	case len(chosen) == 0:
+		return nil, "", errors.New("there is no simulated device to export")
+	case len(ids) > 0 && len(chosen) != len(ids):
+		return nil, "", errors.New("a device to export is no longer there")
+	}
+	if withSecrets {
+		for i := range chosen {
+			sec, err := a.simulatorSecrets(chosen[i].ID)
+			if err != nil {
+				return nil, "", err
+			}
+			chosen[i] = chosen[i].WithSecrets(sec)
+		}
+	}
+	data, err := simulator.ExportDevices(chosen, withSecrets)
+	name := "simulated-devices.json"
+	if len(chosen) == 1 {
+		name = simulator.Slug(chosen[0].Name, "simulated-device") + ".json"
+	}
+	return data, name, err
+}
+
+// ImportSimulatedDevicesDialog asks for files of simulated devices and imports
+// them.
+func (a *App) ImportSimulatedDevicesDialog() ([]SimulatorDeviceImportResult, error) {
+	if a.ctx == nil {
+		return nil, fmt.Errorf("no window")
+	}
+	paths, err := runtime.OpenMultipleFilesDialog(a.ctx, runtime.OpenDialogOptions{
+		Title:   "Import simulated devices",
+		Filters: []runtime.FileFilter{{DisplayName: "Simulated devices (JSON)", Pattern: "*.json"}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Cancelled is an empty list, never null: the caller reports each result.
+	results := []SimulatorDeviceImportResult{}
+	for _, p := range paths {
+		raw, err := readAtMost(p, simulator.MaxDeviceFileBytes)
+		if err != nil {
+			results = append(results, SimulatorDeviceImportResult{Name: filepath.Base(p), Error: err.Error(),
+				Warnings: []SimulatorModelWarning{}})
+			continue
+		}
+		results = append(results, a.importDevices(filepath.Base(p), raw)...)
+	}
+	return results, nil
+}
+
+// importDevices imports the devices of a file as new devices of this machine:
+// each is given an ID, an engine and, when another device answers where it
+// says, an address of its own. A device that cannot be made here — a model this
+// machine does not have, an address off loopback — is refused on its own, and
+// the others are kept. None is started.
+//
+// A file that says it left the passwords out has any it holds anyway ignored:
+// what a file says of itself is what is believed. Its devices are checked for
+// everything but their secrets, and kept to be given them.
+func (a *App) importDevices(file string, raw []byte) []SimulatorDeviceImportResult {
+	fail := func(err error) []SimulatorDeviceImportResult {
+		return []SimulatorDeviceImportResult{{Name: file, Error: err.Error(), Warnings: []SimulatorModelWarning{}}}
+	}
+	s := a.sim
+	if s == nil {
+		return fail(errNoSimulator)
+	}
+	if a.secrets == nil {
+		return fail(errors.New("the credential store is unavailable, so a simulated device cannot keep its community and passphrases"))
+	}
+	f, err := simulator.ParseDeviceFile(raw)
+	if err != nil {
+		return fail(err)
+	}
+	withSecrets := f.Secrets == simulator.SecretsIncluded
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	taken := make([]string, 0, len(s.devices)+len(f.Devices))
+	for _, d := range s.devices {
+		taken = append(taken, d.Listen())
+	}
+	results := make([]SimulatorDeviceImportResult, 0, len(f.Devices))
+	next := slices.Clone(s.devices)
+	var stored []string
+	for _, fd := range f.Devices {
+		d := fd.Device()
+		res := SimulatorDeviceImportResult{Name: d.Name, Warnings: []SimulatorModelWarning{}}
+		refuse := func(err error) {
+			res.Error = err.Error()
+			results = append(results, res)
+		}
+		if !withSecrets {
+			d = d.WithoutSecrets()
+		}
+		d.ID = simulator.NewDeviceID()
+		engineID, err := simulator.NewEngineID(d.Model, d.ID)
+		if err != nil {
+			refuse(err)
+			continue
+		}
+		d.EngineID, d.EngineBoots = engineID, 0
+		for i := range d.Traps.Destinations {
+			if d.Traps.Destinations[i].ID == "" {
+				d.Traps.Destinations[i].ID = simulator.NewDestinationID()
+			}
+		}
+		if slices.Contains(taken, d.Listen()) {
+			was := d.Listen()
+			moved := suggestAddress(goruntime.GOOS, taken, canBindUDP)
+			d.Address, d.Port = moved.Address, moved.Port
+			res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "addressMoved",
+				Detail: was + " → " + net.JoinHostPort(d.Address, strconv.Itoa(d.Port))})
+		}
+		check := d.Validate
+		if !withSecrets {
+			check = d.ValidateWithoutSecrets
+		}
+		if err := check(); err != nil {
+			refuse(err)
+			continue
+		}
+		if withSecrets {
+			sec, err := json.Marshal(d.Secrets())
+			if err != nil {
+				refuse(err)
+				continue
+			}
+			if err := a.secrets.Set(secrets.SimulatorDeviceRef(d.ID), string(sec)); err != nil {
+				refuse(fmt.Errorf("keeping the device's credentials: %w", err))
+				continue
+			}
+			stored = append(stored, d.ID)
+		} else if d.Validate() != nil {
+			// Complete without secrets is a device that needs none.
+			res.Warnings = append(res.Warnings, SimulatorModelWarning{Key: "noSecrets"})
+		}
+		taken = append(taken, d.Listen())
+		next = append(next, d.WithoutSecrets())
+		res.ID, res.Success = d.ID, true
+		results = append(results, res)
+	}
+	if len(next) == len(s.devices) {
+		return results
+	}
+	if err := s.write(next); err != nil {
+		for _, id := range stored {
+			_ = a.secrets.Delete(secrets.SimulatorDeviceRef(id))
+		}
+		for i := range results {
+			if results[i].Success {
+				results[i].Success, results[i].ID = false, ""
+				results[i].Error = fmt.Sprintf("saving the simulated devices: %v", err)
+			}
+		}
+		return results
+	}
+	s.devices = next
+	a.emitSimulatorChanged()
+	return results
+}
+
+// SimulatorDuplicateDevice makes a copy of a device under the name given — the
+// renderer's, in the user's language —, with an ID, an engine and an address of
+// its own, and the passwords of the one it copies. The copy is not started.
+func (a *App) SimulatorDuplicateDevice(id, name string) (SimulatedDevice, error) {
+	s := a.sim
+	if s == nil {
+		return SimulatedDevice{}, errNoSimulator
+	}
+	if a.secrets == nil {
+		return SimulatedDevice{}, errors.New("the credential store is unavailable, so a simulated device cannot keep its community and passphrases")
+	}
+	sec, err := a.simulatorSecrets(id)
+	if err != nil {
+		return SimulatedDevice{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.index(id)
+	if i < 0 {
+		return SimulatedDevice{}, fmt.Errorf("there is no simulated device %q", id)
+	}
+	d := s.devices[i].WithSecrets(sec)
+	d.Name = clipText(strings.TrimSpace(name), simulator.MaxDeviceName)
+	d.ID = simulator.NewDeviceID()
+	if d.EngineID, err = simulator.NewEngineID(d.Model, d.ID); err != nil {
+		return SimulatedDevice{}, err
+	}
+	d.EngineBoots = 0
+	taken := make([]string, len(s.devices))
+	for j, other := range s.devices {
+		taken[j] = other.Listen()
+	}
+	at := suggestAddress(goruntime.GOOS, taken, canBindUDP)
+	d.Address, d.Port = at.Address, at.Port
+	// A copy of a device still waiting for its passwords waits for them too.
+	if err := d.Validate(); err != nil && d.ValidateWithoutSecrets() != nil {
+		return SimulatedDevice{}, err
+	}
+	raw, err := json.Marshal(d.Secrets())
+	if err != nil {
+		return SimulatedDevice{}, err
+	}
+	ref := secrets.SimulatorDeviceRef(d.ID)
+	if err := a.secrets.Set(ref, string(raw)); err != nil {
+		return SimulatedDevice{}, fmt.Errorf("keeping the device's credentials: %w", err)
+	}
+	next := append(slices.Clone(s.devices), d.WithoutSecrets())
+	if err := s.write(next); err != nil {
+		_ = a.secrets.Delete(ref)
+		return SimulatedDevice{}, fmt.Errorf("saving the simulated devices: %w", err)
+	}
+	s.devices = next
+	a.emitSimulatorChanged()
+	return s.view(next[len(next)-1]), nil
+}
+
+// SimulatorRestartDevice restarts a running device as a device reboots: its
+// uptime and counters from zero, its boots one higher — which tells a manager
+// holding its clock to resynchronise —, and coldStart sent if it sends one when
+// it starts.
+func (a *App) SimulatorRestartDevice(id string) error {
+	s := a.sim
+	if s == nil {
+		return errNoSimulator
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.index(id)
+	if i < 0 {
+		return fmt.Errorf("there is no simulated device %q", id)
+	}
+	if !s.fleet.Stop(id) {
+		return fmt.Errorf("%q is not running", s.devices[i].Name)
+	}
+	err := a.startSimulatedLocked(s, i)
+	a.emitSimulatorChanged()
+	return err
+}

--- a/app_simbench_test.go
+++ b/app_simbench_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// freeSimPort is a UDP port on 127.0.0.1 that nothing holds right now.
+func freeSimPort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("no UDP socket: %v", err)
+	}
+	defer c.Close()
+	return c.LocalAddr().(*net.UDPAddr).Port
+}
+
+func listedDevice(a *App, id string) SimulatedDevice {
+	for _, d := range a.ListSimulatedDevices() {
+		if d.ID == id {
+			return d
+		}
+	}
+	return SimulatedDevice{}
+}
+
+// A bench exported without its passwords holds none of them and says so;
+// exported with them it holds them and says that — and neither holds what is
+// this machine's: the device's ID, its engine, its boots.
+func TestABenchIsExportedWithOrWithoutItsPasswords(t *testing.T) {
+	a, _ := simApp(t)
+	saved, err := a.SimulatorSaveDevice(simDevice())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare, name, err := a.exportDevices(nil, false)
+	if err != nil || name != "srv-01.json" {
+		t.Fatalf("%q, %v", name, err)
+	}
+	full, _, err := a.exportDevices([]string{saved.ID}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, secret := range simSecrets {
+		if bytes.Contains(bare, []byte(secret)) {
+			t.Errorf("exported without passwords, the file holds %q", secret)
+		}
+		if !bytes.Contains(full, []byte(secret)) {
+			t.Errorf("exported with passwords, the file lacks %q", secret)
+		}
+	}
+	if !bytes.Contains(bare, []byte(`"secrets": "omitted"`)) || !bytes.Contains(full, []byte(`"secrets": "included"`)) {
+		t.Error("a file does not say whether it holds the passwords")
+	}
+	for _, mine := range []string{saved.ID, saved.EngineID, "engineBoots"} {
+		if bytes.Contains(full, []byte(mine)) {
+			t.Errorf("the file holds %s", mine)
+		}
+	}
+	if _, _, err := a.exportDevices([]string{"gone"}, false); err == nil {
+		t.Error("a device that is not there was exported")
+	}
+}
+
+// Imported, a bench is new devices of this machine: IDs and engines of their
+// own, another address for one whose own is taken, their passwords in the
+// store — and they answer.
+func TestABenchIsImportedAsNewDevices(t *testing.T) {
+	a, _ := simApp(t)
+	original := startSimulated(t, a, simDevice())
+	full, _, err := a.exportDevices(nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := a.importDevices("bench.json", full)
+	if len(res) != 1 || !res[0].Success || len(res[0].Warnings) != 1 || res[0].Warnings[0].Key != "addressMoved" {
+		t.Fatalf("%+v", res)
+	}
+	imported := listedDevice(a, res[0].ID)
+	if imported.ID == "" || imported.ID == original.ID || imported.EngineID == original.EngineID || imported.EngineBoots != 0 ||
+		(imported.Address == original.Address && imported.Port == original.Port) {
+		t.Fatalf("imported as %+v, from %+v", imported, original)
+	}
+	creds, err := a.SimulatorDeviceCredentials(imported.ID)
+	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].AuthPass != "auth-s3cr3t" {
+		t.Fatalf("credentials: %+v, %v", creds, err)
+	}
+	if err := a.SimulatorStartDevice(imported.ID); err != nil {
+		t.Fatal(err)
+	}
+	if v := simGet(t, listedDevice(a, imported.ID), "s3cr3t-community", ".1.3.6.1.2.1.1.5.0"); string(v.Value.([]byte)) != "srv-01" {
+		t.Errorf("the imported device answers sysName %v", v.Value)
+	}
+}
+
+// A bench exported without its passwords is imported all the same, and says
+// so; a device of it starts once it is given them.
+func TestABenchWithoutPasswordsIsImportedToBeCompleted(t *testing.T) {
+	a, _ := simApp(t)
+	saved, err := a.SimulatorSaveDevice(simDevice())
+	if err != nil {
+		t.Fatal(err)
+	}
+	bare, _, err := a.exportDevices(nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.SimulatorDeleteDevice(saved.ID); err != nil {
+		t.Fatal(err)
+	}
+	res := a.importDevices("bench.json", bare)
+	if len(res) != 1 || !res[0].Success ||
+		!slices.ContainsFunc(res[0].Warnings, func(w SimulatorModelWarning) bool { return w.Key == "noSecrets" }) {
+		t.Fatalf("%+v", res)
+	}
+	id := res[0].ID
+	if err := a.SimulatorStartDevice(id); err == nil || !strings.Contains(err.Error(), "community") {
+		t.Fatalf("a device with no community started, or said %v", err)
+	}
+	d := simDevice()
+	d.ID, d.Address, d.Port = id, "127.0.0.1", freeSimPort(t)
+	d.Traps.Destinations[0].ID = listedDevice(a, id).Traps.Destinations[0].ID
+	if _, err := a.SimulatorSaveDevice(d); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.SimulatorStartDevice(id); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A file is refused as a whole when it is not one of devices, and a device of
+// it on its own when it cannot be made here; the others are kept.
+func TestADeviceFileIsReadWithCare(t *testing.T) {
+	a, _ := simApp(t)
+	for _, c := range []struct{ raw, want string }{
+		{`{"kind": "snmplens-simulator-model", "formatVersion": 1}`, "not a file of simulated devices"},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 2}`, "format version 2"},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "omitted", "devices": [], "extra": 1}`, `unknown field "extra"`},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "maybe", "devices": [{}]}`, `"secrets"`},
+		{`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "omitted", "devices": []}`, "no device"},
+		{`not json`, "line 1"},
+	} {
+		res := a.importDevices("f.json", []byte(c.raw))
+		if len(res) != 1 || res[0].Success || res[0].Name != "f.json" || !strings.Contains(res[0].Error, c.want) {
+			t.Errorf("%s: %+v, want %q", c.raw, res, c.want)
+		}
+	}
+	port := freeSimPort(t)
+	raw := fmt.Sprintf(`{"kind": "snmplens-simulated-devices", "formatVersion": 1, "secrets": "included", "devices": [
+		{"name": "gone", "model": "custom:not-here", "address": "127.0.0.1", "port": %[1]d, "versions": ["v2c"], "community": "public", "traps": {}},
+		{"name": "outside", "model": "linux-server", "address": "192.0.2.1", "port": 161, "versions": ["v2c"], "community": "public", "traps": {}},
+		{"name": "kept", "model": "linux-server", "address": "127.0.0.1", "port": %[1]d, "versions": ["v2c"], "community": "public", "traps": {}}]}`, port)
+	res := a.importDevices("bench.json", []byte(raw))
+	if len(res) != 3 || res[0].Success || !strings.Contains(res[0].Error, "not a device model") ||
+		res[1].Success || res[1].Error == "" || res[2].Name != "kept" || !res[2].Success {
+		t.Fatalf("%+v", res)
+	}
+	if got := a.ListSimulatedDevices(); len(got) != 1 || got[0].Name != "kept" {
+		t.Errorf("the devices are %+v", got)
+	}
+}
+
+// A device duplicated is a device of its own — ID, engine and address — with
+// the passwords of the one it copies; a running device restarted comes back
+// with one boot more, and a stopped one is not restarted.
+func TestADeviceIsDuplicatedAndRestarted(t *testing.T) {
+	a, _ := simApp(t)
+	src := startSimulated(t, a, simDevice())
+	dup, err := a.SimulatorDuplicateDevice(src.ID, "srv-01 (copy)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dup.ID == src.ID || dup.EngineID == src.EngineID || dup.Running || dup.Name != "srv-01 (copy)" ||
+		(dup.Address == src.Address && dup.Port == src.Port) {
+		t.Fatalf("duplicated as %+v", dup)
+	}
+	creds, err := a.SimulatorDeviceCredentials(dup.ID)
+	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].PrivPass != "priv-s3cr3t" {
+		t.Errorf("the copy's credentials: %+v, %v", creds, err)
+	}
+	boots := listedDevice(a, src.ID).EngineBoots
+	if err := a.SimulatorRestartDevice(src.ID); err != nil {
+		t.Fatal(err)
+	}
+	if now := listedDevice(a, src.ID); !now.Running || now.EngineBoots != boots+1 {
+		t.Errorf("restarted: running %v, boots %d after %d", now.Running, now.EngineBoots, boots)
+	}
+	if err := a.SimulatorRestartDevice(dup.ID); err == nil {
+		t.Error("a stopped device was restarted")
+	}
+}

--- a/app_simfaults_test.go
+++ b/app_simfaults_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"SnmpLens/pkg/simulator"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Faults are set on a running device without restarting it, kept with it — an
+// edit in the editor keeps them — and cleared the same way.
+func TestFaultsAreSetWithoutARestart(t *testing.T) {
+	a, _ := simApp(t)
+	saved := startSimulated(t, a, simDevice())
+	boots := listedDevice(a, saved.ID).EngineBoots
+	if err := a.SimulatorSetFaults(saved.ID, simulator.Faults{Mute: true}); err != nil {
+		t.Fatal(err)
+	}
+	g := &gosnmp.GoSNMP{Target: saved.Address, Port: uint16(saved.Port), Community: simDevice().Community,
+		Version: gosnmp.Version2c, Timeout: 300 * time.Millisecond}
+	if err := g.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer g.Conn.Close()
+	if _, err := g.Get([]string{".1.3.6.1.2.1.1.5.0"}); err == nil {
+		t.Error("a mute device answered")
+	}
+	now := listedDevice(a, saved.ID)
+	if !now.Running || now.EngineBoots != boots || !now.Faults.Mute {
+		t.Errorf("after the fault: running %v, boots %d after %d, faults %+v", now.Running, now.EngineBoots, boots, now.Faults)
+	}
+	if again := newSimulatorService(filepath.Dir(a.sim.path)); !again.devices[0].Faults.Mute {
+		t.Error("the fault was not kept with the device")
+	}
+
+	d := simDevice()
+	d.ID, d.Address, d.Port = saved.ID, saved.Address, saved.Port
+	d.Traps.Destinations[0].ID = now.Traps.Destinations[0].ID
+	if _, err := a.SimulatorSaveDevice(d); err != nil {
+		t.Fatal(err)
+	}
+	if !listedDevice(a, saved.ID).Faults.Mute {
+		t.Error("an edit cleared the faults")
+	}
+	if err := a.SimulatorSetFaults(saved.ID, simulator.Faults{}); err != nil {
+		t.Fatal(err)
+	}
+	if v := simGet(t, listedDevice(a, saved.ID), simDevice().Community, ".1.3.6.1.2.1.1.5.0"); string(v.Value.([]byte)) != "srv-01" {
+		t.Errorf("cleared, the device answers %v", v.Value)
+	}
+	if err := a.SimulatorSetFaults(saved.ID, simulator.Faults{LossPercent: 101}); err == nil {
+		t.Error("a loss of 101 % was set")
+	}
+}
+
+// A device answers with the location and contact it was given, in place of its
+// model's; one given none answers its model's.
+func TestADeviceHasItsOwnLocationAndContact(t *testing.T) {
+	a, _ := simApp(t)
+	d := simDevice()
+	d.Location, d.Contact = "Lab, rack B4", "noc@lab.example"
+	own := startSimulated(t, a, d)
+	if v := simGet(t, own, d.Community, ".1.3.6.1.2.1.1.6.0"); string(v.Value.([]byte)) != "Lab, rack B4" {
+		t.Errorf("sysLocation: %v", v.Value)
+	}
+	if v := simGet(t, own, d.Community, ".1.3.6.1.2.1.1.4.0"); string(v.Value.([]byte)) != "noc@lab.example" {
+		t.Errorf("sysContact: %v", v.Value)
+	}
+	models := startSimulated(t, a, simDevice())
+	if v := simGet(t, models, d.Community, ".1.3.6.1.2.1.1.6.0"); len(v.Value.([]byte)) == 0 || string(v.Value.([]byte)) == "Lab, rack B4" {
+		t.Errorf("a device given no location answers %q", v.Value)
+	}
+}
+
+// A device set to start with the application starts with it, and one that is
+// not does not.
+func TestADeviceStartsWithTheApplication(t *testing.T) {
+	a, store := simApp(t)
+	auto := simDevice()
+	auto.AutoStart, auto.Address, auto.Port = true, "127.0.0.1", freeSimPort(t)
+	autoSaved, err := a.SimulatorSaveDevice(auto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manual := simDevice()
+	manual.Address, manual.Port = "127.0.0.1", freeSimPort(t)
+	if manual.Port == auto.Port {
+		manual.Port++
+	}
+	manualSaved, err := a.SimulatorSaveDevice(manual)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b := &App{secrets: store, sim: newSimulatorService(filepath.Dir(a.sim.path))}
+	t.Cleanup(b.sim.fleet.StopAll)
+	b.startAutoSimulated()
+	if !listedDevice(b, autoSaved.ID).Running || listedDevice(b, manualSaved.ID).Running {
+		t.Errorf("after startup: %+v", b.ListSimulatedDevices())
+	}
+}

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -173,12 +173,14 @@ type SimulatedUser struct {
 	SecLevel  string `json:"secLevel"`
 	AuthProto string `json:"authProto"`
 	PrivProto string `json:"privProto"`
+	Write     bool   `json:"write"`
 }
 
 func (s *simulatorService) view(d simulator.Device) SimulatedDevice {
 	users := make([]SimulatedUser, len(d.Users))
 	for i, u := range d.Users {
-		users[i] = SimulatedUser{Name: u.Name, SecLevel: u.SecLevel, AuthProto: u.AuthProto, PrivProto: u.PrivProto}
+		users[i] = SimulatedUser{Name: u.Name, SecLevel: u.SecLevel, AuthProto: u.AuthProto, PrivProto: u.PrivProto,
+			Write: u.Write}
 	}
 	stats, running := s.fleet.Status(d.ID)
 	traps := SimulatedTraps{

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -132,6 +132,12 @@ type SimulatedDevice struct {
 	// Packets is what the device has received since it started.
 	Packets uint32         `json:"packets"`
 	Traps   SimulatedTraps `json:"traps"`
+	// Location, Contact and AutoStart are the device's own settings, and
+	// Faults what it is made to do wrong. None of it is a secret.
+	Location  string           `json:"location"`
+	Contact   string           `json:"contact"`
+	AutoStart bool             `json:"autoStart"`
+	Faults    simulator.Faults `json:"faults"`
 }
 
 // SimulatedTraps is what a simulated device sends, as the list shows it: the
@@ -197,6 +203,7 @@ func (s *simulatorService) view(d simulator.Device) SimulatedDevice {
 		Versions: slices.Clone(d.Versions), Users: users,
 		EngineID: d.EngineID, EngineBoots: d.EngineBoots,
 		Running: running, Packets: stats.Packets, Traps: traps,
+		Location: d.Location, Contact: d.Contact, AutoStart: d.AutoStart, Faults: d.Faults,
 	}
 }
 
@@ -336,7 +343,8 @@ func (a *App) SimulatorSaveDevice(d simulator.Device) (SimulatedDevice, error) {
 	} else if i = s.index(d.ID); i < 0 {
 		return SimulatedDevice{}, fmt.Errorf("there is no simulated device %q", d.ID)
 	} else {
-		d.EngineID, d.EngineBoots = s.devices[i].EngineID, s.devices[i].EngineBoots
+		// The faults too: they are set while the device runs, never in the editor.
+		d.EngineID, d.EngineBoots, d.Faults = s.devices[i].EngineID, s.devices[i].EngineBoots, s.devices[i].Faults
 	}
 	if err := d.Validate(); err != nil {
 		return SimulatedDevice{}, err
@@ -437,6 +445,62 @@ func (a *App) SimulatorStopDevice(id string) error {
 		a.emitSimulatorChanged()
 	}
 	return nil
+}
+
+// SimulatorSetFaults changes what a simulated device does wrong, at once and
+// without restarting it — its uptime and counters are what a fault is tested
+// against — and keeps it with the device, for its next start as well.
+func (a *App) SimulatorSetFaults(id string, f simulator.Faults) error {
+	s := a.sim
+	if s == nil {
+		return errNoSimulator
+	}
+	if err := f.Check(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.index(id)
+	if i < 0 {
+		return fmt.Errorf("there is no simulated device %q", id)
+	}
+	next := slices.Clone(s.devices)
+	next[i].Faults = f
+	if err := s.write(next); err != nil {
+		return fmt.Errorf("saving the simulated devices: %w", err)
+	}
+	s.devices = next
+	if err := s.fleet.SetFaults(id, f); err != nil && !errors.Is(err, simulator.ErrNotRunning) {
+		return err
+	}
+	a.emitSimulatorChanged()
+	return nil
+}
+
+// startAutoSimulated starts the devices that start with the application, once
+// the credential store is open. One that will not start is logged and left
+// stopped, and the others start.
+func (a *App) startAutoSimulated() {
+	s := a.sim
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	started := false
+	for i, d := range s.devices {
+		if !d.AutoStart {
+			continue
+		}
+		if err := a.startSimulatedLocked(s, i); err != nil {
+			log.Printf("simulator: %s did not start with the application: %v", d.Name, err)
+			continue
+		}
+		started = true
+	}
+	if started {
+		a.emitSimulatorChanged()
+	}
 }
 
 // SimulatorSendTrap has a running simulated device send a notification now to

--- a/app_simulator_test.go
+++ b/app_simulator_test.go
@@ -28,15 +28,15 @@ func simApp(t *testing.T) (*App, *stubStore) {
 func simDevice() simulator.Device {
 	return simulator.Device{
 		Name: "srv-01", Model: "linux-server", Address: "127.0.0.2", Port: 16161,
-		Versions: []string{"v2c", "v3"}, Community: "s3cr3t-community",
+		Versions: []string{"v2c", "v3"}, Community: "s3cr3t-community", WriteCommunity: "wr1te-s3cr3t",
 		Users: []simulator.User{{Name: "ops", SecLevel: "AuthPriv",
-			AuthProto: "SHA256", AuthPass: "auth-s3cr3t", PrivProto: "AES", PrivPass: "priv-s3cr3t"}},
+			AuthProto: "SHA256", AuthPass: "auth-s3cr3t", PrivProto: "AES", PrivPass: "priv-s3cr3t", Write: true}},
 		Traps: simulator.Traps{Destinations: []simulator.Destination{
 			{Host: "127.0.0.1", Port: 1162, Version: "v2c", Community: "trap-s3cr3t"}}},
 	}
 }
 
-var simSecrets = []string{"s3cr3t-community", "auth-s3cr3t", "priv-s3cr3t", "trap-s3cr3t"}
+var simSecrets = []string{"s3cr3t-community", "wr1te-s3cr3t", "auth-s3cr3t", "priv-s3cr3t", "trap-s3cr3t"}
 
 // startSimulated saves d at 127.0.0.1 on a free port and starts it. A port
 // found free can be taken before the device binds it, since `go test ./...`
@@ -96,8 +96,13 @@ func TestASimulatedDevicesSecretsStayInTheStore(t *testing.T) {
 	}
 
 	creds, err := a.SimulatorDeviceCredentials(saved.ID)
-	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].PrivPass != "priv-s3cr3t" {
+	if err != nil || creds.Community != "s3cr3t-community" || creds.WriteCommunity != "wr1te-s3cr3t" ||
+		creds.Users["ops"].PrivPass != "priv-s3cr3t" {
 		t.Errorf("credentials: %+v, %v", creds, err)
+	}
+	// Whether a user writes is no secret, and the editor needs it back.
+	if len(saved.Users) != 1 || !saved.Users[0].Write {
+		t.Errorf("the list lost the user's write access: %+v", saved.Users)
 	}
 	// A new destination is given its ID, and its community is kept under it.
 	if len(saved.Traps.Destinations) != 1 || saved.Traps.Destinations[0].ID == "" {

--- a/frontend/screenshots/bridge/dynamic.js
+++ b/frontend/screenshots/bridge/dynamic.js
@@ -409,6 +409,7 @@ const DEMO_ONLY = {
   SimulatorExportDevicesDialog: 'Exporting simulated devices opens the operating system’s file dialog and writes a file.',
   SimulatorDuplicateDevice: 'Duplicating a simulated device writes the copy to your configuration directory, and its passwords to the system keychain.',
   SimulatorRestartDevice: 'Restarting a simulated device opens a UDP socket on this machine.',
+  SimulatorSetFaults: 'Faults are applied to a simulated device running on this machine, and kept in your configuration directory.',
 };
 
 for (const [name, why] of Object.entries(DEMO_ONLY)) {

--- a/frontend/screenshots/bridge/dynamic.js
+++ b/frontend/screenshots/bridge/dynamic.js
@@ -405,6 +405,10 @@ const DEMO_ONLY = {
   SimulatorDeleteModel: 'Deleting a simulator model removes its file from your configuration directory.',
   SimulatorRecordDevice: 'Recording a device walks a real device on your network and writes the model to your configuration directory.',
   SimulatorExportModelDialog: 'Exporting a simulator model opens the operating system’s file dialog and writes a file.',
+  ImportSimulatedDevicesDialog: 'Importing simulated devices opens the operating system’s file dialog, and writes the devices to your configuration directory and their passwords to the system keychain.',
+  SimulatorExportDevicesDialog: 'Exporting simulated devices opens the operating system’s file dialog and writes a file.',
+  SimulatorDuplicateDevice: 'Duplicating a simulated device writes the copy to your configuration directory, and its passwords to the system keychain.',
+  SimulatorRestartDevice: 'Restarting a simulated device opens a UDP socket on this machine.',
 };
 
 for (const [name, why] of Object.entries(DEMO_ONLY)) {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -10,10 +10,12 @@
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
     modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets, deviceImportReport,
+    deviceGroups, faultChips, categoryIcon,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
   import ModelIcon from './simulator/ModelIcon.svelte';
+  import FaultsPanel from './simulator/FaultsPanel.svelte';
   import Icon from './Icon.svelte';
 
   /**
@@ -386,6 +388,25 @@
       simulatorStore.refresh().catch(() => {});
     }
   }
+
+  /** The device whose faults are open, or null. */
+  let faultsOpen = null;
+
+  // Applied at once, without a restart: the device keeps its uptime and its
+  // counters, which are what a fault is tested against.
+  async function applyFaults(device, faults) {
+    busy = { ...busy, [device.id]: true };
+    try {
+      await simulatorStore.setFaults(device.id, faults);
+      const key = faultChips(faults).length ? 'simulator.faults.applied' : 'simulator.faults.cleared';
+      notificationStore.add($_(key, { values: { name: device.name } }), 'success');
+      await simulatorStore.refresh();
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+    }
+  }
 </script>
 
 <svelte:window on:keydown={onWindowKey} />
@@ -435,6 +456,19 @@
           </div>
         </div>
         <p class="hint"><Icon name="shield-check" size={14} /> {$_('simulator.loopbackHint')}</p>
+        <div class="grid identity-fields">
+          <div class="form-group">
+            <label for="sim-location">{$_('simulator.field.location')}</label>
+            <input id="sim-location" type="text" maxlength="255" placeholder={$_('simulator.field.modelDefault')}
+              bind:value={editing.location} />
+          </div>
+          <div class="form-group">
+            <label for="sim-contact">{$_('simulator.field.contact')}</label>
+            <input id="sim-contact" type="text" maxlength="255" placeholder={$_('simulator.field.modelDefault')}
+              bind:value={editing.contact} />
+          </div>
+        </div>
+        <label class="check autostart"><input type="checkbox" bind:checked={editing.autoStart} /> {$_('simulator.field.autoStart')}</label>
 
         <fieldset class="versions">
           <legend>{$_('simulator.field.versions')}</legend>
@@ -617,8 +651,12 @@
             <p>{$_('simulator.empty')}</p>
           </div>
         {:else}
+          {#each deviceGroups($simulatorStore.devices, $simulatorStore.models) as group (group.category)}
+          <h4 class="category-title">
+            <Icon name={categoryIcon(group.category)} size={14} /> {$_(`simulator.category.${group.category}`)}
+          </h4>
           <ul class="devices">
-            {#each $simulatorStore.devices as d (d.id)}
+            {#each group.devices as d (d.id)}
               {@const activity = trapActivity(d.traps)}
               {@const model = modelOf($simulatorStore.models, d.model)}
               <li class="device" class:running={d.running}>
@@ -649,6 +687,10 @@
                         {/if}
                       </span>
                     {/if}
+                    {#each faultChips(d.faults) as c (c.key)}
+                      <span class="chip fault">{$_(`simulator.faults.chip.${c.key}`, { values: c.values })}</span>
+                    {/each}
+                    {#if d.autoStart}<span class="chip">{$_('simulator.autoStartChip')}</span>{/if}
                   </span>
                 </div>
                 <div class="actions">
@@ -673,6 +715,11 @@
                   <button class="btn tertiary btn-small" title={$_('simulator.addAsTargetTitle')} on:click={() => addAsTarget(d)}>
                     <Icon name="target" size={13} /> {$_('simulator.addAsTarget')}
                   </button>
+                  <button class="icon-btn" class:active={faultChips(d.faults).length > 0} aria-expanded={faultsOpen === d.id}
+                    title={$_('simulator.faults.button')} aria-label={$_('simulator.faults.button')}
+                    on:click={() => (faultsOpen = faultsOpen === d.id ? null : d.id)}>
+                    <Icon name="zap" size={14} />
+                  </button>
                   {#if d.running}
                     <button class="icon-btn" disabled={busy[d.id]} title={$_('simulator.restart')} aria-label={$_('simulator.restart')}
                       on:click={() => restart(d)}>
@@ -695,9 +742,14 @@
                     {#if confirmDelete === d.id}{$_('simulator.confirmDelete')}{:else}<Icon name="trash-2" size={14} />{/if}
                   </button>
                 </div>
+                {#if faultsOpen === d.id}
+                  <FaultsPanel faults={d.faults} idPrefix="sim-faults-{d.id}" busy={busy[d.id]}
+                    on:apply={(e) => applyFaults(d, e.detail)} on:close={() => (faultsOpen = null)} />
+                {/if}
               </li>
             {/each}
           </ul>
+          {/each}
         {/if}
       </div>
       <footer class="sim-footer">
@@ -887,6 +939,41 @@
   .icon-btn:disabled {
     cursor: not-allowed;
     opacity: 0.5;
+  }
+
+  .icon-btn.active {
+    color: var(--warning-color);
+    border-color: var(--warning-border);
+  }
+
+  .device {
+    flex-wrap: wrap;
+  }
+
+  .category-title {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 14px 0 8px;
+    font-size: 0.85em;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+  }
+
+  .chip.fault {
+    background-color: var(--warning-subtle);
+    color: var(--warning-color);
+  }
+
+  .identity-fields {
+    margin-top: 12px;
+  }
+
+  .autostart {
+    margin-top: 10px;
+    font-size: 0.9em;
   }
 
   .export-choice {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -9,7 +9,7 @@
   import {
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
-    modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets,
+    modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets, deviceImportReport,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
@@ -62,6 +62,10 @@
   // The editor first, the dialog after: Escape backs out one level at a time.
   function onWindowKey(event) {
     if (event.key !== 'Escape') return;
+    if (exportIds) {
+      exportIds = null;
+      return;
+    }
     if (editing) {
       editing = null;
       return;
@@ -318,6 +322,70 @@
       simulatorStore.refresh().catch(() => {});
     }
   }
+
+  /** The devices whose export is being asked about — every one when empty — or null. */
+  let exportIds = null;
+  let benchBusy = false;
+
+  // What an export holds is asked every time: the passwords stay in the
+  // keychain unless the operator says to put them in the file.
+  function askExport(ids) {
+    exportIds = ids;
+  }
+
+  async function exportDevices(ids, withSecrets) {
+    exportIds = null;
+    benchBusy = true;
+    try {
+      const path = await simulatorStore.exportDevices(ids, withSecrets);
+      if (path) notificationStore.add($_('simulator.export.done', { values: { path } }), 'success');
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      benchBusy = false;
+    }
+  }
+
+  async function importDevices() {
+    benchBusy = true;
+    try {
+      const results = await simulatorStore.importDevices();
+      for (const line of deviceImportReport(results)) {
+        notificationStore.add($_(line.key, { values: line.values }), line.level);
+      }
+      await simulatorStore.refresh();
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      benchBusy = false;
+    }
+  }
+
+  async function duplicate(device) {
+    busy = { ...busy, [device.id]: true };
+    try {
+      const copy = await simulatorStore.duplicate(device.id, $_('simulator.copyName', { values: { name: device.name } }));
+      notificationStore.add($_('simulator.duplicated', { values: { name: device.name, copy: copy.name } }), 'success');
+      await simulatorStore.refresh();
+    } catch (e) {
+      notificationStore.add(String(e), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+    }
+  }
+
+  async function restart(device) {
+    busy = { ...busy, [device.id]: true };
+    try {
+      await simulatorStore.restart(device.id);
+      notificationStore.add($_('simulator.restarted', { values: { name: device.name } }), 'success');
+    } catch (e) {
+      notificationStore.add($_('simulator.startFailed', { values: { name: device.name, error: String(e) } }), 'error');
+    } finally {
+      busy = { ...busy, [device.id]: false };
+      simulatorStore.refresh().catch(() => {});
+    }
+  }
 </script>
 
 <svelte:window on:keydown={onWindowKey} />
@@ -526,6 +594,22 @@
       </footer>
     {:else}
       <div class="sim-body">
+        {#if exportIds}
+          <div class="export-choice" role="alertdialog" aria-labelledby="sim-export-title" aria-describedby="sim-export-hint">
+            <h3 id="sim-export-title">
+              <Icon name="download" size={16} />
+              {$_('simulator.export.title', { values: { count: exportIds.length || $simulatorStore.devices.length } })}
+            </h3>
+            <p id="sim-export-hint"><Icon name="key-round" size={14} /> {$_('simulator.export.hint')}</p>
+            <div class="export-actions">
+              <button class="btn secondary btn-small" on:click={() => (exportIds = null)}>{$_('common.cancel')}</button>
+              <button class="btn secondary btn-small warn" on:click={() => exportDevices(exportIds, true)}>
+                <Icon name="triangle-alert" size={13} /> {$_('simulator.export.with')}
+              </button>
+              <button class="btn btn-small" on:click={() => exportDevices(exportIds, false)}>{$_('simulator.export.without')}</button>
+            </div>
+          </div>
+        {/if}
         <p class="intro">{$_('simulator.intro')}</p>
         {#if $simulatorStore.devices.length === 0}
           <div class="empty">
@@ -589,6 +673,20 @@
                   <button class="btn tertiary btn-small" title={$_('simulator.addAsTargetTitle')} on:click={() => addAsTarget(d)}>
                     <Icon name="target" size={13} /> {$_('simulator.addAsTarget')}
                   </button>
+                  {#if d.running}
+                    <button class="icon-btn" disabled={busy[d.id]} title={$_('simulator.restart')} aria-label={$_('simulator.restart')}
+                      on:click={() => restart(d)}>
+                      <Icon name="refresh-cw" size={14} />
+                    </button>
+                  {/if}
+                  <button class="icon-btn" disabled={busy[d.id]} title={$_('simulator.duplicate')} aria-label={$_('simulator.duplicate')}
+                    on:click={() => duplicate(d)}>
+                    <Icon name="copy" size={14} />
+                  </button>
+                  <button class="icon-btn" title={$_('simulator.exportDevice')} aria-label={$_('simulator.exportDevice')}
+                    on:click={() => askExport([d.id])}>
+                    <Icon name="download" size={14} />
+                  </button>
                   <button class="icon-btn" title={$_('common.edit')} aria-label={$_('common.edit')} on:click={() => edit(d)}>
                     <Icon name="pencil" size={14} />
                   </button>
@@ -603,6 +701,14 @@
         {/if}
       </div>
       <footer class="sim-footer">
+        <button class="btn tertiary" disabled={benchBusy} title={$_('simulator.importDevicesTitle')} on:click={importDevices}>
+          <Icon name="upload" size={14} /> {$_('simulator.importDevices')}
+        </button>
+        <button class="btn tertiary" disabled={benchBusy || $simulatorStore.devices.length === 0}
+          title={$_('simulator.exportAllTitle')} on:click={() => askExport([])}>
+          <Icon name="download" size={14} /> {$_('simulator.exportAll')}
+        </button>
+        <span class="footer-gap"></span>
         <button class="btn" on:click={() => newDevice($simulatorStore.models, $simulatorStore.devices)}>
           <Icon name="plus" size={14} /> {$_('simulator.new')}
         </button>
@@ -771,9 +877,68 @@
 
   .actions {
     display: flex;
+    flex: 0 1 auto;
+    flex-wrap: wrap;
+    justify-content: flex-end;
     align-items: center;
     gap: 6px;
-    flex-shrink: 0;
+  }
+
+  .icon-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
+  .export-choice {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 14px;
+    padding: 12px 14px;
+    background-color: var(--bg-color);
+    border: 1px solid var(--accent-border);
+    border-radius: 6px;
+  }
+
+  .export-choice h3 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.95em;
+  }
+
+  .export-choice p {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.85em;
+    line-height: 1.45;
+    color: var(--text-muted);
+  }
+
+  .export-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .export-actions .btn,
+  .sim-footer .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
+
+  .export-actions .warn {
+    color: var(--warning-color);
+    border-color: var(--warning-border);
+  }
+
+  .footer-gap {
+    flex: 1;
   }
 
   .actions .btn {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -10,7 +10,7 @@
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
     modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets, deviceImportReport,
-    deviceGroups, faultChips, categoryIcon,
+    deviceGroups, faultChips, categoryIcon, EDITOR_TABS, tabsWithProblems,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
@@ -45,6 +45,10 @@
 
   $: problems = editing ? deviceProblems(editing) : {};
   $: usmProblems = usmMessages(problems, $_);
+
+  /** The editor's tab, and the tabs holding something to fix. */
+  let tab = 'identity';
+  $: flagged = tabsWithProblems(problems);
 
   /** The editor's SNMPv3 problems, one set per user, in the shape UsmFields shows them. */
   function usmMessages(p, t) {
@@ -89,6 +93,7 @@
     defaultName = nameFor(model, devices);
     editing.name = defaultName;
     saveError = '';
+    tab = 'identity';
   }
 
   // A new device's model. Its name follows the model until someone types
@@ -186,6 +191,7 @@
     try {
       editing = editableDevice(device, await simulatorStore.credentials(device.id));
       saveError = '';
+      tab = 'identity';
     } catch (e) {
       notificationStore.add(String(e), 'error');
     }
@@ -421,6 +427,19 @@
     {#if editing}
       <div class="sim-body">
         <h3 class="editor-title">{editing.id ? $_('simulator.editTitle') : $_('simulator.newTitle')}</h3>
+        <div class="tabs" role="tablist">
+          {#each EDITOR_TABS as t (t.id)}
+            <button type="button" role="tab" id="sim-tab-{t.id}" class="tab" class:active={tab === t.id}
+              aria-selected={tab === t.id} aria-controls="sim-tab-panel" on:click={() => (tab = t.id)}>
+              {$_(`simulator.tab.${t.id}`)}
+              {#if flagged.includes(t.id)}
+                <span class="tab-flag" title={$_('simulator.tabProblem')} aria-label={$_('simulator.tabProblem')}></span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+        <div id="sim-tab-panel" role="tabpanel" aria-labelledby="sim-tab-{tab}">
+        {#if tab === 'identity'}
         {#if editing.id}
           <!-- A device keeps its model: its engine ID carries the model's vendor. -->
           {@const model = modelOf($simulatorStore.models, editing.model)}
@@ -469,7 +488,17 @@
           </div>
         </div>
         <label class="check autostart"><input type="checkbox" bind:checked={editing.autoStart} /> {$_('simulator.field.autoStart')}</label>
+        {#if editing.id && editing.engineId}
+          <div class="engine-line">
+            <span class="engine-label">{$_('simulator.field.engineId')}</span>
+            <code>{editing.engineId}</code>
+            <span class="engine-boots">{$_('simulator.engineBoots', { values: { count: editing.engineBoots } })}</span>
+          </div>
+          <p class="hint"><Icon name="key-round" size={14} /> {$_('simulator.engineHint')}</p>
+        {/if}
+        {/if}
 
+        {#if tab === 'access'}
         <fieldset class="versions">
           <legend>{$_('simulator.field.versions')}</legend>
           {#each SIM_VERSIONS as version (version)}
@@ -482,10 +511,18 @@
         </fieldset>
 
         {#if editing.versions.includes('v1') || editing.versions.includes('v2c')}
-          <div class="form-group community">
-            <label for="sim-community">{$_('simulator.field.community')}</label>
-            <input id="sim-community" type="password" autocomplete="off" bind:value={editing.community} />
-            {#if problems.community}<span class="problem">{$_(`simulator.problem.${problems.community}`)}</span>{/if}
+          <div class="grid communities">
+            <div class="form-group">
+              <label for="sim-community">{$_('simulator.field.community')}</label>
+              <input id="sim-community" type="password" autocomplete="off" bind:value={editing.community} />
+              {#if problems.community}<span class="problem">{$_(`simulator.problem.${problems.community}`)}</span>{/if}
+            </div>
+            <div class="form-group">
+              <label for="sim-write-community">{$_('simulator.field.writeCommunity')}</label>
+              <input id="sim-write-community" type="password" autocomplete="off"
+                placeholder={$_('simulator.field.writeCommunityNone')} bind:value={editing.writeCommunity} />
+              {#if problems.writeCommunity}<span class="problem">{$_(`simulator.problem.${problems.writeCommunity}`)}</span>{/if}
+            </div>
           </div>
         {/if}
 
@@ -505,6 +542,7 @@
               <!-- bind:, as the settings do: UsmFields edits the object in place, and
                    without it the checks above never see a passphrase being typed. -->
               <UsmFields bind:v3={u} idPrefix="sim-v3-{i}" problems={usmProblems[i] || {}} showContext={false} />
+              <label class="check user-write"><input type="checkbox" bind:checked={u.write} /> {$_('simulator.field.userWrite')}</label>
             </div>
           {/each}
           {#if problems.noUser}<span class="problem">{$_(`simulator.problem.${problems.noUser}`)}</span>{/if}
@@ -515,9 +553,11 @@
             {#if editing.users.length > 1}<span class="users-note">{$_('simulator.firstUserTarget')}</span>{/if}
           </div>
         {/if}
+        <p class="hint"><Icon name="pencil" size={14} /> {$_('simulator.writeHint')}</p>
+        {/if}
 
-        <h4 class="section-title">{$_('simulator.traps.title')}</h4>
-        <p class="hint"><Icon name="radio" size={14} /> {$_('simulator.traps.hint')}</p>
+        {#if tab === 'traps'}
+        <p class="hint first"><Icon name="radio" size={14} /> {$_('simulator.traps.hint')}</p>
         {#each editing.traps.destinations as dest, i (i)}
           <div class="user-block">
             <div class="user-head">
@@ -618,6 +658,8 @@
             </button>
           </div>
         {/if}
+        {/if}
+        </div>
       </div>
       <footer class="sim-footer">
         {#if saveError}<span class="save-error">{saveError}</span>{/if}
@@ -1169,9 +1211,78 @@
     cursor: pointer;
   }
 
-  .community {
+  .communities {
     margin-top: 14px;
-    max-width: 50%;
+  }
+
+  .user-write {
+    margin-top: 10px;
+    font-size: 0.9em;
+  }
+
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin: 0 0 14px;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: -1px;
+    padding: 7px 14px;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    font-size: 0.9em;
+    cursor: pointer;
+  }
+
+  .tab:hover {
+    color: var(--text-color);
+  }
+
+  .tab.active {
+    border-bottom-color: var(--accent-color);
+    color: var(--text-color);
+    font-weight: 600;
+  }
+
+  .tab-flag {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: var(--error-color);
+  }
+
+  .hint.first {
+    margin-top: 0;
+  }
+
+  .engine-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    margin-top: 14px;
+    font-size: 0.9em;
+  }
+
+  .engine-label {
+    color: var(--text-light);
+  }
+
+  .engine-line code {
+    overflow-wrap: anywhere;
+  }
+
+  .engine-boots {
+    font-size: 0.92em;
+    color: var(--text-muted);
   }
 
   .section-title {

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1311,6 +1311,7 @@
     "duplicated": "„{name}“ als „{copy}“ dupliziert",
     "restart": "Dieses Gerät neu starten: Uptime und Zähler ab null, und coldStart, falls es einen sendet",
     "restarted": "{name} wurde neu gestartet",
+    "autoStartChip": "startet mit SnmpLens",
     "export": {
       "title": "{count, plural, one {# Gerät} other {# Geräte}} exportieren",
       "hint": "Die Passwörter — Communities und Passphrasen — bleiben im Schlüsselbund Ihres Systems, es sei denn, Sie legen sie in die Datei. Tun Sie das nur, um eine vollständige Testumgebung weiterzugeben: Wer die Datei hat, kann sie lesen.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}: Die Datei enthält keine Passwörter — geben Sie ihm seine Community oder Passphrasen, bevor Sie es starten"
       }
     },
+    "faults": {
+      "button": "Fehler: dieses Gerät fehlerhaft verhalten lassen",
+      "hint": "Sofort angewendet, ohne das Gerät neu zu starten: Seine Uptime und Zähler sind das, woran ein Fehler getestet wird. Wird mit dem Gerät gespeichert.",
+      "mute": "Stumm: beantwortet nichts (Benachrichtigungen werden weiter gesendet)",
+      "latency": "Latenz",
+      "jitter": "Jitter",
+      "loss": "Verlust",
+      "error": "Fehlerantworten",
+      "errorNone": "Keine",
+      "counters": "Zähler",
+      "apply": "Anwenden",
+      "clear": "Alle entfernen",
+      "applied": "Fehler von {name} angewendet",
+      "cleared": "{name} verhält sich wieder normal",
+      "chip": {
+        "mute": "stumm",
+        "latency": "Latenz {ms} ms",
+        "latencyJitter": "Latenz {ms} ± {jitter} ms",
+        "loss": "Verlust {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "Zähler ×{speed}"
+      }
+    },
     "loopbackHint": "Nur Loopback: 127.0.0.1 bis 127.255.255.254 oder ::1. Unter Linux und macOS erfordert ein Port unter 1024 Administratorrechte.",
     "field": {
       "name": "Name",
@@ -1334,7 +1358,11 @@
       "port": "Port",
       "versions": "SNMP-Versionen",
       "community": "Community",
-      "v3": "SNMPv3-Benutzer"
+      "v3": "SNMPv3-Benutzer",
+      "location": "Standort (sysLocation)",
+      "contact": "Kontakt (sysContact)",
+      "modelDefault": "Der des Modells",
+      "autoStart": "Mit SnmpLens starten"
     },
     "problem": {
       "nameRequired": "Geben Sie dem Gerät einen Namen.",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} konnte nicht starten: {error}",
     "confirmDelete": "Löschen?",
     "deleteTitle": "Dieses Gerät löschen",
+    "importDevices": "Geräte importieren…",
+    "importDevicesTitle": "Simulierte Geräte aus einer von SnmpLens exportierten Datei hinzufügen",
+    "exportAll": "Alle exportieren…",
+    "exportAllTitle": "Alle simulierten Geräte in eine Datei schreiben, um die Testumgebung umzuziehen oder weiterzugeben",
+    "exportDevice": "Dieses Gerät in eine Datei exportieren",
+    "duplicate": "Dieses Gerät duplizieren",
+    "copyName": "{name} (Kopie)",
+    "duplicated": "„{name}“ als „{copy}“ dupliziert",
+    "restart": "Dieses Gerät neu starten: Uptime und Zähler ab null, und coldStart, falls es einen sendet",
+    "restarted": "{name} wurde neu gestartet",
+    "export": {
+      "title": "{count, plural, one {# Gerät} other {# Geräte}} exportieren",
+      "hint": "Die Passwörter — Communities und Passphrasen — bleiben im Schlüsselbund Ihres Systems, es sei denn, Sie legen sie in die Datei. Tun Sie das nur, um eine vollständige Testumgebung weiterzugeben: Wer die Datei hat, kann sie lesen.",
+      "without": "Ohne Passwörter",
+      "with": "Mit Passwörtern",
+      "done": "Nach {path} exportiert"
+    },
+    "devices": {
+      "imported": "Gerät „{name}“ importiert",
+      "failed": "{name}: {error}",
+      "warning": {
+        "addressMoved": "{name}: Seine Adresse war belegt, es antwortet daher woanders ({detail})",
+        "noSecrets": "{name}: Die Datei enthält keine Passwörter — geben Sie ihm seine Community oder Passphrasen, bevor Sie es starten"
+      }
+    },
     "loopbackHint": "Nur Loopback: 127.0.0.1 bis 127.255.255.254 oder ::1. Unter Linux und macOS erfordert ein Port unter 1024 Administratorrechte.",
     "field": {
       "name": "Name",

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1350,6 +1350,15 @@
         "counters": "Zähler ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Gerät",
+      "access": "Zugriff",
+      "traps": "Benachrichtigungen"
+    },
+    "tabProblem": "Auf diesem Reiter ist etwas zu korrigieren",
+    "writeHint": "Ein SET mit der Schreib-Community oder von einem Benutzer mit Schreibrecht ändert, was das Gerät antwortet, bis es neu startet — wie eine laufende Konfiguration, solange sie nicht gespeichert ist. Zeilen werden über ihren RowStatus angelegt und gelöscht, so wie die geladenen MIBs sie beschreiben. Was der Agent selbst zählt — seine SNMP-Statistiken, seine Engine —, wird nie geschrieben.",
+    "engineHint": "Von SnmpLens vergeben und für die gesamte Lebensdauer des Geräts beibehalten: Manager lokalisieren ihre SNMPv3-Schlüssel darauf.",
+    "engineBoots": "{count, plural, one {# Mal gestartet} other {# Mal gestartet}}",
     "loopbackHint": "Nur Loopback: 127.0.0.1 bis 127.255.255.254 oder ::1. Unter Linux und macOS erfordert ein Port unter 1024 Administratorrechte.",
     "field": {
       "name": "Name",
@@ -1362,7 +1371,11 @@
       "location": "Standort (sysLocation)",
       "contact": "Kontakt (sysContact)",
       "modelDefault": "Der des Modells",
-      "autoStart": "Mit SnmpLens starten"
+      "autoStart": "Mit SnmpLens starten",
+      "writeCommunity": "Schreib-Community",
+      "writeCommunityNone": "Keine: in v1 und v2c nur lesbar",
+      "userWrite": "Darf schreiben (SET)",
+      "engineId": "Engine-ID"
     },
     "problem": {
       "nameRequired": "Geben Sie dem Gerät einen Namen.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Wählen Sie einen der SNMPv3-Benutzer des Geräts.",
       "trapNeedsV3": "Eine v3-Benachrichtigung wird als SNMPv3-Benutzer des Geräts gesendet: Aktivieren Sie zuerst v3.",
       "engineId": "5 bis 32 Oktette, hexadezimal.",
-      "every": "Von 1 bis 86400 Sekunden."
+      "every": "Von 1 bis 86400 Sekunden.",
+      "writeSameAsRead": "Die Schreib-Community muss sich von der Lese-Community unterscheiden: Sonst schreibt jeder Manager, der liest, auch."
     },
     "category": {
       "server": "Server",
@@ -1450,9 +1464,8 @@
     "userN": "Benutzer {n}",
     "addUser": "Benutzer hinzufügen",
     "removeUser": "Diesen Benutzer entfernen",
-    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer.",
+    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer mit Schreibrecht, sonst den ersten.",
     "traps": {
-      "title": "Benachrichtigungen",
       "hint": "Wohin das Gerät seine Traps und INFORMs sendet, und wann. Anders als die Adresse, an der es antwortet, darf ein Ziel irgendwo im Netzwerk liegen.",
       "destinationN": "Ziel {n}",
       "host": "Host",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} could not start: {error}",
     "confirmDelete": "Delete?",
     "deleteTitle": "Delete this device",
+    "importDevices": "Import devices…",
+    "importDevicesTitle": "Add simulated devices from a file exported by SnmpLens",
+    "exportAll": "Export all…",
+    "exportAllTitle": "Write every simulated device to a file, to move the bench or pass it on",
+    "exportDevice": "Export this device to a file",
+    "duplicate": "Duplicate this device",
+    "copyName": "{name} (copy)",
+    "duplicated": "“{name}” duplicated as “{copy}”",
+    "restart": "Restart this device: uptime and counters from zero, and coldStart if it sends one",
+    "restarted": "{name} restarted",
+    "export": {
+      "title": "Export {count, plural, one {# device} other {# devices}}",
+      "hint": "The passwords — communities and passphrases — stay in your system’s keychain unless you put them in the file. Put them in only to hand over a complete bench: anyone who has the file can read them.",
+      "without": "Without passwords",
+      "with": "With passwords",
+      "done": "Exported to {path}"
+    },
+    "devices": {
+      "imported": "Device “{name}” imported",
+      "failed": "{name}: {error}",
+      "warning": {
+        "addressMoved": "{name}: its address was taken, so it answers elsewhere ({detail})",
+        "noSecrets": "{name}: the file carries no passwords — give it its community or passphrases before starting it"
+      }
+    },
     "loopbackHint": "Loopback only: 127.0.0.1 to 127.255.255.254, or ::1. On Linux and macOS, a port below 1024 needs administrator rights.",
     "field": {
       "name": "Name",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1311,6 +1311,7 @@
     "duplicated": "“{name}” duplicated as “{copy}”",
     "restart": "Restart this device: uptime and counters from zero, and coldStart if it sends one",
     "restarted": "{name} restarted",
+    "autoStartChip": "starts with SnmpLens",
     "export": {
       "title": "Export {count, plural, one {# device} other {# devices}}",
       "hint": "The passwords — communities and passphrases — stay in your system’s keychain unless you put them in the file. Put them in only to hand over a complete bench: anyone who has the file can read them.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}: the file carries no passwords — give it its community or passphrases before starting it"
       }
     },
+    "faults": {
+      "button": "Faults: make this device misbehave",
+      "hint": "Applied at once, without restarting the device: its uptime and counters are what a fault is tested against. Kept with the device.",
+      "mute": "Mute: answer nothing (notifications are still sent)",
+      "latency": "Latency",
+      "jitter": "Jitter",
+      "loss": "Loss",
+      "error": "Errors",
+      "errorNone": "None",
+      "counters": "Counters",
+      "apply": "Apply",
+      "clear": "Clear all",
+      "applied": "Faults of {name} applied",
+      "cleared": "{name} does nothing wrong any more",
+      "chip": {
+        "mute": "mute",
+        "latency": "latency {ms} ms",
+        "latencyJitter": "latency {ms} ± {jitter} ms",
+        "loss": "loss {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "counters ×{speed}"
+      }
+    },
     "loopbackHint": "Loopback only: 127.0.0.1 to 127.255.255.254, or ::1. On Linux and macOS, a port below 1024 needs administrator rights.",
     "field": {
       "name": "Name",
@@ -1334,7 +1358,11 @@
       "port": "Port",
       "versions": "SNMP versions",
       "community": "Community",
-      "v3": "SNMPv3 users"
+      "v3": "SNMPv3 users",
+      "location": "Location (sysLocation)",
+      "contact": "Contact (sysContact)",
+      "modelDefault": "The model’s own",
+      "autoStart": "Start with SnmpLens"
     },
     "problem": {
       "nameRequired": "Give the device a name.",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1350,6 +1350,15 @@
         "counters": "counters ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Device",
+      "access": "Access",
+      "traps": "Notifications"
+    },
+    "tabProblem": "Something on this tab needs fixing",
+    "writeHint": "A SET from the write community, or from a user who can write, changes what the device answers until it restarts — as a running configuration does until it is saved. Rows are created and destroyed through their RowStatus, as the loaded MIBs describe them. What the agent counts itself — its SNMP statistics, its engine — is never written.",
+    "engineHint": "Given by SnmpLens and kept for the life of the device: managers localise their SNMPv3 keys to it.",
+    "engineBoots": "{count, plural, one {started # time} other {started # times}}",
     "loopbackHint": "Loopback only: 127.0.0.1 to 127.255.255.254, or ::1. On Linux and macOS, a port below 1024 needs administrator rights.",
     "field": {
       "name": "Name",
@@ -1362,7 +1371,11 @@
       "location": "Location (sysLocation)",
       "contact": "Contact (sysContact)",
       "modelDefault": "The model’s own",
-      "autoStart": "Start with SnmpLens"
+      "autoStart": "Start with SnmpLens",
+      "writeCommunity": "Write community",
+      "writeCommunityNone": "None: read-only in v1 and v2c",
+      "userWrite": "Can write (SET)",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "Give the device a name.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Choose one of the device's SNMPv3 users.",
       "trapNeedsV3": "A v3 notification is sent as one of the device's SNMPv3 users: answer v3 first.",
       "engineId": "5 to 32 octets, in hex.",
-      "every": "From 1 to 86400 seconds."
+      "every": "From 1 to 86400 seconds.",
+      "writeSameAsRead": "The write community must differ from the read community: otherwise every manager that reads also writes."
     },
     "category": {
       "server": "Servers",
@@ -1450,9 +1464,8 @@
     "userN": "User {n}",
     "addUser": "Add a user",
     "removeUser": "Remove this user",
-    "firstUserTarget": "Add as target uses the first user.",
+    "firstUserTarget": "Add as target uses the first user who can write, or else the first.",
     "traps": {
-      "title": "Notifications",
       "hint": "Where the device sends its traps and INFORMs, and when. Unlike where it answers, a destination may be anywhere on the network.",
       "destinationN": "Destination {n}",
       "host": "Host",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} no pudo iniciarse: {error}",
     "confirmDelete": "¿Eliminar?",
     "deleteTitle": "Eliminar este dispositivo",
+    "importDevices": "Importar dispositivos…",
+    "importDevicesTitle": "Añadir dispositivos simulados desde un archivo exportado por SnmpLens",
+    "exportAll": "Exportar todo…",
+    "exportAllTitle": "Escribir todos los dispositivos simulados en un archivo, para mover el banco de pruebas o compartirlo",
+    "exportDevice": "Exportar este dispositivo a un archivo",
+    "duplicate": "Duplicar este dispositivo",
+    "copyName": "{name} (copia)",
+    "duplicated": "«{name}» duplicado como «{copy}»",
+    "restart": "Reiniciar este dispositivo: uptime y contadores desde cero, y coldStart si envía uno",
+    "restarted": "{name} se reinició",
+    "export": {
+      "title": "Exportar {count, plural, one {# dispositivo} other {# dispositivos}}",
+      "hint": "Las contraseñas — comunidades y frases de paso — se quedan en el llavero de su sistema, salvo que las ponga en el archivo. Hágalo solo para entregar un banco de pruebas completo: quien tenga el archivo podrá leerlas.",
+      "without": "Sin contraseñas",
+      "with": "Con contraseñas",
+      "done": "Exportado a {path}"
+    },
+    "devices": {
+      "imported": "Dispositivo «{name}» importado",
+      "failed": "{name}: {error}",
+      "warning": {
+        "addressMoved": "{name}: su dirección estaba ocupada, así que responde en otra ({detail})",
+        "noSecrets": "{name}: el archivo no trae contraseñas — dele su comunidad o sus frases de paso antes de iniciarlo"
+      }
+    },
     "loopbackHint": "Solo loopback: de 127.0.0.1 a 127.255.255.254, o ::1. En Linux y macOS, un puerto inferior a 1024 requiere permisos de administrador.",
     "field": {
       "name": "Nombre",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1311,6 +1311,7 @@
     "duplicated": "«{name}» duplicado como «{copy}»",
     "restart": "Reiniciar este dispositivo: uptime y contadores desde cero, y coldStart si envía uno",
     "restarted": "{name} se reinició",
+    "autoStartChip": "se inicia con SnmpLens",
     "export": {
       "title": "Exportar {count, plural, one {# dispositivo} other {# dispositivos}}",
       "hint": "Las contraseñas — comunidades y frases de paso — se quedan en el llavero de su sistema, salvo que las ponga en el archivo. Hágalo solo para entregar un banco de pruebas completo: quien tenga el archivo podrá leerlas.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}: el archivo no trae contraseñas — dele su comunidad o sus frases de paso antes de iniciarlo"
       }
     },
+    "faults": {
+      "button": "Fallos: hacer que este dispositivo falle",
+      "hint": "Se aplican al momento, sin reiniciar el dispositivo: su uptime y sus contadores son contra lo que se prueba un fallo. Se guardan con el dispositivo.",
+      "mute": "Mudo: no responde a nada (las notificaciones siguen enviándose)",
+      "latency": "Latencia",
+      "jitter": "Variación",
+      "loss": "Pérdida",
+      "error": "Errores",
+      "errorNone": "Ninguno",
+      "counters": "Contadores",
+      "apply": "Aplicar",
+      "clear": "Quitar todos",
+      "applied": "Fallos de {name} aplicados",
+      "cleared": "{name} ya no falla",
+      "chip": {
+        "mute": "mudo",
+        "latency": "latencia {ms} ms",
+        "latencyJitter": "latencia {ms} ± {jitter} ms",
+        "loss": "pérdida {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "contadores ×{speed}"
+      }
+    },
     "loopbackHint": "Solo loopback: de 127.0.0.1 a 127.255.255.254, o ::1. En Linux y macOS, un puerto inferior a 1024 requiere permisos de administrador.",
     "field": {
       "name": "Nombre",
@@ -1334,7 +1358,11 @@
       "port": "Puerto",
       "versions": "Versiones SNMP",
       "community": "Comunidad",
-      "v3": "Usuarios SNMPv3"
+      "v3": "Usuarios SNMPv3",
+      "location": "Ubicación (sysLocation)",
+      "contact": "Contacto (sysContact)",
+      "modelDefault": "La del modelo",
+      "autoStart": "Iniciar con SnmpLens"
     },
     "problem": {
       "nameRequired": "Dé un nombre al dispositivo.",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1350,6 +1350,15 @@
         "counters": "contadores ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Dispositivo",
+      "access": "Acceso",
+      "traps": "Notificaciones"
+    },
+    "tabProblem": "Hay algo que corregir en esta pestaña",
+    "writeHint": "Un SET con la comunidad de escritura, o de un usuario que puede escribir, cambia lo que responde el dispositivo hasta que se reinicia, como una configuración en ejecución mientras no se guarda. Las filas se crean y se eliminan mediante su RowStatus, tal como las describen las MIB cargadas. Lo que el agente cuenta por sí mismo —sus estadísticas SNMP, su motor— nunca se escribe.",
+    "engineHint": "Asignado por SnmpLens y conservado durante toda la vida del dispositivo: los gestores localizan en él sus claves SNMPv3.",
+    "engineBoots": "{count, plural, one {iniciado # vez} other {iniciado # veces}}",
     "loopbackHint": "Solo loopback: de 127.0.0.1 a 127.255.255.254, o ::1. En Linux y macOS, un puerto inferior a 1024 requiere permisos de administrador.",
     "field": {
       "name": "Nombre",
@@ -1362,7 +1371,11 @@
       "location": "Ubicación (sysLocation)",
       "contact": "Contacto (sysContact)",
       "modelDefault": "La del modelo",
-      "autoStart": "Iniciar con SnmpLens"
+      "autoStart": "Iniciar con SnmpLens",
+      "writeCommunity": "Comunidad de escritura",
+      "writeCommunityNone": "Ninguna: solo lectura en v1 y v2c",
+      "userWrite": "Puede escribir (SET)",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "Dé un nombre al dispositivo.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Elija uno de los usuarios SNMPv3 del dispositivo.",
       "trapNeedsV3": "Una notificación v3 se envía como uno de los usuarios SNMPv3 del dispositivo: active primero la v3.",
       "engineId": "De 5 a 32 octetos, en hexadecimal.",
-      "every": "De 1 a 86400 segundos."
+      "every": "De 1 a 86400 segundos.",
+      "writeSameAsRead": "La comunidad de escritura debe ser distinta de la de lectura: si no, todo gestor que lee también escribe."
     },
     "category": {
       "server": "Servidores",
@@ -1450,9 +1464,8 @@
     "userN": "Usuario {n}",
     "addUser": "Añadir un usuario",
     "removeUser": "Quitar este usuario",
-    "firstUserTarget": "«Añadir como destino» usa el primer usuario.",
+    "firstUserTarget": "«Añadir como destino» usa el primer usuario que puede escribir o, si no hay ninguno, el primero.",
     "traps": {
-      "title": "Notificaciones",
       "hint": "Adónde envía el dispositivo sus Traps e INFORM, y cuándo. A diferencia de la dirección en la que responde, un destino puede estar en cualquier lugar de la red.",
       "destinationN": "Destino {n}",
       "host": "Host",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} n'a pas pu démarrer : {error}",
     "confirmDelete": "Supprimer ?",
     "deleteTitle": "Supprimer cet appareil",
+    "importDevices": "Importer des appareils…",
+    "importDevicesTitle": "Ajouter des appareils simulés depuis un fichier exporté par SnmpLens",
+    "exportAll": "Tout exporter…",
+    "exportAllTitle": "Écrire tous les appareils simulés dans un fichier, pour déplacer le banc ou le transmettre",
+    "exportDevice": "Exporter cet appareil dans un fichier",
+    "duplicate": "Dupliquer cet appareil",
+    "copyName": "{name} (copie)",
+    "duplicated": "« {name} » dupliqué en « {copy} »",
+    "restart": "Redémarrer cet appareil : uptime et compteurs à zéro, et coldStart s’il en envoie un",
+    "restarted": "{name} a redémarré",
+    "export": {
+      "title": "Exporter {count, plural, one {# appareil} other {# appareils}}",
+      "hint": "Les mots de passe — communautés et phrases secrètes — restent dans le coffre de votre système, sauf si vous les mettez dans le fichier. Ne les y mettez que pour transmettre un banc complet : quiconque a le fichier peut les lire.",
+      "without": "Sans les mots de passe",
+      "with": "Avec les mots de passe",
+      "done": "Exporté vers {path}"
+    },
+    "devices": {
+      "imported": "Appareil « {name} » importé",
+      "failed": "{name} : {error}",
+      "warning": {
+        "addressMoved": "{name} : son adresse était prise, il répond donc ailleurs ({detail})",
+        "noSecrets": "{name} : le fichier ne contient pas de mots de passe — donnez-lui sa communauté ou ses phrases secrètes avant de le démarrer"
+      }
+    },
     "loopbackHint": "Bouclage uniquement : de 127.0.0.1 à 127.255.255.254, ou ::1. Sous Linux et macOS, un port inférieur à 1024 exige des droits d'administrateur.",
     "field": {
       "name": "Nom",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1311,6 +1311,7 @@
     "duplicated": "« {name} » dupliqué en « {copy} »",
     "restart": "Redémarrer cet appareil : uptime et compteurs à zéro, et coldStart s’il en envoie un",
     "restarted": "{name} a redémarré",
+    "autoStartChip": "démarre avec SnmpLens",
     "export": {
       "title": "Exporter {count, plural, one {# appareil} other {# appareils}}",
       "hint": "Les mots de passe — communautés et phrases secrètes — restent dans le coffre de votre système, sauf si vous les mettez dans le fichier. Ne les y mettez que pour transmettre un banc complet : quiconque a le fichier peut les lire.",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name} : le fichier ne contient pas de mots de passe — donnez-lui sa communauté ou ses phrases secrètes avant de le démarrer"
       }
     },
+    "faults": {
+      "button": "Pannes : faire dysfonctionner cet appareil",
+      "hint": "Appliquées tout de suite, sans redémarrer l’appareil : son uptime et ses compteurs sont ce contre quoi une panne se teste. Gardées avec l’appareil.",
+      "mute": "Muet : ne répond à rien (les notifications partent toujours)",
+      "latency": "Latence",
+      "jitter": "Gigue",
+      "loss": "Perte",
+      "error": "Erreurs",
+      "errorNone": "Aucune",
+      "counters": "Compteurs",
+      "apply": "Appliquer",
+      "clear": "Tout effacer",
+      "applied": "Pannes de {name} appliquées",
+      "cleared": "{name} ne dysfonctionne plus",
+      "chip": {
+        "mute": "muet",
+        "latency": "latence {ms} ms",
+        "latencyJitter": "latence {ms} ± {jitter} ms",
+        "loss": "perte {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "compteurs ×{speed}"
+      }
+    },
     "loopbackHint": "Bouclage uniquement : de 127.0.0.1 à 127.255.255.254, ou ::1. Sous Linux et macOS, un port inférieur à 1024 exige des droits d'administrateur.",
     "field": {
       "name": "Nom",
@@ -1334,7 +1358,11 @@
       "port": "Port",
       "versions": "Versions SNMP",
       "community": "Communauté",
-      "v3": "Utilisateurs SNMPv3"
+      "v3": "Utilisateurs SNMPv3",
+      "location": "Emplacement (sysLocation)",
+      "contact": "Contact (sysContact)",
+      "modelDefault": "Celui du modèle",
+      "autoStart": "Démarrer avec SnmpLens"
     },
     "problem": {
       "nameRequired": "Donnez un nom à l'appareil.",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1350,6 +1350,15 @@
         "counters": "compteurs ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Appareil",
+      "access": "Accès",
+      "traps": "Notifications"
+    },
+    "tabProblem": "Quelque chose est à corriger dans cet onglet",
+    "writeHint": "Un SET envoyé avec la communauté d’écriture, ou par un utilisateur autorisé à écrire, change ce que l’appareil répond jusqu’à son redémarrage — comme une configuration en cours tant qu’elle n’est pas enregistrée. Les lignes se créent et se suppriment par leur RowStatus, telles que les décrivent les MIB chargées. Ce que l’agent compte lui-même — ses statistiques SNMP, son moteur — ne s’écrit jamais.",
+    "engineHint": "Attribué par SnmpLens et conservé toute la vie de l’appareil : les gestionnaires y localisent leurs clés SNMPv3.",
+    "engineBoots": "{count, plural, one {démarré # fois} other {démarré # fois}}",
     "loopbackHint": "Bouclage uniquement : de 127.0.0.1 à 127.255.255.254, ou ::1. Sous Linux et macOS, un port inférieur à 1024 exige des droits d'administrateur.",
     "field": {
       "name": "Nom",
@@ -1362,7 +1371,11 @@
       "location": "Emplacement (sysLocation)",
       "contact": "Contact (sysContact)",
       "modelDefault": "Celui du modèle",
-      "autoStart": "Démarrer avec SnmpLens"
+      "autoStart": "Démarrer avec SnmpLens",
+      "writeCommunity": "Communauté d’écriture",
+      "writeCommunityNone": "Aucune : lecture seule en v1 et v2c",
+      "userWrite": "Peut écrire (SET)",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "Donnez un nom à l'appareil.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Choisissez l’un des utilisateurs SNMPv3 de l’appareil.",
       "trapNeedsV3": "Une notification v3 part au nom d’un utilisateur SNMPv3 de l’appareil : activez d’abord la v3.",
       "engineId": "5 à 32 octets, en hexadécimal.",
-      "every": "De 1 à 86400 secondes."
+      "every": "De 1 à 86400 secondes.",
+      "writeSameAsRead": "La communauté d’écriture doit différer de celle de lecture : sinon, tout gestionnaire qui lit écrit aussi."
     },
     "category": {
       "server": "Serveurs",
@@ -1450,9 +1464,8 @@
     "userN": "Utilisateur {n}",
     "addUser": "Ajouter un utilisateur",
     "removeUser": "Retirer cet utilisateur",
-    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur.",
+    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur qui peut écrire, sinon le premier.",
     "traps": {
-      "title": "Notifications",
       "hint": "Où l’appareil envoie ses traps et ses INFORM, et quand. Contrairement à l’adresse où il répond, une destination peut se trouver n’importe où sur le réseau.",
       "destinationN": "Destination {n}",
       "host": "Hôte",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1311,6 +1311,7 @@
     "duplicated": "已将“{name}”复制为“{copy}”",
     "restart": "重启此设备：运行时间和计数器从零开始，如会发送 coldStart 则发送",
     "restarted": "{name} 已重启",
+    "autoStartChip": "随 SnmpLens 启动",
     "export": {
       "title": "导出 {count, plural, other {# 台设备}}",
       "hint": "密码（团体名和口令）保存在系统钥匙串中，除非您把它们写入文件。仅在需要交付完整测试环境时才这样做：拿到文件的人都能读取它们。",
@@ -1326,6 +1327,29 @@
         "noSecrets": "{name}：文件中不含密码——启动前请为其设置团体名或口令"
       }
     },
+    "faults": {
+      "button": "故障：让此设备出现异常",
+      "hint": "立即生效，无需重启设备：故障正是针对其运行时间和计数器进行测试的。故障设置随设备保存。",
+      "mute": "静默：不响应任何请求（通知仍会发送）",
+      "latency": "延迟",
+      "jitter": "抖动",
+      "loss": "丢包",
+      "error": "错误",
+      "errorNone": "无",
+      "counters": "计数器",
+      "apply": "应用",
+      "clear": "全部清除",
+      "applied": "已应用 {name} 的故障",
+      "cleared": "{name} 已恢复正常",
+      "chip": {
+        "mute": "静默",
+        "latency": "延迟 {ms} ms",
+        "latencyJitter": "延迟 {ms} ± {jitter} ms",
+        "loss": "丢包 {percent} %",
+        "error": "{error} {percent} %",
+        "counters": "计数器 ×{speed}"
+      }
+    },
     "loopbackHint": "仅限回环地址：127.0.0.1 至 127.255.255.254，或 ::1。在 Linux 和 macOS 上，低于 1024 的端口需要管理员权限。",
     "field": {
       "name": "名称",
@@ -1334,7 +1358,11 @@
       "port": "端口",
       "versions": "SNMP 版本",
       "community": "团体名",
-      "v3": "SNMPv3 用户"
+      "v3": "SNMPv3 用户",
+      "location": "位置（sysLocation）",
+      "contact": "联系人（sysContact）",
+      "modelDefault": "使用型号的默认值",
+      "autoStart": "随 SnmpLens 启动"
     },
     "problem": {
       "nameRequired": "请为设备命名。",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1301,6 +1301,31 @@
     "startFailed": "{name} 未能启动：{error}",
     "confirmDelete": "删除？",
     "deleteTitle": "删除此设备",
+    "importDevices": "导入设备…",
+    "importDevicesTitle": "从 SnmpLens 导出的文件添加模拟设备",
+    "exportAll": "全部导出…",
+    "exportAllTitle": "将所有模拟设备写入文件，以便迁移或分享测试环境",
+    "exportDevice": "将此设备导出到文件",
+    "duplicate": "复制此设备",
+    "copyName": "{name}（副本）",
+    "duplicated": "已将“{name}”复制为“{copy}”",
+    "restart": "重启此设备：运行时间和计数器从零开始，如会发送 coldStart 则发送",
+    "restarted": "{name} 已重启",
+    "export": {
+      "title": "导出 {count, plural, other {# 台设备}}",
+      "hint": "密码（团体名和口令）保存在系统钥匙串中，除非您把它们写入文件。仅在需要交付完整测试环境时才这样做：拿到文件的人都能读取它们。",
+      "without": "不含密码",
+      "with": "包含密码",
+      "done": "已导出到 {path}"
+    },
+    "devices": {
+      "imported": "设备“{name}”已导入",
+      "failed": "{name}：{error}",
+      "warning": {
+        "addressMoved": "{name}：其地址已被占用，因此改在别处应答（{detail}）",
+        "noSecrets": "{name}：文件中不含密码——启动前请为其设置团体名或口令"
+      }
+    },
     "loopbackHint": "仅限回环地址：127.0.0.1 至 127.255.255.254，或 ::1。在 Linux 和 macOS 上，低于 1024 的端口需要管理员权限。",
     "field": {
       "name": "名称",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1350,6 +1350,15 @@
         "counters": "计数器 ×{speed}"
       }
     },
+    "tab": {
+      "identity": "设备",
+      "access": "访问",
+      "traps": "通知"
+    },
+    "tabProblem": "此选项卡中有需要修正的内容",
+    "writeHint": "使用写团体名或由具有写权限的用户发出的 SET 会改变设备的应答，直到设备重启——就像尚未保存的运行配置。表行通过其 RowStatus 创建和删除，依据已加载的 MIB 的描述。代理自身统计的内容（SNMP 统计、引擎）永远不可写。",
+    "engineHint": "由 SnmpLens 分配，并在设备的整个生命周期内保持不变：管理端据此本地化其 SNMPv3 密钥。",
+    "engineBoots": "{count, plural, other {已启动 # 次}}",
     "loopbackHint": "仅限回环地址：127.0.0.1 至 127.255.255.254，或 ::1。在 Linux 和 macOS 上，低于 1024 的端口需要管理员权限。",
     "field": {
       "name": "名称",
@@ -1362,7 +1371,11 @@
       "location": "位置（sysLocation）",
       "contact": "联系人（sysContact）",
       "modelDefault": "使用型号的默认值",
-      "autoStart": "随 SnmpLens 启动"
+      "autoStart": "随 SnmpLens 启动",
+      "writeCommunity": "写团体名",
+      "writeCommunityNone": "无：v1 和 v2c 只读",
+      "userWrite": "可写（SET）",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "请为设备命名。",
@@ -1376,7 +1389,8 @@
       "trapUser": "请选择设备的一个 SNMPv3 用户。",
       "trapNeedsV3": "v3 通知以设备的某个 SNMPv3 用户身份发送：请先启用 v3。",
       "engineId": "5 到 32 个八位组，十六进制。",
-      "every": "1 到 86400 秒。"
+      "every": "1 到 86400 秒。",
+      "writeSameAsRead": "写团体名必须与读团体名不同：否则任何能读的管理端也都能写。"
     },
     "category": {
       "server": "服务器",
@@ -1450,9 +1464,8 @@
     "userN": "用户 {n}",
     "addUser": "添加用户",
     "removeUser": "删除此用户",
-    "firstUserTarget": "“添加为目标”使用第一个用户。",
+    "firstUserTarget": "“添加为目标”使用第一个具有写权限的用户，否则使用第一个用户。",
     "traps": {
-      "title": "通知",
       "hint": "设备向何处、在何时发送 Trap 和 INFORM。与设备应答的地址不同，目标可以位于网络上的任何位置。",
       "destinationN": "目标 {n}",
       "host": "主机",

--- a/frontend/src/simulator/FaultsPanel.svelte
+++ b/frontend/src/simulator/FaultsPanel.svelte
@@ -1,0 +1,161 @@
+<script>
+  import { _ } from 'svelte-i18n';
+  import { createEventDispatcher } from 'svelte';
+  import Icon from '../Icon.svelte';
+  import { COUNTER_SPEEDS, MAX_LATENCY_MS, blankFaults, editableFaults, faultsPayload } from '../utils/simulator.js';
+
+  /**
+   * What a device is made to do wrong. Applied at once and without a restart —
+   * the device keeps the uptime and the counters a fault is tested against —
+   * and kept with it. The modal applies; this asks.
+   */
+  /** The device's faults, as the list gives them. */
+  export let faults = null;
+  /** Keeps the fields' ids unique when more than one panel is open. */
+  export let idPrefix = 'sim-faults';
+  export let busy = false;
+
+  const dispatch = createEventDispatcher();
+  let form = editableFaults(faults);
+
+  function clearAll() {
+    form = blankFaults();
+    dispatch('apply', faultsPayload(form));
+  }
+</script>
+
+<div class="faults">
+  <p class="hint"><Icon name="zap" size={14} /> {$_('simulator.faults.hint')}</p>
+  <label class="check">
+    <input type="checkbox" bind:checked={form.mute} /> {$_('simulator.faults.mute')}
+  </label>
+  <div class="fields">
+    <div class="field">
+      <label for="{idPrefix}-latency">{$_('simulator.faults.latency')}</label>
+      <span class="inputs">
+        <input id="{idPrefix}-latency" type="number" min="0" max={MAX_LATENCY_MS} step="50" bind:value={form.latencyMs} />
+        <span class="unit">ms ±</span>
+        <input id="{idPrefix}-jitter" type="number" min="0" max={MAX_LATENCY_MS} step="50" bind:value={form.jitterMs}
+          aria-label={$_('simulator.faults.jitter')} title={$_('simulator.faults.jitter')} />
+        <span class="unit">ms</span>
+      </span>
+    </div>
+    <div class="field">
+      <label for="{idPrefix}-loss">{$_('simulator.faults.loss')}</label>
+      <span class="inputs">
+        <input id="{idPrefix}-loss" type="number" min="0" max="100" bind:value={form.lossPercent} />
+        <span class="unit">%</span>
+      </span>
+    </div>
+    <div class="field">
+      <label for="{idPrefix}-error">{$_('simulator.faults.error')}</label>
+      <span class="inputs">
+        <select id="{idPrefix}-error" bind:value={form.error}>
+          <option value="">{$_('simulator.faults.errorNone')}</option>
+          <option value="genErr">genErr</option>
+          <option value="tooBig">tooBig</option>
+        </select>
+        {#if form.error}
+          <input id="{idPrefix}-error-share" type="number" min="1" max="100" bind:value={form.errorPercent}
+            aria-label={$_('simulator.faults.error')} />
+          <span class="unit">%</span>
+        {/if}
+      </span>
+    </div>
+    <div class="field">
+      <label for="{idPrefix}-counters">{$_('simulator.faults.counters')}</label>
+      <span class="inputs">
+        <select id="{idPrefix}-counters" bind:value={form.counterSpeed}>
+          {#each COUNTER_SPEEDS as s (s)}<option value={s}>×{s}</option>{/each}
+        </select>
+      </span>
+    </div>
+  </div>
+  <div class="foot">
+    <button type="button" class="btn secondary btn-small" on:click={() => dispatch('close')}>{$_('common.close')}</button>
+    <button type="button" class="btn secondary btn-small" disabled={busy} on:click={clearAll}>{$_('simulator.faults.clear')}</button>
+    <button type="button" class="btn btn-small" disabled={busy} on:click={() => dispatch('apply', faultsPayload(form))}>
+      {$_('simulator.faults.apply')}
+    </button>
+  </div>
+</div>
+
+<style>
+  .faults {
+    flex-basis: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 8px;
+    padding: 10px 12px;
+    background-color: var(--bg-color);
+    border: 1px solid var(--warning-border);
+    border-radius: 6px;
+  }
+
+  .hint {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin: 0;
+    font-size: 0.82em;
+    line-height: 1.4;
+    color: var(--text-muted);
+  }
+
+  .check {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9em;
+    cursor: pointer;
+  }
+
+  .fields {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 10px 16px;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+
+  .field label {
+    font-size: 0.85em;
+    color: var(--text-light);
+  }
+
+  .inputs {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .inputs input {
+    width: 80px;
+  }
+
+  input,
+  select {
+    padding: 5px 8px;
+    background-color: var(--bg-lighter-color);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    color: var(--text-color);
+  }
+
+  .unit {
+    font-size: 0.85em;
+    color: var(--text-muted);
+  }
+
+  .foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>

--- a/frontend/src/stores/simulatorStore.js
+++ b/frontend/src/stores/simulatorStore.js
@@ -15,6 +15,10 @@ import {
   SimulatorRecordDevice,
   SimulatorCancelRecording,
   SimulatorExportModelDialog,
+  ImportSimulatedDevicesDialog,
+  SimulatorExportDevicesDialog,
+  SimulatorDuplicateDevice,
+  SimulatorRestartDevice,
   TrapListenerEngineID,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
@@ -103,6 +107,16 @@ function createSimulatorStore() {
     stopRecording: () => SimulatorCancelRecording(),
     /** Writes a custom model to a ZIP the user names; resolves to where, or '' when cancelled. */
     exportModel: async (id) => (await SimulatorExportModelDialog(id)) || '',
+    /** Asks for files of simulated devices and imports them; resolves to what became of each device. */
+    importDevices: async () => (await ImportSimulatedDevicesDialog()) || [],
+    /**
+     * Writes devices — those named, or every one — to a file the user names,
+     * their passwords only when withSecrets says so; resolves to where, or ''
+     * when cancelled.
+     */
+    exportDevices: async (ids, withSecrets) => (await SimulatorExportDevicesDialog(ids || [], !!withSecrets)) || '',
+    duplicate: (id, name) => SimulatorDuplicateDevice(id, name),
+    restart: (id) => SimulatorRestartDevice(id),
     /** The engine ID SnmpLens's own trap listener stands for, in hex. */
     listenerEngineId: async () => (await TrapListenerEngineID()) || '',
   };

--- a/frontend/src/stores/simulatorStore.js
+++ b/frontend/src/stores/simulatorStore.js
@@ -19,6 +19,7 @@ import {
   SimulatorExportDevicesDialog,
   SimulatorDuplicateDevice,
   SimulatorRestartDevice,
+  SimulatorSetFaults,
   TrapListenerEngineID,
 } from '../../wailsjs/go/main/App';
 import { EventsOn } from '../../wailsjs/runtime/runtime';
@@ -117,6 +118,8 @@ function createSimulatorStore() {
     exportDevices: async (ids, withSecrets) => (await SimulatorExportDevicesDialog(ids || [], !!withSecrets)) || '',
     duplicate: (id, name) => SimulatorDuplicateDevice(id, name),
     restart: (id) => SimulatorRestartDevice(id),
+    /** Changes what a device does wrong, at once and without restarting it. */
+    setFaults: (id, faults) => SimulatorSetFaults(id, faults),
     /** The engine ID SnmpLens's own trap listener stands for, in hex. */
     listenerEngineId: async () => (await TrapListenerEngineID()) || '',
   };

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -379,6 +379,26 @@ export function firstImported(results) {
   return (results || []).find((r) => r.success)?.modelId || '';
 }
 
+/**
+ * What to say about an import of simulated devices, as i18n keys: a line per
+ * device imported or refused — or for the file, when it was refused whole —
+ * and one per warning about a device imported anyway.
+ */
+export function deviceImportReport(results) {
+  const out = [];
+  for (const r of results || []) {
+    if (!r.success) {
+      out.push({ key: 'simulator.devices.failed', values: { name: r.name, error: r.error }, level: 'error' });
+      continue;
+    }
+    out.push({ key: 'simulator.devices.imported', values: { name: r.name }, level: 'success' });
+    for (const w of r.warnings || []) {
+      out.push({ key: `simulator.devices.warning.${w.key}`, values: { name: r.name, detail: w.detail }, level: 'warning' });
+    }
+  }
+  return out;
+}
+
 /** The categories a recorded model may be filed under: Go's customCategories. */
 export const CUSTOM_CATEGORIES = Object.keys(CATEGORY_ICONS);
 

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -66,7 +66,25 @@ export function blankV3(n = 1) {
     privProto: 'AES',
     privPass: '',
     contextName: '',
+    write: false,
   };
+}
+
+/**
+ * The editor's tabs, in order, and the fields of deviceProblems each holds: a
+ * tab with something wrong in it is marked, since what is wrong may be on a tab
+ * nobody is looking at.
+ */
+export const EDITOR_TABS = [
+  { id: 'identity', fields: ['name', 'port'] },
+  { id: 'access', fields: ['versions', 'community', 'writeCommunity', 'noUser', 'users'] },
+  { id: 'traps', fields: ['destinations', 'schedules'] },
+];
+
+/** The tabs holding at least one of a device's problems. */
+export function tabsWithProblems(problems) {
+  const keys = Object.keys(problems || {});
+  return EDITOR_TABS.filter((t) => t.fields.some((f) => keys.includes(f))).map((t) => t.id);
 }
 
 /**
@@ -83,6 +101,8 @@ export function blankDevice(model, suggestion) {
     port: suggestion?.port || 1161,
     versions: ['v2c'],
     community: 'public',
+    // Read-only until someone gives it a way to be written.
+    writeCommunity: '',
     users: [blankV3()],
     traps: blankTraps(),
     location: '',
@@ -104,6 +124,7 @@ export function editableDevice(view, creds) {
     privProto: u.privProto || 'AES',
     privPass: creds?.users?.[u.name]?.privPass || '',
     contextName: '',
+    write: !!u.write,
   }));
   return {
     id: view.id,
@@ -113,7 +134,11 @@ export function editableDevice(view, creds) {
     port: view.port,
     versions: [...(view.versions || [])],
     community: creds?.community || '',
+    writeCommunity: creds?.writeCommunity || '',
     users: users.length ? users : [blankV3()],
+    // Shown, never sent: the engine is the backend's.
+    engineId: view.engineId || '',
+    engineBoots: view.engineBoots || 0,
     location: view.location || '',
     contact: view.contact || '',
     autoStart: !!view.autoStart,
@@ -152,6 +177,10 @@ export function deviceProblems(d) {
   if (!Number.isInteger(port) || port < 1 || port > 65535) problems.port = 'port';
   if (!versions.length) problems.versions = 'versionRequired';
   if (usesCommunity(versions) && !d.community) problems.community = 'communityRequired';
+  // One community for both is every manager that reads also writing.
+  if (usesCommunity(versions) && d.writeCommunity && d.writeCommunity === d.community) {
+    problems.writeCommunity = 'writeSameAsRead';
+  }
   if (versions.includes('v3')) {
     const users = d.users || [];
     if (!users.length) problems.noUser = 'userRequired';
@@ -227,6 +256,7 @@ export function devicePayload(d) {
     port: Number(d.port),
     versions,
     community: usesCommunity(versions) ? d.community : '',
+    writeCommunity: usesCommunity(versions) ? d.writeCommunity || '' : '',
     users: versions.includes('v3')
       ? (d.users || []).map((u) => ({
           name: (u.user || '').trim(),
@@ -235,6 +265,7 @@ export function devicePayload(d) {
           authPass: u.authPass,
           privProto: u.privProto,
           privPass: u.privPass,
+          write: !!u.write,
         }))
       : [],
     location: (d.location || '').trim(),
@@ -568,7 +599,10 @@ function targetOfLine(line) {
 /**
  * The settings with a device added as a target: the target in the list, named
  * after the device, and an override carrying its identifiers in the most secure
- * version it answers — with its FIRST user for v3.
+ * version it answers — the ones that WRITE when it has any, since they read as
+ * well and a device on a bench is there to be written to: its first user with
+ * write access for v3, else its first user; its write community, else its
+ * community.
  *
  * The port travels in the target when it is not 161, and the override then
  * leaves it out: the target's would win over it anyway. A device added again
@@ -581,7 +615,7 @@ export function addDeviceAsTarget(settings, device, creds) {
   const override = { snmpVersion: version };
   if (target === device.address) override.port = device.port;
   if (version === 'v3') {
-    const u = device.users[0];
+    const u = device.users.find((x) => x.write) || device.users[0];
     override.v3 = {
       user: u.name,
       secLevel: u.secLevel,
@@ -592,7 +626,7 @@ export function addDeviceAsTarget(settings, device, creds) {
       contextName: '',
     };
   } else {
-    override.community = creds?.community || '';
+    override.community = creds?.writeCommunity || creds?.community || '';
   }
   const lines = (settings.targets || '').split('\n').filter((l) => l.trim());
   const added = !lines.some((l) => targetOfLine(l) === target);

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -85,6 +85,9 @@ export function blankDevice(model, suggestion) {
     community: 'public',
     users: [blankV3()],
     traps: blankTraps(),
+    location: '',
+    contact: '',
+    autoStart: false,
   };
 }
 
@@ -111,6 +114,9 @@ export function editableDevice(view, creds) {
     versions: [...(view.versions || [])],
     community: creds?.community || '',
     users: users.length ? users : [blankV3()],
+    location: view.location || '',
+    contact: view.contact || '',
+    autoStart: !!view.autoStart,
     traps: {
       destinations: (view.traps?.destinations || []).map((t) => ({
         id: t.id,
@@ -231,6 +237,9 @@ export function devicePayload(d) {
           privPass: u.privPass,
         }))
       : [],
+    location: (d.location || '').trim(),
+    contact: (d.contact || '').trim(),
+    autoStart: !!d.autoStart,
     engineId: '',
     engineBoots: 0,
     // Each destination with only what its version uses, as the users are.
@@ -397,6 +406,79 @@ export function deviceImportReport(results) {
     }
   }
   return out;
+}
+
+/** The speeds a device's counters can run at, and the longest latency, as pkg/simulator bounds them. */
+export const COUNTER_SPEEDS = [1, 10, 100, 1000];
+export const MAX_LATENCY_MS = 10000;
+
+/** A device doing nothing wrong. */
+export function blankFaults() {
+  return { latencyMs: 0, jitterMs: 0, lossPercent: 0, mute: false, error: '', errorPercent: 0, counterSpeed: 1 };
+}
+
+/**
+ * A device's faults in the panel's shape: an error, once chosen, answers every
+ * request until a share is given.
+ */
+export function editableFaults(f) {
+  return {
+    ...blankFaults(),
+    ...(f || {}),
+    counterSpeed: Math.max(Number(f?.counterSpeed) || 1, 1),
+    errorPercent: f?.error ? f.errorPercent : 100,
+  };
+}
+
+/** The faults as SimulatorSetFaults takes them: whole numbers in bounds, and no share of errors without an error. */
+export function faultsPayload(f) {
+  const whole = (v, lo, hi) => Math.min(Math.max(Math.round(Number(v) || 0), lo), hi);
+  const error = f.error === 'tooBig' || f.error === 'genErr' ? f.error : '';
+  return {
+    latencyMs: whole(f.latencyMs, 0, MAX_LATENCY_MS),
+    jitterMs: whole(f.jitterMs, 0, MAX_LATENCY_MS),
+    lossPercent: whole(f.lossPercent, 0, 100),
+    mute: !!f.mute,
+    error,
+    errorPercent: error ? whole(f.errorPercent, 1, 100) : 0,
+    counterSpeed: COUNTER_SPEEDS.includes(Number(f.counterSpeed)) ? Number(f.counterSpeed) : 1,
+  };
+}
+
+/**
+ * What a device is made to do wrong, as the chips its row shows: i18n key
+ * suffixes (simulator.faults.chip.<key>) and what each sentence quotes.
+ */
+export function faultChips(f) {
+  const out = [];
+  if (!f) return out;
+  if (f.mute) out.push({ key: 'mute', values: {} });
+  if (f.latencyMs || f.jitterMs) {
+    out.push({ key: f.jitterMs ? 'latencyJitter' : 'latency', values: { ms: f.latencyMs, jitter: f.jitterMs } });
+  }
+  if (f.lossPercent) out.push({ key: 'loss', values: { percent: f.lossPercent } });
+  if (f.error) out.push({ key: 'error', values: { error: f.error, percent: f.errorPercent } });
+  if (f.counterSpeed > 1) out.push({ key: 'counters', values: { speed: f.counterSpeed } });
+  return out;
+}
+
+/**
+ * The devices grouped by their model's category, the categories in the order
+ * the catalogue gives them; a device of a model since deleted is filed under
+ * "other".
+ */
+export function deviceGroups(devices, models) {
+  const order = categoriesOf(models);
+  const rank = (c) => (order.includes(c) ? order.indexOf(c) : order.length);
+  const groups = new Map();
+  for (const d of devices || []) {
+    const category = modelOf(models, d.model)?.category || 'other';
+    if (!groups.has(category)) groups.set(category, []);
+    groups.get(category).push(d);
+  }
+  return [...groups.entries()]
+    .sort(([a], [b]) => rank(a) - rank(b))
+    .map(([category, list]) => ({ category, devices: list }));
 }
 
 /** The categories a recorded model may be filed under: Go's customCategories. */

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -54,6 +54,8 @@ const {
   editableDevice,
   deviceProblems,
   devicePayload,
+  EDITOR_TABS,
+  tabsWithProblems,
   deliveryReport,
   trapActivity,
   modelGroups,
@@ -209,8 +211,8 @@ check('the editor is given the community, and every user with its passphrases',
   form.users[0].privPass === 'privpass-1' && form.users[1].authPass === 'monitor-pass');
 check('and editing nothing sends back the same users',
   JSON.stringify(devicePayload(form).users) === JSON.stringify([
-    { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1' },
-    { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', authPass: 'monitor-pass', privProto: 'AES', privPass: '' },
+    { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1', write: false },
+    { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', authPass: 'monitor-pass', privProto: 'AES', privPass: '', write: false },
   ]));
 check("a destination's community comes back by its ID, and goes back without the counters",
   form.traps.destinations[0].community === 'trap-community' &&
@@ -220,6 +222,42 @@ check("a destination's community comes back by its ID, and goes back without the
     onAuthFailure: false,
     schedules: [{ notification: 'linkUp', every: 60, irregular: false }],
   }), JSON.stringify(devicePayload(form).traps));
+
+/* --- writing ---------------------------------------------------------------- */
+
+check('a new device writes nothing', fresh.writeCommunity === '' && fresh.users.every((u) => !u.write));
+const writeForm = editableDevice({ ...view, users: [{ ...view.users[0], write: true }] }, { ...creds, writeCommunity: 'wr1te' });
+check('the editor is given the write community, and which users write',
+  writeForm.writeCommunity === 'wr1te' && writeForm.users[0].write === true);
+check('and sends both back', devicePayload(writeForm).writeCommunity === 'wr1te' && devicePayload(writeForm).users[0].write === true);
+check('a device answering v3 alone sends no write community',
+  devicePayload({ ...writeForm, versions: ['v3'] }).writeCommunity === '');
+check('a write community that is the read community is refused',
+  deviceProblems({ ...fresh, name: 'x', writeCommunity: 'public' }).writeCommunity === 'writeSameAsRead' &&
+  !deviceProblems({ ...fresh, name: 'x', writeCommunity: 'private' }).writeCommunity);
+const booted = editableDevice({ ...view, engineId: '8000000903020000000001', engineBoots: 3 }, creds);
+check("the editor shows the device's engine, and sends none",
+  booted.engineId === '8000000903020000000001' && booted.engineBoots === 3 &&
+  devicePayload(booted).engineId === '' && devicePayload(booted).engineBoots === 0);
+
+/* --- the editor's tabs ------------------------------------------------------ */
+
+check('a problem marks the tab it is on',
+  JSON.stringify(tabsWithProblems({ name: 'nameRequired', writeCommunity: 'writeSameAsRead' })) === JSON.stringify(['identity', 'access']) &&
+  tabsWithProblems({}).length === 0);
+// Every problem deviceProblems can report, from devices wrong in every way: one
+// no tab holds would be a Save button greyed out for a reason nobody can see.
+const everyProblem = [
+  { ...fresh, name: '', port: 0, versions: ['v2c', 'v3'], community: '', users: [],
+    traps: { ...blankTraps(), destinations: [{ ...blankDestination(162), host: '' }], schedules: [{ ...blankSchedule(), every: 0 }] } },
+  { ...fresh, versions: [] },
+  { ...fresh, versions: ['v2c', 'v3'], writeCommunity: 'public', users: [{ ...blankV3(), authPass: 'short' }] },
+].flatMap((d) => Object.keys(deviceProblems(d)));
+const onTabs = EDITOR_TABS.flatMap((t) => t.fields);
+check('every problem is on a tab', everyProblem.every((k) => onTabs.includes(k)),
+  everyProblem.filter((k) => !onTabs.includes(k)).join());
+check('and the devices above are wrong in every way a tab names', onTabs.every((k) => everyProblem.includes(k)),
+  onTabs.filter((k) => !everyProblem.includes(k)).join());
 
 /* --- the port a target names --------------------------------------------- */
 
@@ -285,6 +323,14 @@ check('with no override of a port the target already names',
 const overruled = { ...settings, targetOverrides: { '127.0.0.1:1162': { port: 9999 } } };
 check("a port the target names wins over an override's", getEffectiveSettings(overruled, '127.0.0.1:1162').port === 1162);
 check('and over the default, with no override at all', getEffectiveSettings(settings, '127.0.0.1:1163').port === 1163);
+
+// A device on a bench is there to be written to: its target writes when it can.
+const writer = { ...view, users: [view.users[0], { ...view.users[1], write: true }] };
+const w3 = getEffectiveSettings(addDeviceAsTarget(settings, writer, creds).settings, '127.0.0.2');
+check('a device with a user who can write is a target as that user',
+  w3.v3.user === 'monitor' && w3.v3.authPass === 'monitor-pass', w3.v3.user);
+const wc = getEffectiveSettings(addDeviceAsTarget(settings, mac1, { ...creds, writeCommunity: 'wr1te' }).settings, '127.0.0.1:1161');
+check('and a device with a write community, with that community', wc.community === 'wr1te', wc.community);
 
 /* --- every model Go serves is named and described ------------------------ */
 

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -66,6 +66,7 @@ const {
   devicesOfModel,
   importReport,
   firstImported,
+  deviceImportReport,
   CUSTOM_CATEGORIES,
   recordableTargets,
   recordRequest,
@@ -432,5 +433,36 @@ const goCategories = [...customCategories].sort();
 check('the categories a recording offers are those Go accepts',
   goCategories.length > 0 && JSON.stringify([...CUSTOM_CATEGORIES].sort()) === JSON.stringify(goCategories),
   `${CUSTOM_CATEGORIES} vs ${goCategories}`);
+
+// An import of simulated devices is reported device by device, each warning
+// after its device; a file refused whole is one line, under its own name.
+const benchLines = deviceImportReport([
+  { name: 'core-01', success: true, id: 'a', warnings: [{ key: 'addressMoved', detail: '127.0.0.2:161 → 127.0.0.3:161' }] },
+  { name: 'gone', success: false, error: '"custom:x" is not a device model', warnings: [] },
+  { name: 'edge-01', success: true, id: 'b', warnings: [{ key: 'noSecrets', detail: '' }] },
+]);
+check('an import of devices is reported device by device, each warning after its device',
+  benchLines.map((l) => `${l.key}:${l.level}`).join(' ') ===
+  'simulator.devices.imported:success simulator.devices.warning.addressMoved:warning simulator.devices.failed:error ' +
+  'simulator.devices.imported:success simulator.devices.warning.noSecrets:warning',
+  JSON.stringify(benchLines));
+
+// Every warning Go gives about a device imported has its sentence.
+const benchGo = readFileSync(new URL('../../app_simbench.go', import.meta.url), 'utf8');
+const benchKeys = new Set([...benchGo.matchAll(/Key: "([A-Za-z]+)"/g)].map((m) => m[1]));
+check('the warnings a device import gives were found in app_simbench.go', benchKeys.size >= 2, [...benchKeys].join());
+for (const key of benchKeys) {
+  check(`en.json says simulator.devices.warning.${key}`, Boolean(en.simulator?.devices?.warning?.[key]));
+}
+for (const key of ['importDevices', 'importDevicesTitle', 'exportAll', 'exportAllTitle', 'exportDevice', 'duplicate',
+  'copyName', 'duplicated', 'restart', 'restarted']) {
+  check(`en.json says simulator.${key}`, Boolean(en.simulator?.[key]));
+}
+for (const key of ['title', 'hint', 'without', 'with', 'done']) {
+  check(`en.json says simulator.export.${key}`, Boolean(en.simulator?.export?.[key]));
+}
+for (const key of ['imported', 'failed']) {
+  check(`en.json says simulator.devices.${key}`, Boolean(en.simulator?.devices?.[key]));
+}
 
 process.exit(failures ? 1 : 0);

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -67,6 +67,12 @@ const {
   importReport,
   firstImported,
   deviceImportReport,
+  blankFaults,
+  editableFaults,
+  faultsPayload,
+  faultChips,
+  deviceGroups,
+  COUNTER_SPEEDS,
   CUSTOM_CATEGORIES,
   recordableTargets,
   recordRequest,
@@ -464,5 +470,52 @@ for (const key of ['title', 'hint', 'without', 'with', 'done']) {
 for (const key of ['imported', 'failed']) {
   check(`en.json says simulator.devices.${key}`, Boolean(en.simulator?.devices?.[key]));
 }
+
+/* --- faults ---------------------------------------------------------------- */
+
+// What the panel sends is exactly what Go's Faults reads, in bounds: a share of
+// errors only with an error, a counter speed Go accepts.
+const faultsGo = readFileSync(new URL('../../pkg/simulator/faults.go', import.meta.url), 'utf8');
+const faultTags = goTags(faultsGo, 'Faults').sort();
+const sentFaults = faultsPayload({ latencyMs: '250.4', jitterMs: 99999, lossPercent: -5, mute: 1, error: 'genErr', errorPercent: 0, counterSpeed: '100' });
+check('the faults sent are what Go reads, and nothing else',
+  faultTags.length === 7 && JSON.stringify(Object.keys(sentFaults).sort()) === JSON.stringify(faultTags),
+  `${Object.keys(sentFaults).sort()} vs ${faultTags}`);
+check('and in bounds',
+  sentFaults.latencyMs === 250 && sentFaults.jitterMs === 10000 && sentFaults.lossPercent === 0 && sentFaults.mute === true &&
+  sentFaults.errorPercent === 1 && sentFaults.counterSpeed === 100, JSON.stringify(sentFaults));
+check('no share of errors without an error, and an unknown speed is 1',
+  faultsPayload({ ...blankFaults(), errorPercent: 40, error: 'noSuchName', counterSpeed: 7 }).errorPercent === 0 &&
+  faultsPayload({ ...blankFaults(), counterSpeed: 7 }).counterSpeed === 1);
+check('the speeds offered are those Go accepts',
+  JSON.stringify(COUNTER_SPEEDS) === JSON.stringify([...faultsGo.matchAll(/counterSpeeds = \[\]int\{([^}]*)\}/g)][0][1]
+    .split(',').map((s) => Number(s.trim())).filter((n) => n > 0)));
+check('an error chosen in the panel answers every request until a share is given',
+  editableFaults({ ...blankFaults(), error: '' }).errorPercent === 100 &&
+  editableFaults({ ...blankFaults(), error: 'tooBig', errorPercent: 30 }).errorPercent === 30);
+const chips = faultChips({ latencyMs: 500, jitterMs: 100, lossPercent: 10, mute: true, error: 'tooBig', errorPercent: 20, counterSpeed: 1000 });
+check('a device doing everything wrong says so, fault by fault',
+  chips.map((c) => c.key).join() === 'mute,latencyJitter,loss,error,counters' && faultChips(blankFaults()).length === 0,
+  JSON.stringify(chips));
+for (const key of ['button', 'hint', 'mute', 'latency', 'jitter', 'loss', 'error', 'errorNone', 'counters', 'apply', 'clear', 'applied', 'cleared']) {
+  check(`en.json says simulator.faults.${key}`, Boolean(en.simulator?.faults?.[key]));
+}
+for (const key of ['mute', 'latency', 'latencyJitter', 'loss', 'error', 'counters']) {
+  check(`en.json says simulator.faults.chip.${key}`, Boolean(en.simulator?.faults?.chip?.[key]));
+}
+for (const key of ['location', 'contact', 'modelDefault', 'autoStart']) {
+  check(`en.json says simulator.field.${key}`, Boolean(en.simulator?.field?.[key]));
+}
+
+// The list files each device under its model's category, in the catalogue's
+// order, and a device of a model since deleted under "other".
+const groupModels = [{ id: 'linux-server', category: 'server' }, { id: 'cisco-catalyst-24', category: 'network' }];
+const filed = deviceGroups([
+  { id: '1', model: 'cisco-catalyst-24' }, { id: '2', model: 'custom:gone' }, { id: '3', model: 'linux-server' },
+  { id: '4', model: 'linux-server' },
+], groupModels);
+check('devices are grouped by category, in the catalogue order',
+  filed.map((g) => `${g.category}:${g.devices.map((d) => d.id).join('+')}`).join(' ') === 'server:3+4 network:1 other:2',
+  JSON.stringify(filed));
 
 process.exit(failures ? 1 : 0);

--- a/pkg/mib/rowstatus.go
+++ b/pkg/mib/rowstatus.go
@@ -1,0 +1,28 @@
+package mib
+
+import (
+	"strings"
+
+	"github.com/sleepinggenius2/gosmi"
+	"github.com/sleepinggenius2/gosmi/types"
+)
+
+// RowStatusColumn reports whether instance lies in a column whose SYNTAX is
+// RowStatus in a loaded MIB, and that column's OID: what a simulated agent
+// needs to create and destroy rows as RFC 2579 has an agent do, without a MIB
+// of its own. gosmi answers an OID with the closest node at or above it, which
+// for an instance of a column is the column.
+func (s *Service) RowStatusColumn(instance string) (string, bool) {
+	gosmiMu.Lock()
+	defer gosmiMu.Unlock()
+	id, err := types.OidFromString(strings.TrimPrefix(instance, "."))
+	if err != nil {
+		return "", false
+	}
+	node, err := gosmi.GetNodeByOID(id)
+	if err != nil || node.Kind != types.NodeColumn || node.Type == nil || node.Type.Name != "RowStatus" ||
+		len(node.Oid) >= len(id) {
+		return "", false
+	}
+	return node.Oid.String(), true
+}

--- a/pkg/mib/rowstatus_test.go
+++ b/pkg/mib/rowstatus_test.go
@@ -1,0 +1,22 @@
+package mib
+
+import (
+	"strings"
+	"testing"
+)
+
+// An instance of ifStackStatus — IF-MIB's RowStatus — is known as one, with its
+// column; an instance of another column, the column itself and an OID no MIB
+// describes are not.
+func TestARowStatusColumnIsFoundInTheMIB(t *testing.T) {
+	s := loadedService(t)
+	col, ok := s.RowStatusColumn(".1.3.6.1.2.1.31.1.2.1.3.5.6")
+	if !ok || strings.TrimPrefix(col, ".") != "1.3.6.1.2.1.31.1.2.1.3" {
+		t.Errorf("ifStackStatus.5.6: %q, %v", col, ok)
+	}
+	for _, not := range []string{"1.3.6.1.2.1.2.2.1.2.1", "1.3.6.1.2.1.31.1.2.1.3", "1.3.6.1.4.1.32473.1.2.3"} {
+		if col, ok := s.RowStatusColumn(not); ok {
+			t.Errorf("%s was taken for an instance of the RowStatus %s", not, col)
+		}
+	}
+}

--- a/pkg/simulator/agent.go
+++ b/pkg/simulator/agent.go
@@ -34,6 +34,9 @@ type Config struct {
 	Versions []string
 	// Community is what v1 and v2c are read with.
 	Community string
+	// WriteCommunity is what v1 and v2c write with (set.go), and read with as
+	// well; empty, nothing is written in v1 or v2c.
+	WriteCommunity string
 	// Users are the SNMPv3 users.
 	Users []User
 	// EngineID is the agent's snmpEngineID, 5 to 32 octets; see EngineID. It
@@ -52,6 +55,10 @@ type Config struct {
 	Traps Traps
 	// Faults are what the agent is made to do wrong; see Faults.
 	Faults Faults
+	// RowStatus tells an instance of a RowStatus column (RFC 2579) from any
+	// other, and names the column: that needs the MIB, which the agent does not
+	// have. Nil, rows are written like any instance and never destroyed whole.
+	RowStatus func(instance string) (column string, ok bool)
 }
 
 // Stats counts what an agent did with what it received — most of all what it
@@ -86,8 +93,10 @@ type counters struct {
 	unknownEngineIDs, unknownUserNames, unsupportedSecLevels, wrongDigests, notInTimeWindows,
 	decryptionErrors, unknownContexts, unknownPDUHandlers, faults atomic.Uint32
 	// What SNMPv2-MIB's snmp group counts besides: the requests by kind, the
-	// varbinds read, the answers and the notifications sent.
-	inGets, inGetNexts, inSets, inTotalReqVars, outGetResponses, outNoSuchNames, outTraps atomic.Uint32
+	// varbinds read and written, a community used for what it may not do, the
+	// answers and the notifications sent.
+	inGets, inGetNexts, inSets, inTotalReqVars, inTotalSetVars, badCommunityUses,
+	outGetResponses, outNoSuchNames, outTraps atomic.Uint32
 }
 
 // Agent is one simulated device answering on one socket.
@@ -102,8 +111,13 @@ type Agent struct {
 	users       map[string]*user
 	engineID    []byte
 	boots       uint32
-	tree        *tree
-	maxSize     int
+	// tree is what the agent answers. A SET replaces it whole (set.go), so a
+	// notification reading it from another goroutine never sees one half-made.
+	tree    atomic.Pointer[tree]
+	maxSize int
+	// writeCommunity writes in v1 and v2c; empty, nothing is written there.
+	writeCommunity []byte
+	rowStatus      func(string) (string, bool)
 	// notify sends the agent's notifications; nil when it has nowhere to.
 	notify *notifier
 
@@ -150,6 +164,16 @@ func NewAgent(cfg Config) (*Agent, error) {
 		}
 		a.community = []byte(cfg.Community)
 	}
+	if cfg.WriteCommunity != "" {
+		if !a.v1 && !a.v2c {
+			return nil, errors.New("simulator: a write community is for v1 and v2c")
+		}
+		if len(cfg.WriteCommunity) > maxCommunity || cfg.WriteCommunity == cfg.Community {
+			return nil, fmt.Errorf("simulator: a write community is 1 to %d octets, and not the read community", maxCommunity)
+		}
+		a.writeCommunity = []byte(cfg.WriteCommunity)
+	}
+	a.rowStatus = cfg.RowStatus
 	if a.v3 {
 		if len(cfg.EngineID) < 5 || len(cfg.EngineID) > 32 {
 			return nil, errors.New("simulator: an engine ID is 5 to 32 octets (RFC 3411)")
@@ -168,9 +192,11 @@ func NewAgent(cfg Config) (*Agent, error) {
 	// What only the agent knows — its own counters, and for v3 its engine —
 	// beside what the device answers.
 	objects := slices.Concat(cfg.Objects, agentObjects(a.v3, a.engineID, a.boots, cfg.Traps.OnAuthFailure))
-	if a.tree, err = newTree(objects); err != nil {
+	t, err := newTree(objects)
+	if err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
+	a.tree.Store(t)
 	if a.notify, err = newNotifier(a, cfg); err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
@@ -356,8 +382,11 @@ func (a *Agent) answerCommunity(ver gosnmp.SnmpVersion, msg []byte, c clock) []b
 		a.stats.parseErrors.Add(1)
 		return nil
 	}
-	// In constant time: the community is the only secret v1 and v2c have.
-	if subtle.ConstantTimeCompare([]byte(req.Community), a.community) != 1 {
+	// In constant time: the communities are the only secrets v1 and v2c have.
+	// The write community reads as well; the read community only reads.
+	read := subtle.ConstantTimeCompare([]byte(req.Community), a.community) == 1
+	write := len(a.writeCommunity) > 0 && subtle.ConstantTimeCompare([]byte(req.Community), a.writeCommunity) == 1
+	if !read && !write {
 		a.stats.badCommunities.Add(1)
 		a.authFailed()
 		return nil
@@ -374,7 +403,7 @@ func (a *Agent) answerCommunity(ver gosnmp.SnmpVersion, msg []byte, c clock) []b
 		a.stats.unknownPDUHandlers.Add(1)
 		return nil
 	}
-	out, err := fit(a.process(ver, req, c), bulkFloor(req), tooBig(ver, req), a.maxSize,
+	out, err := fit(a.process(ver, req, c, write), bulkFloor(req), tooBig(ver, req), a.maxSize,
 		func(ans answer) ([]byte, error) {
 			resp := &gosnmp.SnmpPacket{
 				Version:    ver,

--- a/pkg/simulator/agent.go
+++ b/pkg/simulator/agent.go
@@ -50,6 +50,8 @@ type Config struct {
 	Notifications []Notification
 	// Traps is where the agent sends them, and when.
 	Traps Traps
+	// Faults are what the agent is made to do wrong; see Faults.
+	Faults Faults
 }
 
 // Stats counts what an agent did with what it received — most of all what it
@@ -113,6 +115,11 @@ type Agent struct {
 	started time.Time
 
 	stats counters
+
+	// faults is what the agent is made to do wrong (faults.go), read on every
+	// message; faultMu serialises changing it, which moves the counters' warp.
+	faults  atomic.Pointer[faultState]
+	faultMu sync.Mutex
 }
 
 // NewAgent checks cfg and prepares an agent; Start makes it answer.
@@ -167,6 +174,10 @@ func NewAgent(cfg Config) (*Agent, error) {
 	if a.notify, err = newNotifier(a, cfg); err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
+	if err := cfg.Faults.Check(); err != nil {
+		return nil, fmt.Errorf("simulator: faults: %w", err)
+	}
+	a.faults.Store(&faultState{faults: cfg.Faults})
 	return a, nil
 }
 
@@ -200,6 +211,12 @@ func (a *Agent) Start() error {
 	a.conn = conn
 	a.done = make(chan struct{})
 	a.started = time.Now()
+	// Counters made to run fast run so from the start.
+	if fs := a.faults.Load(); fs != nil {
+		a.faultMu.Lock()
+		a.setFaultsLocked(fs.faults, a.started, a.started)
+		a.faultMu.Unlock()
+	}
 	go a.serve(conn, a.started, a.done)
 	if a.notify != nil {
 		a.notify.start()
@@ -279,7 +296,23 @@ func (a *Agent) serve(conn *net.UDPConn, started time.Time, done chan struct{}) 
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}
-		if out := a.handle(buf[:n], clock{started: started, now: time.Now(), stats: &a.stats}); out != nil {
+		fs := a.faults.Load()
+		if fs != nil && fs.faults.drops(roll()) {
+			// Lost on the way: the agent never sees it, and counts nothing.
+			continue
+		}
+		c := clock{started: started, now: time.Now(), stats: &a.stats}
+		if fs != nil {
+			c.warp = fs.warp
+		}
+		out := a.handle(buf[:n], c)
+		switch {
+		case out == nil:
+		case fs != nil && (fs.faults.LatencyMs > 0 || fs.faults.JitterMs > 0):
+			// Late, and without holding up the messages after it: a slow
+			// device, not a stuck one.
+			time.AfterFunc(fs.faults.delay(draw()), func() { _, _ = conn.WriteToUDPAddrPort(out, from) })
+		default:
 			_, _ = conn.WriteToUDPAddrPort(out, from)
 		}
 	}

--- a/pkg/simulator/agent_test.go
+++ b/pkg/simulator/agent_test.go
@@ -120,11 +120,12 @@ func TestSNMPv1(t *testing.T) {
 	}
 }
 
+// A device given no write community is written by nobody.
 func TestASetIsRefused(t *testing.T) {
 	a := startAgent(t, Config{Versions: []string{"v1", "v2c"}, Community: "public"})
 	for ver, want := range map[gosnmp.SnmpVersion]gosnmp.SNMPError{
-		gosnmp.Version2c: gosnmp.NotWritable,
-		gosnmp.Version1:  gosnmp.NoSuchName, // v1 has no notWritable (RFC 3584)
+		gosnmp.Version2c: gosnmp.NoAccess,
+		gosnmp.Version1:  gosnmp.NoSuchName, // v1 has no noAccess (RFC 3584)
 	} {
 		g := connect(t, manager(a, ver, "public"))
 		res, err := g.Set([]gosnmp.SnmpPDU{{Name: ".1.3.6.1.2.1.1.5.0", Type: gosnmp.OctetString, Value: "renamed"}})

--- a/pkg/simulator/agentobjects.go
+++ b/pkg/simulator/agentobjects.go
@@ -30,14 +30,14 @@ func agentObjects(v3 bool, engineID []byte, boots uint32, authenTraps bool) []Ob
 	count(snmp+"2.0", func(c *counters) uint32 { return c.outGetResponses.Load() + c.outTraps.Load() })
 	count(snmp+"3.0", load(func(c *counters) *atomic.Uint32 { return &c.badVersions }))
 	count(snmp+"4.0", load(func(c *counters) *atomic.Uint32 { return &c.badCommunities }))
-	count(snmp+"5.0", nothing) // a community used for what it may not do: nothing is writable
+	count(snmp+"5.0", load(func(c *counters) *atomic.Uint32 { return &c.badCommunityUses }))
 	count(snmp+"6.0", load(func(c *counters) *atomic.Uint32 { return &c.parseErrors }))
 	// What arrived in a response, which an agent receives none of.
 	for _, n := range []int{8, 9, 10, 11, 12} {
 		count(fmt.Sprintf(snmp+"%d.0", n), nothing)
 	}
 	count(snmp+"13.0", load(func(c *counters) *atomic.Uint32 { return &c.inTotalReqVars }))
-	count(snmp+"14.0", nothing) // no SET has succeeded
+	count(snmp+"14.0", load(func(c *counters) *atomic.Uint32 { return &c.inTotalSetVars }))
 	count(snmp+"15.0", load(func(c *counters) *atomic.Uint32 { return &c.inGets }))
 	count(snmp+"16.0", load(func(c *counters) *atomic.Uint32 { return &c.inGetNexts }))
 	count(snmp+"17.0", load(func(c *counters) *atomic.Uint32 { return &c.inSets }))

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -31,7 +31,10 @@ type Device struct {
 	Port      int      `json:"port"`
 	Versions  []string `json:"versions"`
 	Community string   `json:"community"`
-	Users     []User   `json:"users"`
+	// WriteCommunity writes in v1 and v2c, and reads as well; empty, the
+	// device is read-only there. A secret, as the community is.
+	WriteCommunity string `json:"writeCommunity"`
+	Users          []User `json:"users"`
 	// EngineID is hex, given once when the device is created (NewEngineID)
 	// and never changed: managers cache it and localise their keys to it.
 	EngineID string `json:"engineId"`
@@ -93,6 +96,16 @@ func (d Device) Validate() error {
 	if (v1 || v2c) && (d.Community == "" || len(d.Community) > maxCommunity) {
 		return fmt.Errorf("v1 and v2c need a community of 1 to %d octets", maxCommunity)
 	}
+	if d.WriteCommunity != "" {
+		switch {
+		case !v1 && !v2c:
+			return errors.New("a write community is for v1 and v2c")
+		case len(d.WriteCommunity) > maxCommunity:
+			return fmt.Errorf("a write community is 1 to %d octets", maxCommunity)
+		case d.WriteCommunity == d.Community:
+			return errors.New("the write community is the read community: every manager reading would write")
+		}
+	}
 	if v3 {
 		if len(d.Users) == 0 {
 			return errors.New("v3 needs a user")
@@ -136,9 +149,10 @@ func (d Device) Validate() error {
 // user's passphrases by user name, and each destination's community by
 // destination ID.
 type DeviceSecrets struct {
-	Community    string                 `json:"community"`
-	Users        map[string]UserSecrets `json:"users"`
-	Destinations map[string]string      `json:"destinations"`
+	Community      string                 `json:"community"`
+	WriteCommunity string                 `json:"writeCommunity"`
+	Users          map[string]UserSecrets `json:"users"`
+	Destinations   map[string]string      `json:"destinations"`
 }
 
 // UserSecrets are one user's passphrases.
@@ -150,9 +164,10 @@ type UserSecrets struct {
 // Secrets is d's secrets and nothing else.
 func (d Device) Secrets() DeviceSecrets {
 	s := DeviceSecrets{
-		Community:    d.Community,
-		Users:        make(map[string]UserSecrets, len(d.Users)),
-		Destinations: make(map[string]string, len(d.Traps.Destinations)),
+		Community:      d.Community,
+		WriteCommunity: d.WriteCommunity,
+		Users:          make(map[string]UserSecrets, len(d.Users)),
+		Destinations:   make(map[string]string, len(d.Traps.Destinations)),
 	}
 	for _, u := range d.Users {
 		s.Users[u.Name] = UserSecrets{AuthPass: u.AuthPass, PrivPass: u.PrivPass}
@@ -165,7 +180,7 @@ func (d Device) Secrets() DeviceSecrets {
 
 // WithoutSecrets is d with its secrets blanked, sharing nothing with d.
 func (d Device) WithoutSecrets() Device {
-	d.Community = ""
+	d.Community, d.WriteCommunity = "", ""
 	d.Versions = slices.Clone(d.Versions)
 	d.Users = slices.Clone(d.Users)
 	for i := range d.Users {
@@ -180,7 +195,7 @@ func (d Device) WithoutSecrets() Device {
 
 // WithSecrets is d with s filled back in.
 func (d Device) WithSecrets(s DeviceSecrets) Device {
-	d.Community = s.Community
+	d.Community, d.WriteCommunity = s.Community, s.WriteCommunity
 	d.Versions = slices.Clone(d.Versions)
 	d.Users = slices.Clone(d.Users)
 	for i := range d.Users {
@@ -238,12 +253,13 @@ func (d Device) config() (Config, error) {
 		return Config{}, fmt.Errorf("engine ID: %w", err)
 	}
 	return Config{
-		Listen:      d.Listen(),
-		Versions:    d.Versions,
-		Community:   d.Community,
-		Users:       d.Users,
-		EngineID:    engineID,
-		EngineBoots: d.EngineBoots,
+		Listen:         d.Listen(),
+		Versions:       d.Versions,
+		Community:      d.Community,
+		WriteCommunity: d.WriteCommunity,
+		Users:          d.Users,
+		EngineID:       engineID,
+		EngineBoots:    d.EngineBoots,
 		Objects: m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID),
 			Location: strings.TrimSpace(d.Location), Contact: strings.TrimSpace(d.Contact)}),
 		Notifications: m.catalogue(),

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -40,6 +40,15 @@ type Device struct {
 	EngineBoots uint32 `json:"engineBoots"`
 	// Traps is what the device sends, where to and when.
 	Traps Traps `json:"traps"`
+	// Location and Contact are the device's sysLocation and sysContact, in
+	// place of its model's when they are given.
+	Location string `json:"location"`
+	Contact  string `json:"contact"`
+	// AutoStart starts the device with the application.
+	AutoStart bool `json:"autoStart"`
+	// Faults are what the device is made to do wrong: changed while it runs
+	// (Fleet.SetFaults), and kept with it.
+	Faults Faults `json:"faults"`
 }
 
 // Listen is the address the device answers on, in the form CheckListen reads.
@@ -107,6 +116,12 @@ func (d Device) Validate() error {
 	}
 	if err := d.Traps.check(users, m.catalogue()); err != nil {
 		return err
+	}
+	if len(d.Location) > 255 || len(d.Contact) > 255 {
+		return errors.New("a device's location and contact are at most 255 octets")
+	}
+	if err := d.Faults.Check(); err != nil {
+		return fmt.Errorf("faults: %w", err)
 	}
 	if id, err := hex.DecodeString(d.EngineID); err != nil || len(id) < 5 || len(id) > 32 {
 		return errors.New("a device's engine ID is 5 to 32 octets, in hex")
@@ -223,14 +238,16 @@ func (d Device) config() (Config, error) {
 		return Config{}, fmt.Errorf("engine ID: %w", err)
 	}
 	return Config{
-		Listen:        d.Listen(),
-		Versions:      d.Versions,
-		Community:     d.Community,
-		Users:         d.Users,
-		EngineID:      engineID,
-		EngineBoots:   d.EngineBoots,
-		Objects:       m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID)}),
+		Listen:      d.Listen(),
+		Versions:    d.Versions,
+		Community:   d.Community,
+		Users:       d.Users,
+		EngineID:    engineID,
+		EngineBoots: d.EngineBoots,
+		Objects: m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID),
+			Location: strings.TrimSpace(d.Location), Contact: strings.TrimSpace(d.Contact)}),
 		Notifications: m.catalogue(),
 		Traps:         d.Traps.clone(),
+		Faults:        d.Faults,
 	}, nil
 }

--- a/pkg/simulator/devicefile.go
+++ b/pkg/simulator/devicefile.go
@@ -1,0 +1,151 @@
+package simulator
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// A file of simulated devices is how a bench moves from one machine to another,
+// or is passed on: one device or several, with or without their secrets — and
+// saying which. It is read as a model file is, because somebody else may have
+// written it: what it says it is first, then all of it and strictly. Each device
+// in it is then checked as one typed in is (Device.Validate), the loopback rule
+// included, by whoever gives it an ID and an engine.
+
+const (
+	// DeviceFileKind is what a file of simulated devices says it is.
+	DeviceFileKind = "snmplens-simulated-devices"
+	// DeviceFileFormat is the format version this package reads.
+	DeviceFileFormat = 1
+	// MaxDeviceFileBytes and MaxFileDevices bound a file: a bench is a few
+	// dozen devices at most.
+	MaxDeviceFileBytes = 1 << 20
+	MaxFileDevices     = 64
+)
+
+// What a file of devices says of their secrets.
+const (
+	SecretsIncluded = "included"
+	SecretsOmitted  = "omitted"
+)
+
+// DeviceFile is simulated devices as a file holds them.
+type DeviceFile struct {
+	Kind          string `json:"kind"`
+	FormatVersion int    `json:"formatVersion"`
+	// Secrets says whether the communities and passphrases are in the file
+	// (SecretsIncluded) or were left out (SecretsOmitted), so that nobody passes
+	// a file on believing it holds none when it does.
+	Secrets string       `json:"secrets"`
+	Devices []FileDevice `json:"devices"`
+}
+
+// FileDevice is a device as a file holds it: what makes it the device it is,
+// and nothing of what makes it this machine's — its ID, its engine and its
+// boots, which a device imported is given anew. Two imports of one file are
+// two devices, with two engines no manager confuses.
+type FileDevice struct {
+	Name      string   `json:"name"`
+	Model     string   `json:"model"`
+	Address   string   `json:"address"`
+	Port      int      `json:"port"`
+	Versions  []string `json:"versions"`
+	Community string   `json:"community,omitempty"`
+	Users     []User   `json:"users,omitempty"`
+	Traps     Traps    `json:"traps"`
+}
+
+// ExportDevices is the file holding devices, their secrets in it or not.
+func ExportDevices(devices []Device, withSecrets bool) ([]byte, error) {
+	f := DeviceFile{Kind: DeviceFileKind, FormatVersion: DeviceFileFormat, Secrets: SecretsOmitted,
+		Devices: make([]FileDevice, len(devices))}
+	if withSecrets {
+		f.Secrets = SecretsIncluded
+	}
+	for i, d := range devices {
+		if !withSecrets {
+			d = d.WithoutSecrets()
+		}
+		traps := d.Traps.clone()
+		if traps.Destinations == nil {
+			traps.Destinations = []Destination{}
+		}
+		if traps.Schedules == nil {
+			traps.Schedules = []Schedule{}
+		}
+		f.Devices[i] = FileDevice{Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
+			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps}
+	}
+	raw, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(raw, '\n'), nil
+}
+
+// ParseDeviceFile reads a file of simulated devices: what it says it is, then
+// all of it, refusing a field the format does not define.
+func ParseDeviceFile(raw []byte) (DeviceFile, error) {
+	if len(raw) > MaxDeviceFileBytes {
+		return DeviceFile{}, fmt.Errorf("a file of devices is at most %d KB", MaxDeviceFileBytes>>10)
+	}
+	raw = bytes.TrimPrefix(raw, bom)
+	var head struct {
+		Kind          string `json:"kind"`
+		FormatVersion int    `json:"formatVersion"`
+	}
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&head); err != nil {
+		return DeviceFile{}, jsonProblem(raw, err)
+	}
+	if head.Kind != DeviceFileKind {
+		return DeviceFile{}, fmt.Errorf("this is not a file of simulated devices: its \"kind\" is %q, and one's is %q",
+			head.Kind, DeviceFileKind)
+	}
+	if head.FormatVersion != DeviceFileFormat {
+		return DeviceFile{}, fmt.Errorf("format version %d: this version of SnmpLens reads version %d",
+			head.FormatVersion, DeviceFileFormat)
+	}
+	var f DeviceFile
+	if err := decodeStrict(raw, &f); err != nil {
+		return DeviceFile{}, err
+	}
+	if f.Secrets != SecretsIncluded && f.Secrets != SecretsOmitted {
+		return DeviceFile{}, fmt.Errorf("\"secrets\" says whether the passwords are in the file: %q or %q",
+			SecretsIncluded, SecretsOmitted)
+	}
+	switch {
+	case len(f.Devices) == 0:
+		return DeviceFile{}, errors.New("the file holds no device")
+	case len(f.Devices) > MaxFileDevices:
+		return DeviceFile{}, fmt.Errorf("the file holds %d devices, and one is read with at most %d", len(f.Devices), MaxFileDevices)
+	}
+	return f, nil
+}
+
+// Device is the device fd describes, yet to be given an ID and an engine.
+func (fd FileDevice) Device() Device {
+	return Device{Name: strings.TrimSpace(fd.Name), Model: fd.Model, Address: strings.TrimSpace(fd.Address),
+		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community,
+		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone()}
+}
+
+// ValidateWithoutSecrets is Validate for a device whose secrets are yet to be
+// given: everything else about it is checked, and a secret it lacks is not an
+// error. A device imported from a file that left its secrets out is checked so,
+// and kept; it starts once it is given them.
+func (d Device) ValidateWithoutSecrets() error {
+	const standIn = "stand-in-secret"
+	c := d.WithoutSecrets()
+	c.Community = standIn
+	for i := range c.Users {
+		c.Users[i].AuthPass, c.Users[i].PrivPass = standIn, standIn
+	}
+	for i := range c.Traps.Destinations {
+		c.Traps.Destinations[i].Community = standIn
+	}
+	return c.Validate()
+}

--- a/pkg/simulator/devicefile.go
+++ b/pkg/simulator/devicefile.go
@@ -57,6 +57,8 @@ type FileDevice struct {
 	Community string   `json:"community,omitempty"`
 	Users     []User   `json:"users,omitempty"`
 	Traps     Traps    `json:"traps"`
+	Location  string   `json:"location,omitempty"`
+	Contact   string   `json:"contact,omitempty"`
 }
 
 // ExportDevices is the file holding devices, their secrets in it or not.
@@ -78,7 +80,8 @@ func ExportDevices(devices []Device, withSecrets bool) ([]byte, error) {
 			traps.Schedules = []Schedule{}
 		}
 		f.Devices[i] = FileDevice{Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
-			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps}
+			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps,
+			Location: d.Location, Contact: d.Contact}
 	}
 	raw, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
@@ -130,7 +133,8 @@ func ParseDeviceFile(raw []byte) (DeviceFile, error) {
 func (fd FileDevice) Device() Device {
 	return Device{Name: strings.TrimSpace(fd.Name), Model: fd.Model, Address: strings.TrimSpace(fd.Address),
 		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community,
-		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone()}
+		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone(),
+		Location: strings.TrimSpace(fd.Location), Contact: strings.TrimSpace(fd.Contact)}
 }
 
 // ValidateWithoutSecrets is Validate for a device whose secrets are yet to be

--- a/pkg/simulator/devicefile.go
+++ b/pkg/simulator/devicefile.go
@@ -49,16 +49,17 @@ type DeviceFile struct {
 // boots, which a device imported is given anew. Two imports of one file are
 // two devices, with two engines no manager confuses.
 type FileDevice struct {
-	Name      string   `json:"name"`
-	Model     string   `json:"model"`
-	Address   string   `json:"address"`
-	Port      int      `json:"port"`
-	Versions  []string `json:"versions"`
-	Community string   `json:"community,omitempty"`
-	Users     []User   `json:"users,omitempty"`
-	Traps     Traps    `json:"traps"`
-	Location  string   `json:"location,omitempty"`
-	Contact   string   `json:"contact,omitempty"`
+	Name           string   `json:"name"`
+	Model          string   `json:"model"`
+	Address        string   `json:"address"`
+	Port           int      `json:"port"`
+	Versions       []string `json:"versions"`
+	Community      string   `json:"community,omitempty"`
+	WriteCommunity string   `json:"writeCommunity,omitempty"`
+	Users          []User   `json:"users,omitempty"`
+	Traps          Traps    `json:"traps"`
+	Location       string   `json:"location,omitempty"`
+	Contact        string   `json:"contact,omitempty"`
 }
 
 // ExportDevices is the file holding devices, their secrets in it or not.
@@ -80,7 +81,8 @@ func ExportDevices(devices []Device, withSecrets bool) ([]byte, error) {
 			traps.Schedules = []Schedule{}
 		}
 		f.Devices[i] = FileDevice{Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
-			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps,
+			Versions: slices.Clone(d.Versions), Community: d.Community, WriteCommunity: d.WriteCommunity,
+			Users: slices.Clone(d.Users), Traps: traps,
 			Location: d.Location, Contact: d.Contact}
 	}
 	raw, err := json.MarshalIndent(f, "", "  ")
@@ -132,7 +134,7 @@ func ParseDeviceFile(raw []byte) (DeviceFile, error) {
 // Device is the device fd describes, yet to be given an ID and an engine.
 func (fd FileDevice) Device() Device {
 	return Device{Name: strings.TrimSpace(fd.Name), Model: fd.Model, Address: strings.TrimSpace(fd.Address),
-		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community,
+		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community, WriteCommunity: fd.WriteCommunity,
 		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone(),
 		Location: strings.TrimSpace(fd.Location), Contact: strings.TrimSpace(fd.Contact)}
 }

--- a/pkg/simulator/devicefile_test.go
+++ b/pkg/simulator/devicefile_test.go
@@ -1,0 +1,69 @@
+package simulator
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// A bench written to a file reads back as the same devices, without the ID, the
+// engine and the boots that are this machine's; its secrets are in it when they
+// were asked for and absent otherwise, and the file says which.
+func TestADeviceFileRoundTrips(t *testing.T) {
+	d := Device{ID: "0123456789abcdef", Name: "core-01", Model: "linux-server", Address: "127.0.0.2", Port: 1161,
+		Versions: []string{"v2c", "v3"}, Community: "s3cret-community",
+		Users: []User{{Name: "ops", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "auth-pass-1",
+			PrivProto: "AES", PrivPass: "priv-pass-1"}},
+		EngineID: "8000000903001122334455", EngineBoots: 7,
+		Traps: Traps{Destinations: []Destination{{ID: "d1", Host: "192.0.2.50", Port: 162, Version: "v2c",
+			Community: "trap-s3cret"}}, OnStart: true, Schedules: []Schedule{}}}
+	for _, with := range []bool{true, false} {
+		raw, err := ExportDevices([]Device{d}, with)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, secret := range []string{"s3cret-community", "auth-pass-1", "priv-pass-1", "trap-s3cret"} {
+			if bytes.Contains(raw, []byte(secret)) != with {
+				t.Errorf("with secrets %v, the file holding %q is %v", with, secret, !with)
+			}
+		}
+		for _, mine := range []string{d.ID, d.EngineID, `"engineBoots"`} {
+			if bytes.Contains(raw, []byte(mine)) {
+				t.Errorf("the file holds %s, which is this machine's", mine)
+			}
+		}
+		f, err := ParseDeviceFile(raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := map[bool]string{true: SecretsIncluded, false: SecretsOmitted}[with]; f.Secrets != want {
+			t.Errorf("the file says its secrets are %q, want %q", f.Secrets, want)
+		}
+		want := d
+		want.ID, want.EngineID, want.EngineBoots = "", "", 0
+		if !with {
+			want = want.WithoutSecrets()
+		}
+		if got := f.Devices[0].Device(); !reflect.DeepEqual(got, want) {
+			t.Errorf("read back as\n%+v\nwant\n%+v", got, want)
+		}
+	}
+}
+
+// A device whose secrets are yet to be given is refused by Validate and passes
+// ValidateWithoutSecrets, which still holds it to everything else.
+func TestADeviceIsCheckedWithoutItsSecrets(t *testing.T) {
+	d := Device{Name: "x", Model: "linux-server", Address: "127.0.0.2", Port: 1161, Versions: []string{"v2c", "v3"},
+		Users:    []User{{Name: "ops", SecLevel: "AuthPriv", AuthProto: "SHA256", PrivProto: "AES"}},
+		EngineID: "8000000903aabbccddeeff"}
+	if d.Validate() == nil {
+		t.Error("a device with neither community nor passphrases was valid")
+	}
+	if err := d.ValidateWithoutSecrets(); err != nil {
+		t.Errorf("without its secrets: %v", err)
+	}
+	d.Address = "192.0.2.1"
+	if d.ValidateWithoutSecrets() == nil {
+		t.Error("the loopback rule was not held")
+	}
+}

--- a/pkg/simulator/devicefile_test.go
+++ b/pkg/simulator/devicefile_test.go
@@ -11,9 +11,9 @@ import (
 // were asked for and absent otherwise, and the file says which.
 func TestADeviceFileRoundTrips(t *testing.T) {
 	d := Device{ID: "0123456789abcdef", Name: "core-01", Model: "linux-server", Address: "127.0.0.2", Port: 1161,
-		Versions: []string{"v2c", "v3"}, Community: "s3cret-community",
+		Versions: []string{"v2c", "v3"}, Community: "s3cret-community", WriteCommunity: "wr1te-community",
 		Users: []User{{Name: "ops", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "auth-pass-1",
-			PrivProto: "AES", PrivPass: "priv-pass-1"}},
+			PrivProto: "AES", PrivPass: "priv-pass-1", Write: true}},
 		EngineID: "8000000903001122334455", EngineBoots: 7,
 		Traps: Traps{Destinations: []Destination{{ID: "d1", Host: "192.0.2.50", Port: 162, Version: "v2c",
 			Community: "trap-s3cret"}}, OnStart: true, Schedules: []Schedule{}}}
@@ -22,7 +22,7 @@ func TestADeviceFileRoundTrips(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, secret := range []string{"s3cret-community", "auth-pass-1", "priv-pass-1", "trap-s3cret"} {
+		for _, secret := range []string{"s3cret-community", "wr1te-community", "auth-pass-1", "priv-pass-1", "trap-s3cret"} {
 			if bytes.Contains(raw, []byte(secret)) != with {
 				t.Errorf("with secrets %v, the file holding %q is %v", with, secret, !with)
 			}

--- a/pkg/simulator/faults.go
+++ b/pkg/simulator/faults.go
@@ -1,0 +1,164 @@
+package simulator
+
+import (
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"slices"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// Faults are what a simulated device is made to do wrong, so that SnmpLens can
+// be tested against it: a reachability alert against a device that stops
+// answering, the overload guardrail against one that answers slowly, the rate
+// derived across a counter's wrap against one whose counters run fast. They are
+// changed while the device runs (Agent.SetFaults) — restarting it would throw
+// away the uptime and the counters a test is watching — and kept with it.
+type Faults struct {
+	// LatencyMs delays every answer, and JitterMs adds up to as much again at
+	// random.
+	LatencyMs int `json:"latencyMs"`
+	JitterMs  int `json:"jitterMs"`
+	// LossPercent of the requests are lost before the agent sees them, as a
+	// lossy link loses them.
+	LossPercent int `json:"lossPercent"`
+	// Mute answers nothing: a device that has stopped answering. What it sends
+	// — its notifications — it still sends.
+	Mute bool `json:"mute"`
+	// Error answers ErrorPercent of the requests with that error instead of
+	// their answer: FaultTooBig or FaultGenErr.
+	Error        string `json:"error"`
+	ErrorPercent int    `json:"errorPercent"`
+	// CounterSpeed runs the counters that many times faster — 1 (or 0), 10, 100
+	// or 1000 — so that a Counter32 wraps in minutes rather than in days.
+	CounterSpeed int `json:"counterSpeed"`
+}
+
+// MaxLatencyMs bounds a latency and its jitter: past it, a manager has long
+// since given up.
+const MaxLatencyMs = 10000
+
+// The errors a device can be made to answer with.
+const (
+	FaultTooBig = "tooBig"
+	FaultGenErr = "genErr"
+)
+
+// counterSpeeds are the speeds a device's counters can run at; 0 is 1.
+var counterSpeeds = []int{0, 1, 10, 100, 1000}
+
+// Check reports the first thing wrong with f.
+func (f Faults) Check() error {
+	switch {
+	case f.LatencyMs < 0 || f.LatencyMs > MaxLatencyMs || f.JitterMs < 0 || f.JitterMs > MaxLatencyMs:
+		return fmt.Errorf("a latency and its jitter are 0 to %d ms", MaxLatencyMs)
+	case f.LossPercent < 0 || f.LossPercent > 100:
+		return errors.New("a loss is 0 to 100 %")
+	case f.Error != "" && f.Error != FaultTooBig && f.Error != FaultGenErr:
+		return fmt.Errorf("%q is not an error a device can be made to answer with: %s or %s", f.Error, FaultTooBig, FaultGenErr)
+	case f.Error != "" && (f.ErrorPercent < 1 || f.ErrorPercent > 100):
+		return errors.New("an error answers 1 to 100 % of the requests")
+	case f.Error == "" && f.ErrorPercent != 0:
+		return errors.New("a share of errors needs an error")
+	case !slices.Contains(counterSpeeds, f.CounterSpeed):
+		return fmt.Errorf("counters run at 1, 10, 100 or 1000 times their speed, not %d", f.CounterSpeed)
+	}
+	return nil
+}
+
+// speed is how many times faster the counters run.
+func (f Faults) speed() float64 { return float64(max(f.CounterSpeed, 1)) }
+
+// drops reports whether a request is lost, roll being drawn from [0, 100).
+func (f Faults) drops(roll int) bool { return f.Mute || roll < f.LossPercent }
+
+// errs reports whether a request is answered with the error, roll being drawn
+// from [0, 100).
+func (f Faults) errs(roll int) bool { return f.Error != "" && roll < f.ErrorPercent }
+
+// delay is how long an answer waits, share being drawn from [0, 1).
+func (f Faults) delay(share float64) time.Duration {
+	return time.Duration((float64(f.LatencyMs) + share*float64(f.JitterMs)) * float64(time.Millisecond))
+}
+
+// roll and draw are the chances a fault is decided by. Not a secret, so
+// math/rand's.
+func roll() int     { return rand.IntN(100) }
+func draw() float64 { return rand.Float64() }
+
+// warp is how far the counters had run, in the seconds they count, when their
+// speed last changed: they run on from there at the new speed. So a counter
+// made to run faster turns faster and never jumps, and one slowed down again
+// never goes back — a counter that went back would read as a wrap.
+type warp struct {
+	at    time.Time
+	base  float64 // the counters' seconds at `at`
+	speed float64
+}
+
+// counterSeconds is how far the counters have run at c: the time since the
+// agent started, or where its warp has taken them.
+func counterSeconds(c clock) float64 {
+	if c.warp == nil {
+		return elapsed(c)
+	}
+	return c.warp.base + c.now.Sub(c.warp.at).Seconds()*c.warp.speed
+}
+
+// faultState is the faults an agent runs with, and where its counters are.
+type faultState struct {
+	faults Faults
+	warp   *warp
+}
+
+// SetFaults changes what a running agent does wrong, from its next message on,
+// without restarting it.
+func (a *Agent) SetFaults(f Faults) error {
+	if err := f.Check(); err != nil {
+		return err
+	}
+	a.mu.Lock()
+	started := a.started
+	a.mu.Unlock()
+	a.faultMu.Lock()
+	defer a.faultMu.Unlock()
+	if started.IsZero() {
+		// Start runs the counters from where the faults say.
+		a.faults.Store(&faultState{faults: f})
+		return nil
+	}
+	a.setFaultsLocked(f, time.Now(), started)
+	return nil
+}
+
+// setFaultsLocked keeps f, and moves the counters' warp on when their speed
+// changes, so that they run on from where they are at now. faultMu is held.
+func (a *Agent) setFaultsLocked(f Faults, now, started time.Time) {
+	next := &faultState{faults: f}
+	if prev := a.faults.Load(); prev != nil {
+		next.warp = prev.warp
+	}
+	switch speed := f.speed(); {
+	case next.warp == nil && speed == 1:
+	case next.warp == nil:
+		next.warp = &warp{at: now, base: now.Sub(started).Seconds(), speed: speed}
+	case next.warp.speed != speed:
+		next.warp = &warp{at: now, base: counterSeconds(clock{started: started, now: now, warp: next.warp}), speed: speed}
+	}
+	a.faults.Store(next)
+}
+
+// injectedError is the error the agent's faults answer a request with instead
+// of its answer, if they answer this one with one.
+func (a *Agent) injectedError(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket) (answer, bool) {
+	fs := a.faults.Load()
+	if fs == nil || !fs.faults.errs(roll()) {
+		return answer{}, false
+	}
+	if fs.faults.Error == FaultTooBig {
+		return tooBig(ver, req), true
+	}
+	return answer{vars: req.Variables, status: gosnmp.GenErr, index: errIndex(0, len(req.Variables))}, true
+}

--- a/pkg/simulator/faults_test.go
+++ b/pkg/simulator/faults_test.go
@@ -1,0 +1,124 @@
+package simulator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A fault is checked before it is applied: a share without its error, a speed
+// the counters cannot run at or a latency past any timeout is refused.
+func TestAFaultIsChecked(t *testing.T) {
+	for _, ok := range []Faults{{}, {LatencyMs: 500, JitterMs: 100}, {LossPercent: 100}, {Mute: true},
+		{Error: FaultGenErr, ErrorPercent: 30}, {Error: FaultTooBig, ErrorPercent: 100}, {CounterSpeed: 1000}} {
+		if err := ok.Check(); err != nil {
+			t.Errorf("%+v: %v", ok, err)
+		}
+	}
+	for _, bad := range []Faults{{LatencyMs: -1}, {LatencyMs: MaxLatencyMs + 1}, {JitterMs: MaxLatencyMs + 1},
+		{LossPercent: 101}, {Error: "noSuchName", ErrorPercent: 10}, {Error: FaultGenErr}, {ErrorPercent: 10},
+		{CounterSpeed: 7}} {
+		if bad.Check() == nil {
+			t.Errorf("%+v was accepted", bad)
+		}
+	}
+}
+
+// Whether a request is lost, or answered with an error, is a share of the
+// rolls; a mute device loses them all.
+func TestAFaultIsAShareOfTheRequests(t *testing.T) {
+	loss := Faults{LossPercent: 30}
+	errs := Faults{Error: FaultGenErr, ErrorPercent: 30}
+	for roll := 0; roll < 100; roll++ {
+		if loss.drops(roll) != (roll < 30) || errs.errs(roll) != (roll < 30) {
+			t.Fatalf("roll %d", roll)
+		}
+		if !(Faults{Mute: true}).drops(roll) || (Faults{}).drops(roll) || (Faults{}).errs(roll) {
+			t.Fatalf("roll %d: a mute device, or one doing nothing wrong", roll)
+		}
+	}
+}
+
+// Counters made to run faster turn faster from where they are, and slowed down
+// again they run on from there: never a jump and never a step back, either of
+// which would read as a wrap.
+func TestCountersChangeSpeedWithoutJumping(t *testing.T) {
+	a := &Agent{}
+	t0 := time.Now()
+	at := func(s float64) time.Time { return t0.Add(time.Duration(s * float64(time.Second))) }
+	seconds := func(s float64) float64 {
+		c := clock{started: t0, now: at(s)}
+		if fs := a.faults.Load(); fs != nil {
+			c.warp = fs.warp
+		}
+		return counterSeconds(c)
+	}
+	a.setFaultsLocked(Faults{}, t0, t0)
+	if got := seconds(10); got != 10 {
+		t.Fatalf("at 10 s the counters count %v", got)
+	}
+	a.setFaultsLocked(Faults{CounterSpeed: 100}, at(10), t0)
+	if got := seconds(10); got != 10 {
+		t.Errorf("sped up, the counters jumped to %v", got)
+	}
+	if got := seconds(11); got != 110 {
+		t.Errorf("a second at ×100 counts %v", got)
+	}
+	a.setFaultsLocked(Faults{LossPercent: 5, CounterSpeed: 100}, at(11), t0)
+	if got := seconds(12); got != 210 {
+		t.Errorf("another fault moved the counters: %v", got)
+	}
+	a.setFaultsLocked(Faults{}, at(12), t0)
+	if got := seconds(12); got != 210 {
+		t.Errorf("slowed down, the counters went to %v", got)
+	}
+	if got := seconds(13); got != 211 {
+		t.Errorf("a second at ×1 counts %v", got)
+	}
+}
+
+// A running device's faults change from its next message on: a mute device
+// answers nothing, one made to err answers with the error, a slow one late,
+// and one cleared answers again — none of it restarting it.
+func TestFaultsChangeWhileTheDeviceRuns(t *testing.T) {
+	a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public"})
+	g := manager(a, gosnmp.Version2c, "public")
+	g.Timeout = silent
+	connect(t, g)
+	set := func(f Faults) {
+		t.Helper()
+		if err := a.SetFaults(f); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	set(Faults{Mute: true})
+	if _, err := g.Get([]string{sysDescrOID}); err == nil {
+		t.Error("a mute device answered")
+	}
+	set(Faults{Error: FaultGenErr, ErrorPercent: 100})
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.GenErr {
+		t.Errorf("made to answer genErr: %v, %v", res, err)
+	}
+	set(Faults{Error: FaultTooBig, ErrorPercent: 100})
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.TooBig || len(res.Variables) != 0 {
+		t.Errorf("made to answer tooBig: %v, %v", res, err)
+	}
+	set(Faults{LatencyMs: 300})
+	g.Timeout = 3 * time.Second
+	start := time.Now()
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.NoError {
+		t.Errorf("a slow device: %v, %v", res, err)
+	}
+	if took := time.Since(start); took < 300*time.Millisecond {
+		t.Errorf("a device made to wait 300 ms answered in %v", took)
+	}
+	set(Faults{})
+	if res, err := g.Get([]string{sysDescrOID}); err != nil || res.Error != gosnmp.NoError {
+		t.Errorf("cleared: %v, %v", res, err)
+	}
+	if err := a.SetFaults(Faults{LossPercent: 101}); err == nil {
+		t.Error("a loss of 101 % was set")
+	}
+}

--- a/pkg/simulator/fleet.go
+++ b/pkg/simulator/fleet.go
@@ -16,6 +16,9 @@ var ErrRunning = errors.New("simulator: the device is already running")
 type Fleet struct {
 	mu     sync.Mutex
 	agents map[string]*Agent
+	// RowStatus is given to every device the fleet starts: see
+	// Config.RowStatus. Set before the first start.
+	RowStatus func(instance string) (column string, ok bool)
 }
 
 // NewFleet returns a fleet running nothing.
@@ -32,6 +35,7 @@ func (f *Fleet) Start(d Device) error {
 	if err != nil {
 		return err
 	}
+	cfg.RowStatus = f.RowStatus
 	// Outside the lock: localising the users' keys hashes a megabyte each.
 	a, err := NewAgent(cfg)
 	if err != nil {

--- a/pkg/simulator/fleet.go
+++ b/pkg/simulator/fleet.go
@@ -88,6 +88,18 @@ func (f *Fleet) Notify(id, name string) ([]Delivery, error) {
 	return a.Notify(name)
 }
 
+// SetFaults changes what a running device does wrong, without restarting it;
+// see Agent.SetFaults.
+func (f *Fleet) SetFaults(id string, faults Faults) error {
+	f.mu.Lock()
+	a := f.agents[id]
+	f.mu.Unlock()
+	if a == nil {
+		return ErrNotRunning
+	}
+	return a.SetFaults(faults)
+}
+
 // Status reports whether a device is running, and its counters if it is.
 func (f *Fleet) Status(id string) (Stats, bool) {
 	f.mu.Lock()

--- a/pkg/simulator/model.go
+++ b/pkg/simulator/model.go
@@ -1,6 +1,7 @@
 package simulator
 
 import (
+	"cmp"
 	"slices"
 
 	"github.com/gosnmp/gosnmp"
@@ -31,6 +32,9 @@ type Identity struct {
 	// Seed decides how the device's values move, so two devices of one model
 	// do not move in step.
 	Seed uint64
+	// Location and Contact are the device's own sysLocation and sysContact,
+	// which take the place of its model's when they are given.
+	Location, Contact string
 }
 
 type model struct {
@@ -106,13 +110,14 @@ func (o *objects) addForNotify(oid string, t gosnmp.Asn1BER, r Reading) {
 
 // addSystem adds the system group (RFC 3418) as a model's agent answers it.
 // sysServices adds up the layers the device serves: 2 a bridge, 4 a router,
-// 8 end to end, 64 applications.
+// 8 end to end, 64 applications. The contact and location a device was given
+// take the place of its model's.
 func addSystem(o *objects, id Identity, descr, sysObjectID, contact, location string, services int) {
 	o.add("1.3.6.1.2.1.1.1.0", gosnmp.OctetString, Const(descr))
 	o.add("1.3.6.1.2.1.1.2.0", gosnmp.ObjectIdentifier, Const(sysObjectID))
 	o.add("1.3.6.1.2.1.1.3.0", gosnmp.TimeTicks, Uptime())
-	o.add("1.3.6.1.2.1.1.4.0", gosnmp.OctetString, Const(contact))
+	o.add("1.3.6.1.2.1.1.4.0", gosnmp.OctetString, Const(cmp.Or(id.Contact, contact)))
 	o.add("1.3.6.1.2.1.1.5.0", gosnmp.OctetString, Const(id.Name))
-	o.add("1.3.6.1.2.1.1.6.0", gosnmp.OctetString, Const(location))
+	o.add("1.3.6.1.2.1.1.6.0", gosnmp.OctetString, Const(cmp.Or(id.Location, location)))
 	o.add("1.3.6.1.2.1.1.7.0", gosnmp.Integer, Const(services))
 }

--- a/pkg/simulator/model_test.go
+++ b/pkg/simulator/model_test.go
@@ -147,7 +147,7 @@ func TestEveryModelServesAWalk(t *testing.T) {
 			a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public", Objects: objects})
 			// Everything a request may read: the model's objects less those only a
 			// notification carries, and the agent's own.
-			readable := len(a.tree.entries)
+			readable := len(a.tree.Load().entries)
 			g := connect(t, manager(a, gosnmp.Version2c, "public"))
 			n := 0
 			// Both subtrees a device answers in: LLDP-MIB lives under

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -631,7 +631,7 @@ func (a *Agent) objectsOf(n Notification, c clock) []gosnmp.SnmpPDU {
 		if err != nil {
 			continue
 		}
-		if e := a.tree.notification(id); e != nil {
+		if e := a.tree.Load().notification(id); e != nil {
 			out = append(out, e.varbind(c))
 		}
 	}
@@ -640,7 +640,7 @@ func (a *Agent) objectsOf(n Notification, c clock) []gosnmp.SnmpPDU {
 
 func (a *Agent) sysObjectID(c clock) (string, bool) {
 	id, _ := parseOID(oidSysObjectID)
-	e := a.tree.get(id)
+	e := a.tree.Load().get(id)
 	if e == nil || e.typ != gosnmp.ObjectIdentifier {
 		return "", false
 	}

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -515,6 +515,9 @@ func (nt *notifier) pick(name string) (Notification, bool) {
 func (nt *notifier) deliver(o *outbound, n Notification) error {
 	a := nt.a
 	c := clock{started: a.started, now: time.Now(), stats: &a.stats}
+	if fs := a.faults.Load(); fs != nil {
+		c.warp = fs.warp
+	}
 	g := &gosnmp.GoSNMP{
 		Target:    o.dial,
 		Port:      uint16(o.Port),

--- a/pkg/simulator/package_test.go
+++ b/pkg/simulator/package_test.go
@@ -184,8 +184,8 @@ func TestAPackageServesAWalk(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if n != len(a.tree.entries) {
-		t.Errorf("walked %d objects of %d", n, len(a.tree.entries))
+	if all := len(a.tree.Load().entries); n != all {
+		t.Errorf("walked %d objects of %d", n, all)
 	}
 	if s := a.Stats(); s.Faults != 0 {
 		t.Errorf("%d answers failed to encode", s.Faults)

--- a/pkg/simulator/pdu.go
+++ b/pkg/simulator/pdu.go
@@ -36,7 +36,10 @@ func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock)
 	case gosnmp.SetRequest:
 		st.inSets.Add(1)
 	}
-	ans := a.dispatch(ver, req, c)
+	ans, injected := a.injectedError(ver, req)
+	if !injected {
+		ans = a.dispatch(ver, req, c)
+	}
 	if ans.status == gosnmp.NoError && req.PDUType != gosnmp.SetRequest {
 		st.inTotalReqVars.Add(uint32(len(ans.vars)))
 	}

--- a/pkg/simulator/pdu.go
+++ b/pkg/simulator/pdu.go
@@ -24,7 +24,7 @@ type answer struct {
 // for SNMPv1, whose errors are different. It counts what SNMPv2-MIB's snmp
 // group counts — the request on arrival, as net-snmp does, so that a GET of
 // snmpInGetRequests counts itself.
-func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock) answer {
+func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock, write bool) answer {
 	st := &a.stats
 	switch req.PDUType {
 	case gosnmp.GetRequest:
@@ -38,9 +38,13 @@ func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock)
 	}
 	ans, injected := a.injectedError(ver, req)
 	if !injected {
-		ans = a.dispatch(ver, req, c)
+		ans = a.dispatch(ver, req, c, write)
 	}
-	if ans.status == gosnmp.NoError && req.PDUType != gosnmp.SetRequest {
+	switch {
+	case ans.status != gosnmp.NoError:
+	case req.PDUType == gosnmp.SetRequest:
+		st.inTotalSetVars.Add(uint32(len(ans.vars)))
+	default:
 		st.inTotalReqVars.Add(uint32(len(ans.vars)))
 	}
 	if ans.status == gosnmp.NoSuchName {
@@ -50,7 +54,7 @@ func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock)
 	return ans
 }
 
-func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock) answer {
+func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock, write bool) answer {
 	v1 := ver == gosnmp.Version1
 	switch req.PDUType {
 	case gosnmp.GetRequest:
@@ -60,11 +64,19 @@ func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock
 	case gosnmp.GetBulkRequest:
 		return a.getBulk(req, c)
 	}
-	// A SET. Nothing in a simulated device is writable yet; SNMPv1 has no
-	// notWritable, and RFC 3584 has a v1 agent say noSuchName instead.
-	status := gosnmp.NotWritable
+	if write {
+		return a.set(ver, req)
+	}
+	// A SET from a manager that only reads: nothing is in the view it may
+	// write, which RFC 3416 4.2.5 answers noAccess — net-snmp's answer to a
+	// rocommunity or a rouser. SNMPv1 has no noAccess, and RFC 3584 has a v1
+	// agent say noSuchName instead. A community used so is counted.
+	if ver != gosnmp.Version3 {
+		a.stats.badCommunityUses.Add(1)
+	}
+	status := gosnmp.NoAccess
 	if v1 {
-		status = gosnmp.NoSuchName
+		status = v1Status(status)
 	}
 	return answer{vars: req.Variables, status: status, index: errIndex(0, len(req.Variables))}
 }
@@ -75,12 +87,13 @@ func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock
 func v1Hidden(e *entry) bool { return e.typ == gosnmp.Counter64 }
 
 func (a *Agent) get(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
+	t := a.tree.Load()
 	out := make([]gosnmp.SnmpPDU, len(vars))
 	for i, v := range vars {
 		id, err := parseArcs(v.Name)
 		var e *entry
 		if err == nil {
-			e = a.tree.get(id)
+			e = t.get(id)
 		}
 		switch {
 		case e != nil && !(v1 && v1Hidden(e)):
@@ -88,7 +101,7 @@ func (a *Agent) get(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
 		case v1:
 			return answer{vars: vars, status: gosnmp.NoSuchName, index: errIndex(i, len(vars))}
 		default:
-			out[i] = gosnmp.SnmpPDU{Name: v.Name, Type: a.tree.missing(id)}
+			out[i] = gosnmp.SnmpPDU{Name: v.Name, Type: t.missing(id)}
 		}
 	}
 	return answer{vars: out}
@@ -99,12 +112,13 @@ func (a *Agent) getNext(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
 	if v1 {
 		skip = v1Hidden
 	}
+	t := a.tree.Load()
 	out := make([]gosnmp.SnmpPDU, len(vars))
 	for i, v := range vars {
 		// A name that does not parse is placed before every object, so its
 		// successor is the first one.
 		id, _ := parseArcs(v.Name)
-		switch e := a.tree.next(id, skip); {
+		switch e := t.next(id, skip); {
 		case e != nil:
 			out[i] = e.varbind(c)
 		case v1:
@@ -120,6 +134,7 @@ func (a *Agent) getNext(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
 // GETNEXT, then the rest max-repetitions times, each repetition carrying on
 // from the one before.
 func (a *Agent) getBulk(req *gosnmp.SnmpPacket, c clock) answer {
+	t := a.tree.Load()
 	vars := req.Variables
 	n := min(int(req.NonRepeaters), len(vars))
 	out := a.getNext(false, vars[:n], c).vars
@@ -133,7 +148,7 @@ func (a *Agent) getBulk(req *gosnmp.SnmpPacket, c clock) answer {
 	for rep := 0; rep < int(req.MaxRepetitions) && len(repeaters) > 0 && len(out)+len(repeaters) <= maxBulk; rep++ {
 		ended := true
 		for j := range repeaters {
-			if e := a.tree.next(last[j], nil); e != nil {
+			if e := t.next(last[j], nil); e != nil {
 				out = append(out, e.varbind(c))
 				last[j], names[j], ended = e.oid, e.name, false
 			} else {

--- a/pkg/simulator/record.go
+++ b/pkg/simulator/record.go
@@ -157,10 +157,14 @@ var latinFolds = map[rune]string{
 	'ù': "u", 'ú': "u", 'û': "u", 'ü': "u", 'ý': "y", 'ÿ': "y", 'æ': "ae", 'œ': "oe", 'ß': "ss",
 }
 
-// ModelSlug makes a custom model's id from a name: lower-case letters and
-// digits, one hyphen for whatever runs between them, the accents of a Latin
-// name taken off rather than made into hyphens.
-func ModelSlug(name string) string {
+// ModelSlug makes a custom model's id from a name (Slug).
+func ModelSlug(name string) string { return Slug(name, "recorded-device") }
+
+// Slug makes an id, or a file name, from a name: lower-case letters and digits,
+// one hyphen for whatever runs between them, the accents of a Latin name taken
+// off rather than made into hyphens — and fallback for a name with nothing of
+// the kind, one in Chinese among them.
+func Slug(name, fallback string) string {
 	var b strings.Builder
 	gap := false
 	for _, r := range strings.ToLower(name) {
@@ -182,7 +186,7 @@ func ModelSlug(name string) string {
 		slug = strings.TrimRight(slug[:48], "-")
 	}
 	if slug == "" {
-		return "recorded-device"
+		return fallback
 	}
 	return slug
 }

--- a/pkg/simulator/set.go
+++ b/pkg/simulator/set.go
@@ -1,0 +1,264 @@
+package simulator
+
+import (
+	"bytes"
+	"errors"
+	"maps"
+	"math"
+	"slices"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A device written to. A SET from a manager allowed to write — the write
+// community, or a v3 user with write access — changes what the device answers
+// until it restarts, as a running agent's configuration does until it is saved.
+// RFC 3416 4.2.5: every varbind is checked before any is applied, and a SET is
+// applied whole or not at all.
+//
+// Everything a manager reads may be written, except what the agent answers
+// itself — its counters, its engine, the USM and the VACM — and an object only
+// a notification carries. A varbind naming an instance nothing answers creates
+// it, when it would sit in the tree the way an instance does: a leaf, under no
+// other instance and with none under it. That is what lets a table be given a
+// row.
+//
+// Rows proper need the MIB: which column is a RowStatus (RFC 2579). The agent
+// has no MIB, so it is told (Config.RowStatus), and it then does what RFC 2579
+// has an agent do — createAndGo makes the row active, createAndWait
+// notInService, destroy removes every instance of the row — and refuses what the
+// RFC refuses.
+
+// The values of a RowStatus (RFC 2579).
+const (
+	rowActive        = 1
+	rowNotInService  = 2
+	rowCreateAndGo   = 4
+	rowCreateAndWait = 5
+	rowDestroy       = 6
+)
+
+// change is one varbind of a SET, checked and ready to apply.
+type change struct {
+	id  oid
+	typ gosnmp.Asn1BER
+	val any
+	// destroy removes a row — every instance under entry whose index is index
+	// — rather than writing a value.
+	destroy      bool
+	entry, index oid
+}
+
+// set answers a SET from a manager allowed to write. Requests are handled on
+// the receive goroutine alone, so no other SET comes between the Load and the
+// Store: notifications only read the tree.
+func (a *Agent) set(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket) answer {
+	t := a.tree.Load()
+	fail := func(i int, status gosnmp.SNMPError) answer {
+		if ver == gosnmp.Version1 {
+			status = v1Status(status)
+		}
+		return answer{vars: req.Variables, status: status, index: errIndex(i, len(req.Variables))}
+	}
+	changes := make([]change, 0, len(req.Variables))
+	for i, v := range req.Variables {
+		id, err := parseArcs(v.Name)
+		if err != nil || len(id) < 2 {
+			return fail(i, gosnmp.NoCreation)
+		}
+		if slices.ContainsFunc(agentSubtrees, id.hasPrefix) || t.notifyOnly[id.String()] != nil {
+			return fail(i, gosnmp.NotWritable)
+		}
+		e := t.get(id)
+		switch {
+		case e != nil && v.Type != e.typ:
+			return fail(i, gosnmp.WrongType)
+		case e == nil && !t.placeable(id):
+			return fail(i, gosnmp.NoCreation)
+		}
+		val, status := setValue(v.Type, v.Value)
+		if status != gosnmp.NoError {
+			return fail(i, status)
+		}
+		ch := change{id: id, typ: v.Type, val: val}
+		if column, ok := a.rowStatusColumn(id); ok {
+			asked, isInt := val.(int)
+			if !isInt {
+				return fail(i, gosnmp.WrongType)
+			}
+			next, status := rowStatus(e != nil, asked)
+			switch {
+			case status != gosnmp.NoError:
+				return fail(i, status)
+			case next == rowDestroy:
+				ch = change{id: id, destroy: true, entry: column[:len(column)-1], index: id[len(column):]}
+			default:
+				ch.val = next
+			}
+		}
+		changes = append(changes, ch)
+	}
+	next, err := t.with(changes)
+	if err != nil {
+		// Two instances of one SET, one under the other.
+		return fail(0, gosnmp.NoCreation)
+	}
+	a.tree.Store(next)
+	return answer{vars: req.Variables}
+}
+
+// rowStatusColumn is the RowStatus column id is an instance of, when the agent
+// has been told of one.
+func (a *Agent) rowStatusColumn(id oid) (oid, bool) {
+	if a.rowStatus == nil {
+		return nil, false
+	}
+	name, ok := a.rowStatus(id.String())
+	if !ok {
+		return nil, false
+	}
+	column, err := parseOID(name)
+	if err != nil || len(id) <= len(column) || !id.hasPrefix(column) {
+		return nil, false
+	}
+	return column, true
+}
+
+// rowStatus is what a RowStatus is set to, from what a manager asked for and
+// whether the row exists (RFC 2579): the row made active or notInService, kept
+// as it is asked to be, or destroyed — or the error the RFC answers instead.
+func rowStatus(exists bool, asked int) (int, gosnmp.SNMPError) {
+	switch asked {
+	case rowCreateAndGo, rowCreateAndWait:
+		if exists {
+			return 0, gosnmp.InconsistentValue
+		}
+		if asked == rowCreateAndGo {
+			return rowActive, gosnmp.NoError
+		}
+		return rowNotInService, gosnmp.NoError
+	case rowActive, rowNotInService:
+		if !exists {
+			return 0, gosnmp.InconsistentValue
+		}
+		return asked, gosnmp.NoError
+	case rowDestroy:
+		return rowDestroy, gosnmp.NoError
+	}
+	// notReady(3) is the agent's to say, never a manager's to set.
+	return 0, gosnmp.WrongValue
+}
+
+// setValue is a varbind's value in the Go type Const holds for its type, or
+// the error a SET carrying it earns.
+func setValue(t gosnmp.Asn1BER, v any) (any, gosnmp.SNMPError) {
+	var out any
+	switch t {
+	case gosnmp.Integer:
+		n := gosnmp.ToBigInt(v)
+		if !n.IsInt64() || n.Int64() < math.MinInt32 || n.Int64() > math.MaxInt32 {
+			return nil, gosnmp.WrongValue
+		}
+		out = int(n.Int64())
+	case gosnmp.OctetString, gosnmp.Opaque:
+		switch b := v.(type) {
+		case []byte:
+			out = bytes.Clone(b)
+		case string:
+			out = []byte(b)
+		default:
+			return nil, gosnmp.WrongValue
+		}
+	case gosnmp.ObjectIdentifier, gosnmp.IPAddress:
+		s, ok := v.(string)
+		if !ok {
+			return nil, gosnmp.WrongValue
+		}
+		out = s
+	case gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks:
+		n := gosnmp.ToBigInt(v)
+		if !n.IsUint64() || n.Uint64() > math.MaxUint32 {
+			return nil, gosnmp.WrongValue
+		}
+		out = uint32(n.Uint64())
+	case gosnmp.Counter64:
+		n := gosnmp.ToBigInt(v)
+		if !n.IsUint64() {
+			return nil, gosnmp.WrongValue
+		}
+		out = n.Uint64()
+	default:
+		return nil, gosnmp.WrongType
+	}
+	if err := checkValue(t, out); err != nil {
+		return nil, gosnmp.WrongValue
+	}
+	return out, gosnmp.NoError
+}
+
+// v1Status is an SNMPv2 error as an SNMPv1 agent answers it (RFC 3584 4.4).
+func v1Status(s gosnmp.SNMPError) gosnmp.SNMPError {
+	switch s {
+	case gosnmp.WrongValue, gosnmp.WrongEncoding, gosnmp.WrongType, gosnmp.WrongLength, gosnmp.InconsistentValue:
+		return gosnmp.BadValue
+	case gosnmp.NoAccess, gosnmp.NotWritable, gosnmp.NoCreation, gosnmp.InconsistentName, gosnmp.AuthorizationError:
+		return gosnmp.NoSuchName
+	case gosnmp.ResourceUnavailable, gosnmp.CommitFailed, gosnmp.UndoFailed:
+		return gosnmp.GenErr
+	}
+	return s
+}
+
+// placeable reports whether an instance could be made at o: a leaf, lying
+// under no instance and with none under it.
+func (t *tree) placeable(o oid) bool {
+	i, found := t.find(o)
+	switch {
+	case found:
+		return false
+	case i < len(t.entries) && t.entries[i].oid.hasPrefix(o):
+		return false
+	case i > 0 && o.hasPrefix(t.entries[i-1].oid):
+		return false
+	}
+	return true
+}
+
+// with is t with changes applied. t is left as it is — a request reading it
+// meanwhile sees it whole — and the tree returned shares none of its entries.
+func (t *tree) with(changes []change) (*tree, error) {
+	next := &tree{entries: slices.Clone(t.entries), objects: t.objects, notifyOnly: t.notifyOnly}
+	var made []oid
+	for _, ch := range changes {
+		if ch.destroy {
+			next.entries = slices.DeleteFunc(next.entries, func(e entry) bool { return inRow(e.oid, ch.entry, ch.index) })
+			continue
+		}
+		e := entry{oid: ch.id, name: ch.id.String(), typ: ch.typ, val: Const(ch.val)}
+		i, found := next.find(ch.id)
+		if found {
+			next.entries[i] = e
+			continue
+		}
+		next.entries = slices.Insert(next.entries, i, e)
+		made = append(made, ch.id)
+	}
+	for i := 1; i < len(next.entries); i++ {
+		if next.entries[i].oid.hasPrefix(next.entries[i-1].oid) {
+			return nil, errors.New("an instance lies under another")
+		}
+	}
+	if len(made) > 0 {
+		next.objects = maps.Clone(t.objects)
+		for _, id := range made {
+			next.objects[id[:len(id)-1].String()] = true
+		}
+	}
+	return next, nil
+}
+
+// inRow reports whether o is an instance of the row index names under entry:
+// entry, then a column, then the index.
+func inRow(o, entry, index oid) bool {
+	return len(o) == len(entry)+1+len(index) && o.hasPrefix(entry) && slices.Equal(o[len(entry)+1:], index)
+}

--- a/pkg/simulator/set_test.go
+++ b/pkg/simulator/set_test.go
@@ -1,0 +1,195 @@
+package simulator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+const (
+	sysContactOID  = ".1.3.6.1.2.1.1.4.0"
+	sysLocationOID = ".1.3.6.1.2.1.1.6.0"
+)
+
+// writable is a device answering v1 and v2c, read with "public" and written
+// with "private", holding a contact, a location and a table whose third column
+// the agent is told is a RowStatus.
+func writable(t *testing.T) *Agent {
+	t.Helper()
+	return startAgent(t, Config{
+		Versions: []string{"v1", "v2c"}, Community: "public", WriteCommunity: "private",
+		Objects: []Object{
+			{OID: sysContactOID, Type: gosnmp.OctetString, Value: Const("noc@example.net")},
+			{OID: sysLocationOID, Type: gosnmp.OctetString, Value: Const("Lab")},
+			{OID: "1.3.6.1.4.1.32473.10.1.2.1", Type: gosnmp.OctetString, Value: Const("first")},
+			{OID: "1.3.6.1.4.1.32473.10.1.3.1", Type: gosnmp.Integer, Value: Const(rowActive)},
+		},
+		RowStatus: func(o string) (string, bool) {
+			if strings.HasPrefix(o, ".1.3.6.1.4.1.32473.10.1.3.") {
+				return ".1.3.6.1.4.1.32473.10.1.3", true
+			}
+			return "", false
+		},
+	})
+}
+
+func setOne(t *testing.T, g *gosnmp.GoSNMP, vars ...gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	t.Helper()
+	res, err := g.Set(vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
+}
+
+func getOne(t *testing.T, g *gosnmp.GoSNMP, name string) gosnmp.SnmpPDU {
+	t.Helper()
+	res, err := g.Get([]string{name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.Variables[0]
+}
+
+// The read community reads and does not write — noAccess in v2c, the
+// noSuchName RFC 3584 has a v1 agent say instead, and counted as a community
+// used for what it may not do — and the write community writes, and reads too.
+func TestOnlyTheWriteCommunityWrites(t *testing.T) {
+	a := writable(t)
+	contact := gosnmp.SnmpPDU{Name: sysContactOID, Type: gosnmp.OctetString, Value: "ops@example.net"}
+	if res := setOne(t, connect(t, manager(a, gosnmp.Version2c, "public")), contact); res.Error != gosnmp.NoAccess {
+		t.Errorf("v2c, read community: %v", res.Error)
+	}
+	if res := setOne(t, connect(t, manager(a, gosnmp.Version1, "public")), contact); res.Error != gosnmp.NoSuchName {
+		t.Errorf("v1, read community: %v", res.Error)
+	}
+	if n := a.stats.badCommunityUses.Load(); n != 2 {
+		t.Errorf("snmpInBadCommunityUses is %d", n)
+	}
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	if res := setOne(t, w, contact); res.Error != gosnmp.NoError {
+		t.Fatalf("v2c, write community: %v", res.Error)
+	}
+	if v := getOne(t, connect(t, manager(a, gosnmp.Version2c, "public")), sysContactOID); text(v) != "ops@example.net" {
+		t.Errorf("read back as %q", text(v))
+	}
+	if v := getOne(t, w, sysLocationOID); text(v) != "Lab" {
+		t.Errorf("the write community reads %q", text(v))
+	}
+	if n := a.stats.inTotalSetVars.Load(); n != 1 {
+		t.Errorf("snmpInTotalSetVars is %d", n)
+	}
+}
+
+// A SET is applied whole or not at all, and an error names its varbind; a v1
+// manager is told badValue where v2c says wrongType.
+func TestASetIsAppliedWholeOrNotAtAll(t *testing.T) {
+	a := writable(t)
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	res := setOne(t, w,
+		gosnmp.SnmpPDU{Name: sysContactOID, Type: gosnmp.OctetString, Value: "changed"},
+		gosnmp.SnmpPDU{Name: sysLocationOID, Type: gosnmp.Integer, Value: 7})
+	if res.Error != gosnmp.WrongType || res.ErrorIndex != 2 {
+		t.Errorf("a location written as an INTEGER: %v at %d", res.Error, res.ErrorIndex)
+	}
+	if v := getOne(t, w, sysContactOID); text(v) != "noc@example.net" {
+		t.Errorf("half a SET was applied: the contact is %q", text(v))
+	}
+	v1 := connect(t, manager(a, gosnmp.Version1, "private"))
+	if res := setOne(t, v1, gosnmp.SnmpPDU{Name: sysLocationOID, Type: gosnmp.Integer, Value: 7}); res.Error != gosnmp.BadValue {
+		t.Errorf("v1: %v", res.Error)
+	}
+}
+
+// What the agent answers itself is not written, and an instance under another
+// is not made; an instance nothing answered is, and a walk finds it.
+func TestASetCreatesAnInstanceWhereOneCanBe(t *testing.T) {
+	a := writable(t)
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.11.30.0", Type: gosnmp.Integer, Value: 1}); res.Error != gosnmp.NotWritable {
+		t.Errorf("snmpEnableAuthenTraps: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: sysContactOID + ".1", Type: gosnmp.Integer, Value: 1}); res.Error != gosnmp.NoCreation {
+		t.Errorf("under an instance: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.4.1.32473.9.1.0", Type: gosnmp.Gauge32, Value: uint(42)}); res.Error != gosnmp.NoError {
+		t.Fatalf("a new instance: %v", res.Error)
+	}
+	res, err := w.GetNext([]string{".1.3.6.1.4.1.32473.9"})
+	if err != nil || res.Variables[0].Name != ".1.3.6.1.4.1.32473.9.1.0" || gosnmp.ToBigInt(res.Variables[0].Value).Int64() != 42 {
+		t.Errorf("the walk finds %v, %v", res, err)
+	}
+}
+
+// A row is made through its RowStatus — createAndGo leaves it active — and
+// destroyed through it with every instance it has; what RFC 2579 refuses is
+// refused.
+func TestRowsAreMadeAndDestroyedThroughTheirRowStatus(t *testing.T) {
+	a := writable(t)
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	const name, status = ".1.3.6.1.4.1.32473.10.1.2.5", ".1.3.6.1.4.1.32473.10.1.3.5"
+	if res := setOne(t, w,
+		gosnmp.SnmpPDU{Name: name, Type: gosnmp.OctetString, Value: "fifth"},
+		gosnmp.SnmpPDU{Name: status, Type: gosnmp.Integer, Value: rowCreateAndGo}); res.Error != gosnmp.NoError {
+		t.Fatalf("createAndGo: %v", res.Error)
+	}
+	if v := getOne(t, w, status); gosnmp.ToBigInt(v.Value).Int64() != rowActive {
+		t.Errorf("a row made with createAndGo is %v", v.Value)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: status, Type: gosnmp.Integer, Value: rowCreateAndWait}); res.Error != gosnmp.InconsistentValue {
+		t.Errorf("createAndWait on a row that exists: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: status, Type: gosnmp.Integer, Value: rowDestroy}); res.Error != gosnmp.NoError {
+		t.Fatalf("destroy: %v", res.Error)
+	}
+	for _, gone := range []string{name, status} {
+		if v := getOne(t, w, gone); v.Type != gosnmp.NoSuchInstance && v.Type != gosnmp.NoSuchObject {
+			t.Errorf("%s outlived its row: %v", gone, v.Value)
+		}
+	}
+	if v := getOne(t, w, ".1.3.6.1.4.1.32473.10.1.2.1"); text(v) != "first" {
+		t.Errorf("destroying row 5 touched row 1: %v", v.Value)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.4.1.32473.10.1.3.7", Type: gosnmp.Integer, Value: rowActive}); res.Error != gosnmp.InconsistentValue {
+		t.Errorf("active on a row that does not exist: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.4.1.32473.10.1.3.8", Type: gosnmp.Integer, Value: 3}); res.Error != gosnmp.WrongValue {
+		t.Errorf("notReady: %v", res.Error)
+	}
+}
+
+// A v3 user writes only with write access, and what a device was written
+// holds until it restarts: a new agent answers as configured.
+func TestAV3UserWritesWithWriteAccessUntilTheDeviceRestarts(t *testing.T) {
+	cfg := Config{Versions: []string{"v3"}, EngineID: testEngineID, EngineBoots: 1,
+		Users: []User{
+			{Name: "reader", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "authpass-1", PrivProto: "AES", PrivPass: "privpass-1"},
+			{Name: "writer", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "authpass-2", PrivProto: "AES", PrivPass: "privpass-2", Write: true},
+		},
+		Objects: []Object{{OID: sysContactOID, Type: gosnmp.OctetString, Value: Const("noc@example.net")}},
+	}
+	a := startAgent(t, cfg)
+	as := func(name, auth, priv string) *gosnmp.GoSNMP {
+		return connect(t, v3Manager(a, name, gosnmp.AuthPriv, gosnmp.SHA256, auth, gosnmp.AES, priv))
+	}
+	contact := gosnmp.SnmpPDU{Name: sysContactOID, Type: gosnmp.OctetString, Value: "written"}
+	if res := setOne(t, as("reader", "authpass-1", "privpass-1"), contact); res.Error != gosnmp.NoAccess {
+		t.Errorf("a user without write access: %v", res.Error)
+	}
+	writer := as("writer", "authpass-2", "privpass-2")
+	if res := setOne(t, writer, contact); res.Error != gosnmp.NoError {
+		t.Fatalf("a user with write access: %v", res.Error)
+	}
+	if v := getOne(t, writer, sysContactOID); text(v) != "written" {
+		t.Errorf("read back as %q", text(v))
+	}
+
+	a.Stop()
+	cfg.EngineBoots = 2
+	again := startAgent(t, cfg)
+	g := connect(t, v3Manager(again, "reader", gosnmp.AuthPriv, gosnmp.SHA256, "authpass-1", gosnmp.AES, "privpass-1"))
+	if v := getOne(t, g, sysContactOID); text(v) != "noc@example.net" {
+		t.Errorf("a write outlived the restart: %q", text(v))
+	}
+}

--- a/pkg/simulator/tree.go
+++ b/pkg/simulator/tree.go
@@ -46,6 +46,9 @@ type clock struct {
 	// stats are the agent's own counters, which SNMPv2-MIB's snmp group and
 	// the USM statistics read (agentObjects); nil where no agent is answering.
 	stats *counters
+	// warp is where the counters are once a fault has changed their speed
+	// (faults.go); nil when none ever has.
+	warp *warp
 }
 
 // uptime is the time since the agent started, in hundredths of a second.

--- a/pkg/simulator/usm.go
+++ b/pkg/simulator/usm.go
@@ -49,6 +49,8 @@ type User struct {
 	AuthPass  string `json:"authPass"`
 	PrivProto string `json:"privProto"` // DES, AES, AES192, AES256, AES192C or AES256C
 	PrivPass  string `json:"privPass"`
+	// Write lets the user SET; a user without it only reads.
+	Write bool `json:"write"`
 }
 
 // The names pkg/snmp maps, mapped the same way; TestSnmpLensReadsTheSimulator
@@ -91,6 +93,7 @@ type user struct {
 	priv    gosnmp.SnmpV3PrivProtocol
 	authKey []byte
 	privKey []byte
+	write   bool
 }
 
 func newUsers(list []User, engineID []byte) (map[string]*user, error) {
@@ -119,7 +122,7 @@ func checkUser(u User) (*user, error) {
 	if !ok {
 		return nil, fmt.Errorf("user %q: %q is not a security level (NoAuthNoPriv, AuthNoPriv or AuthPriv)", u.Name, u.SecLevel)
 	}
-	r := &user{name: u.Name, level: level, auth: gosnmp.NoAuth, priv: gosnmp.NoPriv}
+	r := &user{name: u.Name, level: level, auth: gosnmp.NoAuth, priv: gosnmp.NoPriv, write: u.Write}
 	if level&gosnmp.AuthNoPriv != 0 {
 		if r.auth, ok = authProtocols[strings.ToUpper(u.AuthProto)]; !ok {
 			return nil, fmt.Errorf("user %q: %q is not an authentication protocol", u.Name, u.AuthProto)
@@ -271,7 +274,7 @@ func (a *Agent) answerV3(msg []byte, c clock) []byte {
 		// authorizationError, and nothing read.
 		ans = answer{vars: req.Variables, status: gosnmp.AuthorizationError}
 	} else {
-		ans = a.process(gosnmp.Version3, req, c)
+		ans = a.process(gosnmp.Version3, req, c, u.write)
 	}
 	out, err := fit(ans, bulkFloor(req), tooBig(gosnmp.Version3, req), min(a.maxSize, int(req.MsgMaxSize)),
 		func(ans answer) ([]byte, error) {

--- a/pkg/simulator/values.go
+++ b/pkg/simulator/values.go
@@ -110,7 +110,7 @@ func (c counter) count(t float64) uint64 {
 }
 
 func (c counter) read(k clock) any {
-	n := c.count(elapsed(k))
+	n := c.count(counterSeconds(k))
 	switch {
 	case c.wide:
 		return n

--- a/pkg/snmp/simulated_test.go
+++ b/pkg/snmp/simulated_test.go
@@ -13,7 +13,7 @@ import (
 // back through SnmpLens's own client. The target names its port and the port
 // field says 161: the target's port wins, as it does everywhere.
 func TestTheOperationsAgainstASimulatedSwitch(t *testing.T) {
-	d := simtest.Start(t, simulator.Device{Model: "cisco-catalyst-24", Name: "sw-floor-2"})
+	d := simtest.Start(t, simulator.Device{Model: "cisco-catalyst-24", Name: "sw-floor-2", WriteCommunity: "private"})
 	c := NewClient(context.Background())
 	targets := []string{d.Target()}
 	answer := func(t *testing.T, res []*BulkResult) *Result {
@@ -53,9 +53,17 @@ func TestTheOperationsAgainstASimulatedSwitch(t *testing.T) {
 		}
 	})
 	t.Run("SET", func(t *testing.T) {
-		res := c.Set(targets, "1.3.6.1.2.1.1.5.0", "public", "renamed", "OctetString", "v2c", 161, 2, 0, V3Params{})
-		if len(res) != 1 || !strings.Contains(strings.ToLower(res[0].Error), "notwritable") {
-			t.Errorf("a SET the device refuses came back as %+v", res[0])
+		// The read community reads and nothing more, as a rocommunity does.
+		res := c.Set(targets, "1.3.6.1.2.1.1.5.0", "public", "refused", "OctetString", "v2c", 161, 2, 0, V3Params{})
+		if len(res) != 1 || !strings.Contains(strings.ToLower(res[0].Error), "noaccess") {
+			t.Errorf("a SET with the read community came back as %+v", res[0])
+		}
+		res = c.Set(targets, "1.3.6.1.2.1.1.5.0", "private", "renamed", "OctetString", "v2c", 161, 2, 0, V3Params{})
+		if len(res) != 1 || res[0].Error != "" {
+			t.Fatalf("a SET with the write community came back as %+v", res[0])
+		}
+		if r := answer(t, c.Get(targets, "1.3.6.1.2.1.1.5.0", "public", "v2c", 161, 2, 0, V3Params{})); r.Value != "renamed" {
+			t.Errorf("sysName read back as %v", r.Value)
 		}
 	})
 }


### PR DESCRIPTION
Stacked on #74 — merge that first.

## What

- **SET on simulated devices** (`pkg/simulator/set.go`). A SET from a manager allowed to write changes what the device answers **until it restarts**, as a running configuration does until it is saved. Every varbind is checked before any is applied (RFC 3416 4.2.5): wrong type → `wrongType`, a value out of range → `wrongValue`, the agent's own subtrees (snmp group, engine, USM, VACM) and notification-only objects → `notWritable`, an instance that cannot be placed → `noCreation`. An instance nothing answered is **created** when it would sit in the tree as an instance does, which is what lets a table gain a row. Errors are mapped for v1 per RFC 3584 4.4.
- **Write access.** A **write community** for v1/v2c — a secret, kept in the credential store beside the community, carried by a bench file only when its passwords are, and refused if it equals the read community — and a **per-user `write` flag** for SNMPv3.
- **RowStatus rows.** `createAndGo` makes the row `active`, `createAndWait` `notInService`, `destroy` removes every instance of the row; a create on an existing row, `active` on a missing one and `notReady` are refused as RFC 2579 says. Which column is a RowStatus comes from the **loaded MIBs** through a new `mib.Service.RowStatusColumn`, handed to the fleet in `app.go` (`Config.RowStatus`), so the agent stays free of gosmi.
- **Read-only managers** are answered `noAccess` — net-snmp's answer to a `rocommunity` / `rouser` — or `noSuchName` in v1, and counted in `snmpInBadCommunityUses`. `snmpInTotalSetVars` is now live.
- **Tabbed editor**: Device / Access / Notifications. A tab holding a problem carries a dot, so a greyed-out Save always has a visible reason; the Device tab shows the engine ID and boot count. New fields: write community, **Can write (SET)** per v3 user.
- **Add as target** now prefers identifiers that write: the first v3 user with write access, and the write community before the community.

## Design notes

- **The tree is replaced, not edited.** A SET builds a copy with its changes and swaps it in through an `atomic.Pointer[tree]`: notifications read the tree from their own goroutines, and neither they nor a GETBULK may see a SET half-applied. Requests are handled on the receive goroutine alone, so a Load and a Store never interleave with another SET.
- **Nothing written is saved.** A restart is a new `Agent` built from the model again, which is also what a manager expects of an unsaved running config.
- **`noAccess` rather than `notWritable`** for a read-only manager: `notWritable` says the *object* cannot be written, which is no longer true once a write community exists; `noAccess` says *this manager* may not.
- `RowStatusColumn` takes gosmi's lock once per varbind on the agent's receive goroutine, holding nothing of the agent's while it waits.

## Tests

- `pkg/simulator/set_test.go`: only the write community writes (and reads); a SET is applied whole or not at all, with v1's `badValue`; creation where an instance can sit and nowhere else; rows made and destroyed through their RowStatus, with every refusal; a v3 user writes only with write access, and nothing written outlives a restart.
- `pkg/mib/rowstatus_test.go`: `ifStackStatus` instances are recognised with their column; another column, the column itself and an unknown OID are not.
- `pkg/snmp/simulated_test.go`: SnmpLens's own client is refused with the read community, then writes with the write community and reads the value back.
- App: the write community stays in the credential store and out of the file and the list; a user's write flag survives the list.
- Frontend: editor/payload round trip of the write community and flags, the same-as-read problem, tab marking (every problem `deviceProblems` can report sits on a tab), Add as target's preference.

Run locally: `go vet`, `staticcheck`, `go test -race ./...`, `npm test`, `vite build`.
