### PR TITLE
Let a simulated device be written to: SET, write access and RowStatus rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,9 +584,27 @@ the count: that is what makes a manager still holding the old clock resynchronis
 builds the MAC format a Cisco reports), since managers cache it and localise their keys to it.
 
 A request below the level its user is held to is answered `authorizationError` with nothing read, as a device
-configured `rouser NAME priv` answers. Only the default context exists. Nothing is writable yet: a SET is
-`notWritable`, or `noSuchName` in v1 (RFC 3584), where a Counter64 is invisible too — stepped over on GETNEXT,
-`noSuchName` on GET.
+configured `rouser NAME priv` answers. Only the default context exists. SNMPv1 cannot see a Counter64 (RFC 3584):
+it is stepped over on GETNEXT and `noSuchName` on GET.
+
+**A SET writes the running device and nothing else** (`set.go`). The write community — a secret, kept beside the
+community — or a v3 user with `Write` may SET. A manager that only reads is answered `noAccess`, as net-snmp answers
+a `rocommunity` or a `rouser`, or `noSuchName` in v1, and a community used so is counted in
+`snmpInBadCommunityUses`. What is written lives in the agent's tree until the device restarts, which is a new
+`Agent` built from its model again: nothing is saved, as a running configuration is not until someone saves it.
+Every varbind is checked before any is applied (RFC 3416 4.2.5), and the tree is REPLACED rather than edited — a
+copy with the changes, swapped in through an `atomic.Pointer` — because notifications read it from their own
+goroutines, and neither they nor a GETBULK may see a SET half-applied. The agent's own subtrees (the snmp group, the
+engine, the USM, the VACM) and an object only a notification carries are `notWritable`. A varbind naming an instance
+nothing answers CREATES it, if it would sit in the tree as an instance does: a leaf, under no instance and with none
+under it. Errors are v2c's, mapped for v1 by `v1Status` (RFC 3584 4.4).
+
+Rows need the MIB, and the agent has none: which column is a `RowStatus` is asked of `Config.RowStatus`, which
+`app.go` points at `mib.Service.RowStatusColumn`, so rows are created and destroyed as the LOADED MIBs describe
+them. `createAndGo` makes the row `active`, `createAndWait` `notInService`, `destroy` removes every instance of the
+row, and what RFC 2579 refuses is refused — a create on a row that exists, `active` on one that does not, and
+`notReady`, which is the agent's to say. The callback takes gosmi's lock once per varbind, on the agent's receive
+goroutine, holding nothing of the agent's while it waits.
 
 The protocol names are `pkg/snmp`'s (`MD5` to `SHA512`, `DES`, `AES` to `AES256C`), mapped again here so the
 package stays a leaf. `TestSnmpLensReadsTheSimulator` holds the two together by driving the SnmpLens client
@@ -746,8 +764,9 @@ again, and nothing would say why until somebody tried. The renderer lists models
 and not with the devices it polls every two seconds, since an icon crosses the bridge as a data URI.
 
 **A device becomes a target in the renderer** (`addDeviceAsTarget` in `utils/simulator.js`): the target in the
-list, and an override with its identifiers in the most secure version it answers — its FIRST user for v3, since a
-device may have several. The target is the device's address, with its port unless that is 161 (`targetOf`:
+list, and an override with its identifiers in the most secure version it answers — the ones that WRITE when it has
+any, since they read as well and a device on a bench is there to be written to: its first user with `Write` for v3,
+else its first, and its write community before its community. The target is the device's address, with its port unless that is 161 (`targetOf`:
 `127.0.0.1:1162`), because a target is what tells devices apart and on macOS — 127.0.0.1 alone unless aliases
 were added — the port is all that does. A port the target names wins over every port field, in Go
 (`netaddr.SplitTarget`) and in `getEffectiveSettings`, so the override leaves it out and `TargetOverrideForm`

--- a/README.md
+++ b/README.md
@@ -397,6 +397,8 @@ A bench moves as a file. **Export all…**, or a device's export button, writes 
 
 **Faults** make a device misbehave while it runs, without restarting it — its uptime and counters are what a fault is tested against: a latency (with jitter), a share of requests lost, a device that answers nothing at all, a share answered with `genErr` or `tooBig`, and counters running 10, 100 or 1000 times faster, so that a Counter32 wraps in minutes. They are what SnmpLens's reachability alerts, overload guardrail and counter-wrap arithmetic are tested against, and they are kept with the device. A device can also be given its own sysLocation and sysContact, and set to start with SnmpLens.
 
+**A device can be written to.** Give it a write community (v1 and v2c — a password, kept in the keychain like the community), or tick **Can write (SET)** on an SNMPv3 user, and a SET changes what it answers until it restarts, as a running configuration does until it is saved. A table row is created and destroyed through its `RowStatus`, as the MIBs loaded in SnmpLens describe it, so the row editor works against a simulated device as it does against a real one. A manager that only reads is answered `noAccess`, and **Add as target** uses the write access when the device has one. The editor is in three tabs — the device, its access, its notifications — and a tab holding something to fix is marked.
+
 ---
 
 ## Custom Simulator Models

--- a/app.go
+++ b/app.go
@@ -151,6 +151,9 @@ func (a *App) startup(ctx context.Context) {
 	// application are started — after the secret store, which holds their
 	// communities and passphrases. The others answer once someone starts them.
 	a.sim = newSimulatorService(filepath.Join(configDir, "SnmpLens"))
+	// Which column is a RowStatus is in the MIBs, and the agents have none: a
+	// row is created and destroyed as the loaded MIBs describe it.
+	a.sim.fleet.RowStatus = a.mibService.RowStatusColumn
 	a.startAutoSimulated()
 
 	// The trap listener's engine ID, before initBackgroundMode can start the

--- a/app_simulator.go
+++ b/app_simulator.go
@@ -173,12 +173,14 @@ type SimulatedUser struct {
 	SecLevel  string `json:"secLevel"`
 	AuthProto string `json:"authProto"`
 	PrivProto string `json:"privProto"`
+	Write     bool   `json:"write"`
 }
 
 func (s *simulatorService) view(d simulator.Device) SimulatedDevice {
 	users := make([]SimulatedUser, len(d.Users))
 	for i, u := range d.Users {
-		users[i] = SimulatedUser{Name: u.Name, SecLevel: u.SecLevel, AuthProto: u.AuthProto, PrivProto: u.PrivProto}
+		users[i] = SimulatedUser{Name: u.Name, SecLevel: u.SecLevel, AuthProto: u.AuthProto, PrivProto: u.PrivProto,
+			Write: u.Write}
 	}
 	stats, running := s.fleet.Status(d.ID)
 	traps := SimulatedTraps{

--- a/app_simulator_test.go
+++ b/app_simulator_test.go
@@ -28,15 +28,15 @@ func simApp(t *testing.T) (*App, *stubStore) {
 func simDevice() simulator.Device {
 	return simulator.Device{
 		Name: "srv-01", Model: "linux-server", Address: "127.0.0.2", Port: 16161,
-		Versions: []string{"v2c", "v3"}, Community: "s3cr3t-community",
+		Versions: []string{"v2c", "v3"}, Community: "s3cr3t-community", WriteCommunity: "wr1te-s3cr3t",
 		Users: []simulator.User{{Name: "ops", SecLevel: "AuthPriv",
-			AuthProto: "SHA256", AuthPass: "auth-s3cr3t", PrivProto: "AES", PrivPass: "priv-s3cr3t"}},
+			AuthProto: "SHA256", AuthPass: "auth-s3cr3t", PrivProto: "AES", PrivPass: "priv-s3cr3t", Write: true}},
 		Traps: simulator.Traps{Destinations: []simulator.Destination{
 			{Host: "127.0.0.1", Port: 1162, Version: "v2c", Community: "trap-s3cr3t"}}},
 	}
 }
 
-var simSecrets = []string{"s3cr3t-community", "auth-s3cr3t", "priv-s3cr3t", "trap-s3cr3t"}
+var simSecrets = []string{"s3cr3t-community", "wr1te-s3cr3t", "auth-s3cr3t", "priv-s3cr3t", "trap-s3cr3t"}
 
 // startSimulated saves d at 127.0.0.1 on a free port and starts it. A port
 // found free can be taken before the device binds it, since `go test ./...`
@@ -96,8 +96,13 @@ func TestASimulatedDevicesSecretsStayInTheStore(t *testing.T) {
 	}
 
 	creds, err := a.SimulatorDeviceCredentials(saved.ID)
-	if err != nil || creds.Community != "s3cr3t-community" || creds.Users["ops"].PrivPass != "priv-s3cr3t" {
+	if err != nil || creds.Community != "s3cr3t-community" || creds.WriteCommunity != "wr1te-s3cr3t" ||
+		creds.Users["ops"].PrivPass != "priv-s3cr3t" {
 		t.Errorf("credentials: %+v, %v", creds, err)
+	}
+	// Whether a user writes is no secret, and the editor needs it back.
+	if len(saved.Users) != 1 || !saved.Users[0].Write {
+		t.Errorf("the list lost the user's write access: %+v", saved.Users)
 	}
 	// A new destination is given its ID, and its community is kept under it.
 	if len(saved.Traps.Destinations) != 1 || saved.Traps.Destinations[0].ID == "" {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -10,7 +10,7 @@
     SIM_VERSIONS, MAX_EVERY, MAX_DESTINATIONS, MAX_SCHEDULES, blankDevice, blankV3, blankDestination, blankSchedule,
     editableDevice, deviceProblems, devicePayload, addDeviceAsTarget, notificationsOf, trapActivity, deliveryReport,
     modelOf, modelName, modelDescription, importReport, firstImported, recordRequest, recordableTargets, deviceImportReport,
-    deviceGroups, faultChips, categoryIcon,
+    deviceGroups, faultChips, categoryIcon, EDITOR_TABS, tabsWithProblems,
   } from './utils/simulator.js';
   import UsmFields from './settings/UsmFields.svelte';
   import ModelPicker from './simulator/ModelPicker.svelte';
@@ -45,6 +45,10 @@
 
   $: problems = editing ? deviceProblems(editing) : {};
   $: usmProblems = usmMessages(problems, $_);
+
+  /** The editor's tab, and the tabs holding something to fix. */
+  let tab = 'identity';
+  $: flagged = tabsWithProblems(problems);
 
   /** The editor's SNMPv3 problems, one set per user, in the shape UsmFields shows them. */
   function usmMessages(p, t) {
@@ -89,6 +93,7 @@
     defaultName = nameFor(model, devices);
     editing.name = defaultName;
     saveError = '';
+    tab = 'identity';
   }
 
   // A new device's model. Its name follows the model until someone types
@@ -186,6 +191,7 @@
     try {
       editing = editableDevice(device, await simulatorStore.credentials(device.id));
       saveError = '';
+      tab = 'identity';
     } catch (e) {
       notificationStore.add(String(e), 'error');
     }
@@ -421,6 +427,19 @@
     {#if editing}
       <div class="sim-body">
         <h3 class="editor-title">{editing.id ? $_('simulator.editTitle') : $_('simulator.newTitle')}</h3>
+        <div class="tabs" role="tablist">
+          {#each EDITOR_TABS as t (t.id)}
+            <button type="button" role="tab" id="sim-tab-{t.id}" class="tab" class:active={tab === t.id}
+              aria-selected={tab === t.id} aria-controls="sim-tab-panel" on:click={() => (tab = t.id)}>
+              {$_(`simulator.tab.${t.id}`)}
+              {#if flagged.includes(t.id)}
+                <span class="tab-flag" title={$_('simulator.tabProblem')} aria-label={$_('simulator.tabProblem')}></span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+        <div id="sim-tab-panel" role="tabpanel" aria-labelledby="sim-tab-{tab}">
+        {#if tab === 'identity'}
         {#if editing.id}
           <!-- A device keeps its model: its engine ID carries the model's vendor. -->
           {@const model = modelOf($simulatorStore.models, editing.model)}
@@ -469,7 +488,17 @@
           </div>
         </div>
         <label class="check autostart"><input type="checkbox" bind:checked={editing.autoStart} /> {$_('simulator.field.autoStart')}</label>
+        {#if editing.id && editing.engineId}
+          <div class="engine-line">
+            <span class="engine-label">{$_('simulator.field.engineId')}</span>
+            <code>{editing.engineId}</code>
+            <span class="engine-boots">{$_('simulator.engineBoots', { values: { count: editing.engineBoots } })}</span>
+          </div>
+          <p class="hint"><Icon name="key-round" size={14} /> {$_('simulator.engineHint')}</p>
+        {/if}
+        {/if}
 
+        {#if tab === 'access'}
         <fieldset class="versions">
           <legend>{$_('simulator.field.versions')}</legend>
           {#each SIM_VERSIONS as version (version)}
@@ -482,10 +511,18 @@
         </fieldset>
 
         {#if editing.versions.includes('v1') || editing.versions.includes('v2c')}
-          <div class="form-group community">
-            <label for="sim-community">{$_('simulator.field.community')}</label>
-            <input id="sim-community" type="password" autocomplete="off" bind:value={editing.community} />
-            {#if problems.community}<span class="problem">{$_(`simulator.problem.${problems.community}`)}</span>{/if}
+          <div class="grid communities">
+            <div class="form-group">
+              <label for="sim-community">{$_('simulator.field.community')}</label>
+              <input id="sim-community" type="password" autocomplete="off" bind:value={editing.community} />
+              {#if problems.community}<span class="problem">{$_(`simulator.problem.${problems.community}`)}</span>{/if}
+            </div>
+            <div class="form-group">
+              <label for="sim-write-community">{$_('simulator.field.writeCommunity')}</label>
+              <input id="sim-write-community" type="password" autocomplete="off"
+                placeholder={$_('simulator.field.writeCommunityNone')} bind:value={editing.writeCommunity} />
+              {#if problems.writeCommunity}<span class="problem">{$_(`simulator.problem.${problems.writeCommunity}`)}</span>{/if}
+            </div>
           </div>
         {/if}
 
@@ -505,6 +542,7 @@
               <!-- bind:, as the settings do: UsmFields edits the object in place, and
                    without it the checks above never see a passphrase being typed. -->
               <UsmFields bind:v3={u} idPrefix="sim-v3-{i}" problems={usmProblems[i] || {}} showContext={false} />
+              <label class="check user-write"><input type="checkbox" bind:checked={u.write} /> {$_('simulator.field.userWrite')}</label>
             </div>
           {/each}
           {#if problems.noUser}<span class="problem">{$_(`simulator.problem.${problems.noUser}`)}</span>{/if}
@@ -515,9 +553,11 @@
             {#if editing.users.length > 1}<span class="users-note">{$_('simulator.firstUserTarget')}</span>{/if}
           </div>
         {/if}
+        <p class="hint"><Icon name="pencil" size={14} /> {$_('simulator.writeHint')}</p>
+        {/if}
 
-        <h4 class="section-title">{$_('simulator.traps.title')}</h4>
-        <p class="hint"><Icon name="radio" size={14} /> {$_('simulator.traps.hint')}</p>
+        {#if tab === 'traps'}
+        <p class="hint first"><Icon name="radio" size={14} /> {$_('simulator.traps.hint')}</p>
         {#each editing.traps.destinations as dest, i (i)}
           <div class="user-block">
             <div class="user-head">
@@ -618,6 +658,8 @@
             </button>
           </div>
         {/if}
+        {/if}
+        </div>
       </div>
       <footer class="sim-footer">
         {#if saveError}<span class="save-error">{saveError}</span>{/if}
@@ -1169,9 +1211,78 @@
     cursor: pointer;
   }
 
-  .community {
+  .communities {
     margin-top: 14px;
-    max-width: 50%;
+  }
+
+  .user-write {
+    margin-top: 10px;
+    font-size: 0.9em;
+  }
+
+  .tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px;
+    margin: 0 0 14px;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: -1px;
+    padding: 7px 14px;
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: var(--text-muted);
+    font-size: 0.9em;
+    cursor: pointer;
+  }
+
+  .tab:hover {
+    color: var(--text-color);
+  }
+
+  .tab.active {
+    border-bottom-color: var(--accent-color);
+    color: var(--text-color);
+    font-weight: 600;
+  }
+
+  .tab-flag {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background-color: var(--error-color);
+  }
+
+  .hint.first {
+    margin-top: 0;
+  }
+
+  .engine-line {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    margin-top: 14px;
+    font-size: 0.9em;
+  }
+
+  .engine-label {
+    color: var(--text-light);
+  }
+
+  .engine-line code {
+    overflow-wrap: anywhere;
+  }
+
+  .engine-boots {
+    font-size: 0.92em;
+    color: var(--text-muted);
   }
 
   .section-title {

--- a/frontend/src/SimulatorModal.svelte
+++ b/frontend/src/SimulatorModal.svelte
@@ -1454,8 +1454,5 @@
     .device {
       flex-wrap: wrap;
     }
-    .community {
-      max-width: none;
-    }
   }
 </style>

--- a/frontend/src/i18n/de.json
+++ b/frontend/src/i18n/de.json
@@ -1350,6 +1350,15 @@
         "counters": "Zähler ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Gerät",
+      "access": "Zugriff",
+      "traps": "Benachrichtigungen"
+    },
+    "tabProblem": "Auf diesem Reiter ist etwas zu korrigieren",
+    "writeHint": "Ein SET mit der Schreib-Community oder von einem Benutzer mit Schreibrecht ändert, was das Gerät antwortet, bis es neu startet — wie eine laufende Konfiguration, solange sie nicht gespeichert ist. Zeilen werden über ihren RowStatus angelegt und gelöscht, so wie die geladenen MIBs sie beschreiben. Was der Agent selbst zählt — seine SNMP-Statistiken, seine Engine —, wird nie geschrieben.",
+    "engineHint": "Von SnmpLens vergeben und für die gesamte Lebensdauer des Geräts beibehalten: Manager lokalisieren ihre SNMPv3-Schlüssel darauf.",
+    "engineBoots": "{count, plural, one {# Mal gestartet} other {# Mal gestartet}}",
     "loopbackHint": "Nur Loopback: 127.0.0.1 bis 127.255.255.254 oder ::1. Unter Linux und macOS erfordert ein Port unter 1024 Administratorrechte.",
     "field": {
       "name": "Name",
@@ -1362,7 +1371,11 @@
       "location": "Standort (sysLocation)",
       "contact": "Kontakt (sysContact)",
       "modelDefault": "Der des Modells",
-      "autoStart": "Mit SnmpLens starten"
+      "autoStart": "Mit SnmpLens starten",
+      "writeCommunity": "Schreib-Community",
+      "writeCommunityNone": "Keine: in v1 und v2c nur lesbar",
+      "userWrite": "Darf schreiben (SET)",
+      "engineId": "Engine-ID"
     },
     "problem": {
       "nameRequired": "Geben Sie dem Gerät einen Namen.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Wählen Sie einen der SNMPv3-Benutzer des Geräts.",
       "trapNeedsV3": "Eine v3-Benachrichtigung wird als SNMPv3-Benutzer des Geräts gesendet: Aktivieren Sie zuerst v3.",
       "engineId": "5 bis 32 Oktette, hexadezimal.",
-      "every": "Von 1 bis 86400 Sekunden."
+      "every": "Von 1 bis 86400 Sekunden.",
+      "writeSameAsRead": "Die Schreib-Community muss sich von der Lese-Community unterscheiden: Sonst schreibt jeder Manager, der liest, auch."
     },
     "category": {
       "server": "Server",
@@ -1450,9 +1464,8 @@
     "userN": "Benutzer {n}",
     "addUser": "Benutzer hinzufügen",
     "removeUser": "Diesen Benutzer entfernen",
-    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer.",
+    "firstUserTarget": "„Als Ziel hinzufügen“ verwendet den ersten Benutzer mit Schreibrecht, sonst den ersten.",
     "traps": {
-      "title": "Benachrichtigungen",
       "hint": "Wohin das Gerät seine Traps und INFORMs sendet, und wann. Anders als die Adresse, an der es antwortet, darf ein Ziel irgendwo im Netzwerk liegen.",
       "destinationN": "Ziel {n}",
       "host": "Host",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1350,6 +1350,15 @@
         "counters": "counters ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Device",
+      "access": "Access",
+      "traps": "Notifications"
+    },
+    "tabProblem": "Something on this tab needs fixing",
+    "writeHint": "A SET from the write community, or from a user who can write, changes what the device answers until it restarts — as a running configuration does until it is saved. Rows are created and destroyed through their RowStatus, as the loaded MIBs describe them. What the agent counts itself — its SNMP statistics, its engine — is never written.",
+    "engineHint": "Given by SnmpLens and kept for the life of the device: managers localise their SNMPv3 keys to it.",
+    "engineBoots": "{count, plural, one {started # time} other {started # times}}",
     "loopbackHint": "Loopback only: 127.0.0.1 to 127.255.255.254, or ::1. On Linux and macOS, a port below 1024 needs administrator rights.",
     "field": {
       "name": "Name",
@@ -1362,7 +1371,11 @@
       "location": "Location (sysLocation)",
       "contact": "Contact (sysContact)",
       "modelDefault": "The model’s own",
-      "autoStart": "Start with SnmpLens"
+      "autoStart": "Start with SnmpLens",
+      "writeCommunity": "Write community",
+      "writeCommunityNone": "None: read-only in v1 and v2c",
+      "userWrite": "Can write (SET)",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "Give the device a name.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Choose one of the device's SNMPv3 users.",
       "trapNeedsV3": "A v3 notification is sent as one of the device's SNMPv3 users: answer v3 first.",
       "engineId": "5 to 32 octets, in hex.",
-      "every": "From 1 to 86400 seconds."
+      "every": "From 1 to 86400 seconds.",
+      "writeSameAsRead": "The write community must differ from the read community: otherwise every manager that reads also writes."
     },
     "category": {
       "server": "Servers",
@@ -1450,9 +1464,8 @@
     "userN": "User {n}",
     "addUser": "Add a user",
     "removeUser": "Remove this user",
-    "firstUserTarget": "Add as target uses the first user.",
+    "firstUserTarget": "Add as target uses the first user who can write, or else the first.",
     "traps": {
-      "title": "Notifications",
       "hint": "Where the device sends its traps and INFORMs, and when. Unlike where it answers, a destination may be anywhere on the network.",
       "destinationN": "Destination {n}",
       "host": "Host",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -1350,6 +1350,15 @@
         "counters": "contadores ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Dispositivo",
+      "access": "Acceso",
+      "traps": "Notificaciones"
+    },
+    "tabProblem": "Hay algo que corregir en esta pestaña",
+    "writeHint": "Un SET con la comunidad de escritura, o de un usuario que puede escribir, cambia lo que responde el dispositivo hasta que se reinicia, como una configuración en ejecución mientras no se guarda. Las filas se crean y se eliminan mediante su RowStatus, tal como las describen las MIB cargadas. Lo que el agente cuenta por sí mismo —sus estadísticas SNMP, su motor— nunca se escribe.",
+    "engineHint": "Asignado por SnmpLens y conservado durante toda la vida del dispositivo: los gestores localizan en él sus claves SNMPv3.",
+    "engineBoots": "{count, plural, one {iniciado # vez} other {iniciado # veces}}",
     "loopbackHint": "Solo loopback: de 127.0.0.1 a 127.255.255.254, o ::1. En Linux y macOS, un puerto inferior a 1024 requiere permisos de administrador.",
     "field": {
       "name": "Nombre",
@@ -1362,7 +1371,11 @@
       "location": "Ubicación (sysLocation)",
       "contact": "Contacto (sysContact)",
       "modelDefault": "La del modelo",
-      "autoStart": "Iniciar con SnmpLens"
+      "autoStart": "Iniciar con SnmpLens",
+      "writeCommunity": "Comunidad de escritura",
+      "writeCommunityNone": "Ninguna: solo lectura en v1 y v2c",
+      "userWrite": "Puede escribir (SET)",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "Dé un nombre al dispositivo.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Elija uno de los usuarios SNMPv3 del dispositivo.",
       "trapNeedsV3": "Una notificación v3 se envía como uno de los usuarios SNMPv3 del dispositivo: active primero la v3.",
       "engineId": "De 5 a 32 octetos, en hexadecimal.",
-      "every": "De 1 a 86400 segundos."
+      "every": "De 1 a 86400 segundos.",
+      "writeSameAsRead": "La comunidad de escritura debe ser distinta de la de lectura: si no, todo gestor que lee también escribe."
     },
     "category": {
       "server": "Servidores",
@@ -1450,9 +1464,8 @@
     "userN": "Usuario {n}",
     "addUser": "Añadir un usuario",
     "removeUser": "Quitar este usuario",
-    "firstUserTarget": "«Añadir como destino» usa el primer usuario.",
+    "firstUserTarget": "«Añadir como destino» usa el primer usuario que puede escribir o, si no hay ninguno, el primero.",
     "traps": {
-      "title": "Notificaciones",
       "hint": "Adónde envía el dispositivo sus Traps e INFORM, y cuándo. A diferencia de la dirección en la que responde, un destino puede estar en cualquier lugar de la red.",
       "destinationN": "Destino {n}",
       "host": "Host",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -1350,6 +1350,15 @@
         "counters": "compteurs ×{speed}"
       }
     },
+    "tab": {
+      "identity": "Appareil",
+      "access": "Accès",
+      "traps": "Notifications"
+    },
+    "tabProblem": "Quelque chose est à corriger dans cet onglet",
+    "writeHint": "Un SET envoyé avec la communauté d’écriture, ou par un utilisateur autorisé à écrire, change ce que l’appareil répond jusqu’à son redémarrage — comme une configuration en cours tant qu’elle n’est pas enregistrée. Les lignes se créent et se suppriment par leur RowStatus, telles que les décrivent les MIB chargées. Ce que l’agent compte lui-même — ses statistiques SNMP, son moteur — ne s’écrit jamais.",
+    "engineHint": "Attribué par SnmpLens et conservé toute la vie de l’appareil : les gestionnaires y localisent leurs clés SNMPv3.",
+    "engineBoots": "{count, plural, one {démarré # fois} other {démarré # fois}}",
     "loopbackHint": "Bouclage uniquement : de 127.0.0.1 à 127.255.255.254, ou ::1. Sous Linux et macOS, un port inférieur à 1024 exige des droits d'administrateur.",
     "field": {
       "name": "Nom",
@@ -1362,7 +1371,11 @@
       "location": "Emplacement (sysLocation)",
       "contact": "Contact (sysContact)",
       "modelDefault": "Celui du modèle",
-      "autoStart": "Démarrer avec SnmpLens"
+      "autoStart": "Démarrer avec SnmpLens",
+      "writeCommunity": "Communauté d’écriture",
+      "writeCommunityNone": "Aucune : lecture seule en v1 et v2c",
+      "userWrite": "Peut écrire (SET)",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "Donnez un nom à l'appareil.",
@@ -1376,7 +1389,8 @@
       "trapUser": "Choisissez l’un des utilisateurs SNMPv3 de l’appareil.",
       "trapNeedsV3": "Une notification v3 part au nom d’un utilisateur SNMPv3 de l’appareil : activez d’abord la v3.",
       "engineId": "5 à 32 octets, en hexadécimal.",
-      "every": "De 1 à 86400 secondes."
+      "every": "De 1 à 86400 secondes.",
+      "writeSameAsRead": "La communauté d’écriture doit différer de celle de lecture : sinon, tout gestionnaire qui lit écrit aussi."
     },
     "category": {
       "server": "Serveurs",
@@ -1450,9 +1464,8 @@
     "userN": "Utilisateur {n}",
     "addUser": "Ajouter un utilisateur",
     "removeUser": "Retirer cet utilisateur",
-    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur.",
+    "firstUserTarget": "« Ajouter comme cible » utilise le premier utilisateur qui peut écrire, sinon le premier.",
     "traps": {
-      "title": "Notifications",
       "hint": "Où l’appareil envoie ses traps et ses INFORM, et quand. Contrairement à l’adresse où il répond, une destination peut se trouver n’importe où sur le réseau.",
       "destinationN": "Destination {n}",
       "host": "Hôte",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -1350,6 +1350,15 @@
         "counters": "计数器 ×{speed}"
       }
     },
+    "tab": {
+      "identity": "设备",
+      "access": "访问",
+      "traps": "通知"
+    },
+    "tabProblem": "此选项卡中有需要修正的内容",
+    "writeHint": "使用写团体名或由具有写权限的用户发出的 SET 会改变设备的应答，直到设备重启——就像尚未保存的运行配置。表行通过其 RowStatus 创建和删除，依据已加载的 MIB 的描述。代理自身统计的内容（SNMP 统计、引擎）永远不可写。",
+    "engineHint": "由 SnmpLens 分配，并在设备的整个生命周期内保持不变：管理端据此本地化其 SNMPv3 密钥。",
+    "engineBoots": "{count, plural, other {已启动 # 次}}",
     "loopbackHint": "仅限回环地址：127.0.0.1 至 127.255.255.254，或 ::1。在 Linux 和 macOS 上，低于 1024 的端口需要管理员权限。",
     "field": {
       "name": "名称",
@@ -1362,7 +1371,11 @@
       "location": "位置（sysLocation）",
       "contact": "联系人（sysContact）",
       "modelDefault": "使用型号的默认值",
-      "autoStart": "随 SnmpLens 启动"
+      "autoStart": "随 SnmpLens 启动",
+      "writeCommunity": "写团体名",
+      "writeCommunityNone": "无：v1 和 v2c 只读",
+      "userWrite": "可写（SET）",
+      "engineId": "Engine ID"
     },
     "problem": {
       "nameRequired": "请为设备命名。",
@@ -1376,7 +1389,8 @@
       "trapUser": "请选择设备的一个 SNMPv3 用户。",
       "trapNeedsV3": "v3 通知以设备的某个 SNMPv3 用户身份发送：请先启用 v3。",
       "engineId": "5 到 32 个八位组，十六进制。",
-      "every": "1 到 86400 秒。"
+      "every": "1 到 86400 秒。",
+      "writeSameAsRead": "写团体名必须与读团体名不同：否则任何能读的管理端也都能写。"
     },
     "category": {
       "server": "服务器",
@@ -1450,9 +1464,8 @@
     "userN": "用户 {n}",
     "addUser": "添加用户",
     "removeUser": "删除此用户",
-    "firstUserTarget": "“添加为目标”使用第一个用户。",
+    "firstUserTarget": "“添加为目标”使用第一个具有写权限的用户，否则使用第一个用户。",
     "traps": {
-      "title": "通知",
       "hint": "设备向何处、在何时发送 Trap 和 INFORM。与设备应答的地址不同，目标可以位于网络上的任何位置。",
       "destinationN": "目标 {n}",
       "host": "主机",

--- a/frontend/src/utils/simulator.js
+++ b/frontend/src/utils/simulator.js
@@ -66,7 +66,25 @@ export function blankV3(n = 1) {
     privProto: 'AES',
     privPass: '',
     contextName: '',
+    write: false,
   };
+}
+
+/**
+ * The editor's tabs, in order, and the fields of deviceProblems each holds: a
+ * tab with something wrong in it is marked, since what is wrong may be on a tab
+ * nobody is looking at.
+ */
+export const EDITOR_TABS = [
+  { id: 'identity', fields: ['name', 'port'] },
+  { id: 'access', fields: ['versions', 'community', 'writeCommunity', 'noUser', 'users'] },
+  { id: 'traps', fields: ['destinations', 'schedules'] },
+];
+
+/** The tabs holding at least one of a device's problems. */
+export function tabsWithProblems(problems) {
+  const keys = Object.keys(problems || {});
+  return EDITOR_TABS.filter((t) => t.fields.some((f) => keys.includes(f))).map((t) => t.id);
 }
 
 /**
@@ -83,6 +101,8 @@ export function blankDevice(model, suggestion) {
     port: suggestion?.port || 1161,
     versions: ['v2c'],
     community: 'public',
+    // Read-only until someone gives it a way to be written.
+    writeCommunity: '',
     users: [blankV3()],
     traps: blankTraps(),
     location: '',
@@ -104,6 +124,7 @@ export function editableDevice(view, creds) {
     privProto: u.privProto || 'AES',
     privPass: creds?.users?.[u.name]?.privPass || '',
     contextName: '',
+    write: !!u.write,
   }));
   return {
     id: view.id,
@@ -113,7 +134,11 @@ export function editableDevice(view, creds) {
     port: view.port,
     versions: [...(view.versions || [])],
     community: creds?.community || '',
+    writeCommunity: creds?.writeCommunity || '',
     users: users.length ? users : [blankV3()],
+    // Shown, never sent: the engine is the backend's.
+    engineId: view.engineId || '',
+    engineBoots: view.engineBoots || 0,
     location: view.location || '',
     contact: view.contact || '',
     autoStart: !!view.autoStart,
@@ -152,6 +177,10 @@ export function deviceProblems(d) {
   if (!Number.isInteger(port) || port < 1 || port > 65535) problems.port = 'port';
   if (!versions.length) problems.versions = 'versionRequired';
   if (usesCommunity(versions) && !d.community) problems.community = 'communityRequired';
+  // One community for both is every manager that reads also writing.
+  if (usesCommunity(versions) && d.writeCommunity && d.writeCommunity === d.community) {
+    problems.writeCommunity = 'writeSameAsRead';
+  }
   if (versions.includes('v3')) {
     const users = d.users || [];
     if (!users.length) problems.noUser = 'userRequired';
@@ -227,6 +256,7 @@ export function devicePayload(d) {
     port: Number(d.port),
     versions,
     community: usesCommunity(versions) ? d.community : '',
+    writeCommunity: usesCommunity(versions) ? d.writeCommunity || '' : '',
     users: versions.includes('v3')
       ? (d.users || []).map((u) => ({
           name: (u.user || '').trim(),
@@ -235,6 +265,7 @@ export function devicePayload(d) {
           authPass: u.authPass,
           privProto: u.privProto,
           privPass: u.privPass,
+          write: !!u.write,
         }))
       : [],
     location: (d.location || '').trim(),
@@ -568,7 +599,10 @@ function targetOfLine(line) {
 /**
  * The settings with a device added as a target: the target in the list, named
  * after the device, and an override carrying its identifiers in the most secure
- * version it answers — with its FIRST user for v3.
+ * version it answers — the ones that WRITE when it has any, since they read as
+ * well and a device on a bench is there to be written to: its first user with
+ * write access for v3, else its first user; its write community, else its
+ * community.
  *
  * The port travels in the target when it is not 161, and the override then
  * leaves it out: the target's would win over it anyway. A device added again
@@ -581,7 +615,7 @@ export function addDeviceAsTarget(settings, device, creds) {
   const override = { snmpVersion: version };
   if (target === device.address) override.port = device.port;
   if (version === 'v3') {
-    const u = device.users[0];
+    const u = device.users.find((x) => x.write) || device.users[0];
     override.v3 = {
       user: u.name,
       secLevel: u.secLevel,
@@ -592,7 +626,7 @@ export function addDeviceAsTarget(settings, device, creds) {
       contextName: '',
     };
   } else {
-    override.community = creds?.community || '';
+    override.community = creds?.writeCommunity || creds?.community || '';
   }
   const lines = (settings.targets || '').split('\n').filter((l) => l.trim());
   const added = !lines.some((l) => targetOfLine(l) === target);

--- a/frontend/tests/simulator.test.mjs
+++ b/frontend/tests/simulator.test.mjs
@@ -54,6 +54,8 @@ const {
   editableDevice,
   deviceProblems,
   devicePayload,
+  EDITOR_TABS,
+  tabsWithProblems,
   deliveryReport,
   trapActivity,
   modelGroups,
@@ -209,8 +211,8 @@ check('the editor is given the community, and every user with its passphrases',
   form.users[0].privPass === 'privpass-1' && form.users[1].authPass === 'monitor-pass');
 check('and editing nothing sends back the same users',
   JSON.stringify(devicePayload(form).users) === JSON.stringify([
-    { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1' },
-    { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', authPass: 'monitor-pass', privProto: 'AES', privPass: '' },
+    { name: 'ops', secLevel: 'AuthPriv', authProto: 'SHA256', authPass: 'authpass-1', privProto: 'AES', privPass: 'privpass-1', write: false },
+    { name: 'monitor', secLevel: 'AuthNoPriv', authProto: 'SHA', authPass: 'monitor-pass', privProto: 'AES', privPass: '', write: false },
   ]));
 check("a destination's community comes back by its ID, and goes back without the counters",
   form.traps.destinations[0].community === 'trap-community' &&
@@ -220,6 +222,42 @@ check("a destination's community comes back by its ID, and goes back without the
     onAuthFailure: false,
     schedules: [{ notification: 'linkUp', every: 60, irregular: false }],
   }), JSON.stringify(devicePayload(form).traps));
+
+/* --- writing ---------------------------------------------------------------- */
+
+check('a new device writes nothing', fresh.writeCommunity === '' && fresh.users.every((u) => !u.write));
+const writeForm = editableDevice({ ...view, users: [{ ...view.users[0], write: true }] }, { ...creds, writeCommunity: 'wr1te' });
+check('the editor is given the write community, and which users write',
+  writeForm.writeCommunity === 'wr1te' && writeForm.users[0].write === true);
+check('and sends both back', devicePayload(writeForm).writeCommunity === 'wr1te' && devicePayload(writeForm).users[0].write === true);
+check('a device answering v3 alone sends no write community',
+  devicePayload({ ...writeForm, versions: ['v3'] }).writeCommunity === '');
+check('a write community that is the read community is refused',
+  deviceProblems({ ...fresh, name: 'x', writeCommunity: 'public' }).writeCommunity === 'writeSameAsRead' &&
+  !deviceProblems({ ...fresh, name: 'x', writeCommunity: 'private' }).writeCommunity);
+const booted = editableDevice({ ...view, engineId: '8000000903020000000001', engineBoots: 3 }, creds);
+check("the editor shows the device's engine, and sends none",
+  booted.engineId === '8000000903020000000001' && booted.engineBoots === 3 &&
+  devicePayload(booted).engineId === '' && devicePayload(booted).engineBoots === 0);
+
+/* --- the editor's tabs ------------------------------------------------------ */
+
+check('a problem marks the tab it is on',
+  JSON.stringify(tabsWithProblems({ name: 'nameRequired', writeCommunity: 'writeSameAsRead' })) === JSON.stringify(['identity', 'access']) &&
+  tabsWithProblems({}).length === 0);
+// Every problem deviceProblems can report, from devices wrong in every way: one
+// no tab holds would be a Save button greyed out for a reason nobody can see.
+const everyProblem = [
+  { ...fresh, name: '', port: 0, versions: ['v2c', 'v3'], community: '', users: [],
+    traps: { ...blankTraps(), destinations: [{ ...blankDestination(162), host: '' }], schedules: [{ ...blankSchedule(), every: 0 }] } },
+  { ...fresh, versions: [] },
+  { ...fresh, versions: ['v2c', 'v3'], writeCommunity: 'public', users: [{ ...blankV3(), authPass: 'short' }] },
+].flatMap((d) => Object.keys(deviceProblems(d)));
+const onTabs = EDITOR_TABS.flatMap((t) => t.fields);
+check('every problem is on a tab', everyProblem.every((k) => onTabs.includes(k)),
+  everyProblem.filter((k) => !onTabs.includes(k)).join());
+check('and the devices above are wrong in every way a tab names', onTabs.every((k) => everyProblem.includes(k)),
+  onTabs.filter((k) => !everyProblem.includes(k)).join());
 
 /* --- the port a target names --------------------------------------------- */
 
@@ -285,6 +323,14 @@ check('with no override of a port the target already names',
 const overruled = { ...settings, targetOverrides: { '127.0.0.1:1162': { port: 9999 } } };
 check("a port the target names wins over an override's", getEffectiveSettings(overruled, '127.0.0.1:1162').port === 1162);
 check('and over the default, with no override at all', getEffectiveSettings(settings, '127.0.0.1:1163').port === 1163);
+
+// A device on a bench is there to be written to: its target writes when it can.
+const writer = { ...view, users: [view.users[0], { ...view.users[1], write: true }] };
+const w3 = getEffectiveSettings(addDeviceAsTarget(settings, writer, creds).settings, '127.0.0.2');
+check('a device with a user who can write is a target as that user',
+  w3.v3.user === 'monitor' && w3.v3.authPass === 'monitor-pass', w3.v3.user);
+const wc = getEffectiveSettings(addDeviceAsTarget(settings, mac1, { ...creds, writeCommunity: 'wr1te' }).settings, '127.0.0.1:1161');
+check('and a device with a write community, with that community', wc.community === 'wr1te', wc.community);
 
 /* --- every model Go serves is named and described ------------------------ */
 

--- a/pkg/mib/rowstatus.go
+++ b/pkg/mib/rowstatus.go
@@ -1,0 +1,28 @@
+package mib
+
+import (
+	"strings"
+
+	"github.com/sleepinggenius2/gosmi"
+	"github.com/sleepinggenius2/gosmi/types"
+)
+
+// RowStatusColumn reports whether instance lies in a column whose SYNTAX is
+// RowStatus in a loaded MIB, and that column's OID: what a simulated agent
+// needs to create and destroy rows as RFC 2579 has an agent do, without a MIB
+// of its own. gosmi answers an OID with the closest node at or above it, which
+// for an instance of a column is the column.
+func (s *Service) RowStatusColumn(instance string) (string, bool) {
+	gosmiMu.Lock()
+	defer gosmiMu.Unlock()
+	id, err := types.OidFromString(strings.TrimPrefix(instance, "."))
+	if err != nil {
+		return "", false
+	}
+	node, err := gosmi.GetNodeByOID(id)
+	if err != nil || node.Kind != types.NodeColumn || node.Type == nil || node.Type.Name != "RowStatus" ||
+		len(node.Oid) >= len(id) {
+		return "", false
+	}
+	return node.Oid.String(), true
+}

--- a/pkg/mib/rowstatus_test.go
+++ b/pkg/mib/rowstatus_test.go
@@ -1,0 +1,22 @@
+package mib
+
+import (
+	"strings"
+	"testing"
+)
+
+// An instance of ifStackStatus — IF-MIB's RowStatus — is known as one, with its
+// column; an instance of another column, the column itself and an OID no MIB
+// describes are not.
+func TestARowStatusColumnIsFoundInTheMIB(t *testing.T) {
+	s := loadedService(t)
+	col, ok := s.RowStatusColumn(".1.3.6.1.2.1.31.1.2.1.3.5.6")
+	if !ok || strings.TrimPrefix(col, ".") != "1.3.6.1.2.1.31.1.2.1.3" {
+		t.Errorf("ifStackStatus.5.6: %q, %v", col, ok)
+	}
+	for _, not := range []string{"1.3.6.1.2.1.2.2.1.2.1", "1.3.6.1.2.1.31.1.2.1.3", "1.3.6.1.4.1.32473.1.2.3"} {
+		if col, ok := s.RowStatusColumn(not); ok {
+			t.Errorf("%s was taken for an instance of the RowStatus %s", not, col)
+		}
+	}
+}

--- a/pkg/simulator/agent.go
+++ b/pkg/simulator/agent.go
@@ -34,6 +34,9 @@ type Config struct {
 	Versions []string
 	// Community is what v1 and v2c are read with.
 	Community string
+	// WriteCommunity is what v1 and v2c write with (set.go), and read with as
+	// well; empty, nothing is written in v1 or v2c.
+	WriteCommunity string
 	// Users are the SNMPv3 users.
 	Users []User
 	// EngineID is the agent's snmpEngineID, 5 to 32 octets; see EngineID. It
@@ -52,6 +55,10 @@ type Config struct {
 	Traps Traps
 	// Faults are what the agent is made to do wrong; see Faults.
 	Faults Faults
+	// RowStatus tells an instance of a RowStatus column (RFC 2579) from any
+	// other, and names the column: that needs the MIB, which the agent does not
+	// have. Nil, rows are written like any instance and never destroyed whole.
+	RowStatus func(instance string) (column string, ok bool)
 }
 
 // Stats counts what an agent did with what it received — most of all what it
@@ -86,8 +93,10 @@ type counters struct {
 	unknownEngineIDs, unknownUserNames, unsupportedSecLevels, wrongDigests, notInTimeWindows,
 	decryptionErrors, unknownContexts, unknownPDUHandlers, faults atomic.Uint32
 	// What SNMPv2-MIB's snmp group counts besides: the requests by kind, the
-	// varbinds read, the answers and the notifications sent.
-	inGets, inGetNexts, inSets, inTotalReqVars, outGetResponses, outNoSuchNames, outTraps atomic.Uint32
+	// varbinds read and written, a community used for what it may not do, the
+	// answers and the notifications sent.
+	inGets, inGetNexts, inSets, inTotalReqVars, inTotalSetVars, badCommunityUses,
+	outGetResponses, outNoSuchNames, outTraps atomic.Uint32
 }
 
 // Agent is one simulated device answering on one socket.
@@ -102,8 +111,13 @@ type Agent struct {
 	users       map[string]*user
 	engineID    []byte
 	boots       uint32
-	tree        *tree
-	maxSize     int
+	// tree is what the agent answers. A SET replaces it whole (set.go), so a
+	// notification reading it from another goroutine never sees one half-made.
+	tree    atomic.Pointer[tree]
+	maxSize int
+	// writeCommunity writes in v1 and v2c; empty, nothing is written there.
+	writeCommunity []byte
+	rowStatus      func(string) (string, bool)
 	// notify sends the agent's notifications; nil when it has nowhere to.
 	notify *notifier
 
@@ -150,6 +164,16 @@ func NewAgent(cfg Config) (*Agent, error) {
 		}
 		a.community = []byte(cfg.Community)
 	}
+	if cfg.WriteCommunity != "" {
+		if !a.v1 && !a.v2c {
+			return nil, errors.New("simulator: a write community is for v1 and v2c")
+		}
+		if len(cfg.WriteCommunity) > maxCommunity || cfg.WriteCommunity == cfg.Community {
+			return nil, fmt.Errorf("simulator: a write community is 1 to %d octets, and not the read community", maxCommunity)
+		}
+		a.writeCommunity = []byte(cfg.WriteCommunity)
+	}
+	a.rowStatus = cfg.RowStatus
 	if a.v3 {
 		if len(cfg.EngineID) < 5 || len(cfg.EngineID) > 32 {
 			return nil, errors.New("simulator: an engine ID is 5 to 32 octets (RFC 3411)")
@@ -168,9 +192,11 @@ func NewAgent(cfg Config) (*Agent, error) {
 	// What only the agent knows — its own counters, and for v3 its engine —
 	// beside what the device answers.
 	objects := slices.Concat(cfg.Objects, agentObjects(a.v3, a.engineID, a.boots, cfg.Traps.OnAuthFailure))
-	if a.tree, err = newTree(objects); err != nil {
+	t, err := newTree(objects)
+	if err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
+	a.tree.Store(t)
 	if a.notify, err = newNotifier(a, cfg); err != nil {
 		return nil, fmt.Errorf("simulator: %w", err)
 	}
@@ -356,8 +382,11 @@ func (a *Agent) answerCommunity(ver gosnmp.SnmpVersion, msg []byte, c clock) []b
 		a.stats.parseErrors.Add(1)
 		return nil
 	}
-	// In constant time: the community is the only secret v1 and v2c have.
-	if subtle.ConstantTimeCompare([]byte(req.Community), a.community) != 1 {
+	// In constant time: the communities are the only secrets v1 and v2c have.
+	// The write community reads as well; the read community only reads.
+	read := subtle.ConstantTimeCompare([]byte(req.Community), a.community) == 1
+	write := len(a.writeCommunity) > 0 && subtle.ConstantTimeCompare([]byte(req.Community), a.writeCommunity) == 1
+	if !read && !write {
 		a.stats.badCommunities.Add(1)
 		a.authFailed()
 		return nil
@@ -374,7 +403,7 @@ func (a *Agent) answerCommunity(ver gosnmp.SnmpVersion, msg []byte, c clock) []b
 		a.stats.unknownPDUHandlers.Add(1)
 		return nil
 	}
-	out, err := fit(a.process(ver, req, c), bulkFloor(req), tooBig(ver, req), a.maxSize,
+	out, err := fit(a.process(ver, req, c, write), bulkFloor(req), tooBig(ver, req), a.maxSize,
 		func(ans answer) ([]byte, error) {
 			resp := &gosnmp.SnmpPacket{
 				Version:    ver,

--- a/pkg/simulator/agent_test.go
+++ b/pkg/simulator/agent_test.go
@@ -120,11 +120,12 @@ func TestSNMPv1(t *testing.T) {
 	}
 }
 
+// A device given no write community is written by nobody.
 func TestASetIsRefused(t *testing.T) {
 	a := startAgent(t, Config{Versions: []string{"v1", "v2c"}, Community: "public"})
 	for ver, want := range map[gosnmp.SnmpVersion]gosnmp.SNMPError{
-		gosnmp.Version2c: gosnmp.NotWritable,
-		gosnmp.Version1:  gosnmp.NoSuchName, // v1 has no notWritable (RFC 3584)
+		gosnmp.Version2c: gosnmp.NoAccess,
+		gosnmp.Version1:  gosnmp.NoSuchName, // v1 has no noAccess (RFC 3584)
 	} {
 		g := connect(t, manager(a, ver, "public"))
 		res, err := g.Set([]gosnmp.SnmpPDU{{Name: ".1.3.6.1.2.1.1.5.0", Type: gosnmp.OctetString, Value: "renamed"}})

--- a/pkg/simulator/agentobjects.go
+++ b/pkg/simulator/agentobjects.go
@@ -30,14 +30,14 @@ func agentObjects(v3 bool, engineID []byte, boots uint32, authenTraps bool) []Ob
 	count(snmp+"2.0", func(c *counters) uint32 { return c.outGetResponses.Load() + c.outTraps.Load() })
 	count(snmp+"3.0", load(func(c *counters) *atomic.Uint32 { return &c.badVersions }))
 	count(snmp+"4.0", load(func(c *counters) *atomic.Uint32 { return &c.badCommunities }))
-	count(snmp+"5.0", nothing) // a community used for what it may not do: nothing is writable
+	count(snmp+"5.0", load(func(c *counters) *atomic.Uint32 { return &c.badCommunityUses }))
 	count(snmp+"6.0", load(func(c *counters) *atomic.Uint32 { return &c.parseErrors }))
 	// What arrived in a response, which an agent receives none of.
 	for _, n := range []int{8, 9, 10, 11, 12} {
 		count(fmt.Sprintf(snmp+"%d.0", n), nothing)
 	}
 	count(snmp+"13.0", load(func(c *counters) *atomic.Uint32 { return &c.inTotalReqVars }))
-	count(snmp+"14.0", nothing) // no SET has succeeded
+	count(snmp+"14.0", load(func(c *counters) *atomic.Uint32 { return &c.inTotalSetVars }))
 	count(snmp+"15.0", load(func(c *counters) *atomic.Uint32 { return &c.inGets }))
 	count(snmp+"16.0", load(func(c *counters) *atomic.Uint32 { return &c.inGetNexts }))
 	count(snmp+"17.0", load(func(c *counters) *atomic.Uint32 { return &c.inSets }))

--- a/pkg/simulator/device.go
+++ b/pkg/simulator/device.go
@@ -31,7 +31,10 @@ type Device struct {
 	Port      int      `json:"port"`
 	Versions  []string `json:"versions"`
 	Community string   `json:"community"`
-	Users     []User   `json:"users"`
+	// WriteCommunity writes in v1 and v2c, and reads as well; empty, the
+	// device is read-only there. A secret, as the community is.
+	WriteCommunity string `json:"writeCommunity"`
+	Users          []User `json:"users"`
 	// EngineID is hex, given once when the device is created (NewEngineID)
 	// and never changed: managers cache it and localise their keys to it.
 	EngineID string `json:"engineId"`
@@ -93,6 +96,16 @@ func (d Device) Validate() error {
 	if (v1 || v2c) && (d.Community == "" || len(d.Community) > maxCommunity) {
 		return fmt.Errorf("v1 and v2c need a community of 1 to %d octets", maxCommunity)
 	}
+	if d.WriteCommunity != "" {
+		switch {
+		case !v1 && !v2c:
+			return errors.New("a write community is for v1 and v2c")
+		case len(d.WriteCommunity) > maxCommunity:
+			return fmt.Errorf("a write community is 1 to %d octets", maxCommunity)
+		case d.WriteCommunity == d.Community:
+			return errors.New("the write community is the read community: every manager reading would write")
+		}
+	}
 	if v3 {
 		if len(d.Users) == 0 {
 			return errors.New("v3 needs a user")
@@ -136,9 +149,10 @@ func (d Device) Validate() error {
 // user's passphrases by user name, and each destination's community by
 // destination ID.
 type DeviceSecrets struct {
-	Community    string                 `json:"community"`
-	Users        map[string]UserSecrets `json:"users"`
-	Destinations map[string]string      `json:"destinations"`
+	Community      string                 `json:"community"`
+	WriteCommunity string                 `json:"writeCommunity"`
+	Users          map[string]UserSecrets `json:"users"`
+	Destinations   map[string]string      `json:"destinations"`
 }
 
 // UserSecrets are one user's passphrases.
@@ -150,9 +164,10 @@ type UserSecrets struct {
 // Secrets is d's secrets and nothing else.
 func (d Device) Secrets() DeviceSecrets {
 	s := DeviceSecrets{
-		Community:    d.Community,
-		Users:        make(map[string]UserSecrets, len(d.Users)),
-		Destinations: make(map[string]string, len(d.Traps.Destinations)),
+		Community:      d.Community,
+		WriteCommunity: d.WriteCommunity,
+		Users:          make(map[string]UserSecrets, len(d.Users)),
+		Destinations:   make(map[string]string, len(d.Traps.Destinations)),
 	}
 	for _, u := range d.Users {
 		s.Users[u.Name] = UserSecrets{AuthPass: u.AuthPass, PrivPass: u.PrivPass}
@@ -165,7 +180,7 @@ func (d Device) Secrets() DeviceSecrets {
 
 // WithoutSecrets is d with its secrets blanked, sharing nothing with d.
 func (d Device) WithoutSecrets() Device {
-	d.Community = ""
+	d.Community, d.WriteCommunity = "", ""
 	d.Versions = slices.Clone(d.Versions)
 	d.Users = slices.Clone(d.Users)
 	for i := range d.Users {
@@ -180,7 +195,7 @@ func (d Device) WithoutSecrets() Device {
 
 // WithSecrets is d with s filled back in.
 func (d Device) WithSecrets(s DeviceSecrets) Device {
-	d.Community = s.Community
+	d.Community, d.WriteCommunity = s.Community, s.WriteCommunity
 	d.Versions = slices.Clone(d.Versions)
 	d.Users = slices.Clone(d.Users)
 	for i := range d.Users {
@@ -238,12 +253,13 @@ func (d Device) config() (Config, error) {
 		return Config{}, fmt.Errorf("engine ID: %w", err)
 	}
 	return Config{
-		Listen:      d.Listen(),
-		Versions:    d.Versions,
-		Community:   d.Community,
-		Users:       d.Users,
-		EngineID:    engineID,
-		EngineBoots: d.EngineBoots,
+		Listen:         d.Listen(),
+		Versions:       d.Versions,
+		Community:      d.Community,
+		WriteCommunity: d.WriteCommunity,
+		Users:          d.Users,
+		EngineID:       engineID,
+		EngineBoots:    d.EngineBoots,
 		Objects: m.build(Identity{Name: strings.TrimSpace(d.Name), Seed: deviceSeed(d.ID),
 			Location: strings.TrimSpace(d.Location), Contact: strings.TrimSpace(d.Contact)}),
 		Notifications: m.catalogue(),

--- a/pkg/simulator/devicefile.go
+++ b/pkg/simulator/devicefile.go
@@ -49,16 +49,17 @@ type DeviceFile struct {
 // boots, which a device imported is given anew. Two imports of one file are
 // two devices, with two engines no manager confuses.
 type FileDevice struct {
-	Name      string   `json:"name"`
-	Model     string   `json:"model"`
-	Address   string   `json:"address"`
-	Port      int      `json:"port"`
-	Versions  []string `json:"versions"`
-	Community string   `json:"community,omitempty"`
-	Users     []User   `json:"users,omitempty"`
-	Traps     Traps    `json:"traps"`
-	Location  string   `json:"location,omitempty"`
-	Contact   string   `json:"contact,omitempty"`
+	Name           string   `json:"name"`
+	Model          string   `json:"model"`
+	Address        string   `json:"address"`
+	Port           int      `json:"port"`
+	Versions       []string `json:"versions"`
+	Community      string   `json:"community,omitempty"`
+	WriteCommunity string   `json:"writeCommunity,omitempty"`
+	Users          []User   `json:"users,omitempty"`
+	Traps          Traps    `json:"traps"`
+	Location       string   `json:"location,omitempty"`
+	Contact        string   `json:"contact,omitempty"`
 }
 
 // ExportDevices is the file holding devices, their secrets in it or not.
@@ -80,7 +81,8 @@ func ExportDevices(devices []Device, withSecrets bool) ([]byte, error) {
 			traps.Schedules = []Schedule{}
 		}
 		f.Devices[i] = FileDevice{Name: d.Name, Model: d.Model, Address: d.Address, Port: d.Port,
-			Versions: slices.Clone(d.Versions), Community: d.Community, Users: slices.Clone(d.Users), Traps: traps,
+			Versions: slices.Clone(d.Versions), Community: d.Community, WriteCommunity: d.WriteCommunity,
+			Users: slices.Clone(d.Users), Traps: traps,
 			Location: d.Location, Contact: d.Contact}
 	}
 	raw, err := json.MarshalIndent(f, "", "  ")
@@ -132,7 +134,7 @@ func ParseDeviceFile(raw []byte) (DeviceFile, error) {
 // Device is the device fd describes, yet to be given an ID and an engine.
 func (fd FileDevice) Device() Device {
 	return Device{Name: strings.TrimSpace(fd.Name), Model: fd.Model, Address: strings.TrimSpace(fd.Address),
-		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community,
+		Port: fd.Port, Versions: slices.Clone(fd.Versions), Community: fd.Community, WriteCommunity: fd.WriteCommunity,
 		Users: slices.Clone(fd.Users), Traps: fd.Traps.clone(),
 		Location: strings.TrimSpace(fd.Location), Contact: strings.TrimSpace(fd.Contact)}
 }

--- a/pkg/simulator/devicefile_test.go
+++ b/pkg/simulator/devicefile_test.go
@@ -11,9 +11,9 @@ import (
 // were asked for and absent otherwise, and the file says which.
 func TestADeviceFileRoundTrips(t *testing.T) {
 	d := Device{ID: "0123456789abcdef", Name: "core-01", Model: "linux-server", Address: "127.0.0.2", Port: 1161,
-		Versions: []string{"v2c", "v3"}, Community: "s3cret-community",
+		Versions: []string{"v2c", "v3"}, Community: "s3cret-community", WriteCommunity: "wr1te-community",
 		Users: []User{{Name: "ops", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "auth-pass-1",
-			PrivProto: "AES", PrivPass: "priv-pass-1"}},
+			PrivProto: "AES", PrivPass: "priv-pass-1", Write: true}},
 		EngineID: "8000000903001122334455", EngineBoots: 7,
 		Traps: Traps{Destinations: []Destination{{ID: "d1", Host: "192.0.2.50", Port: 162, Version: "v2c",
 			Community: "trap-s3cret"}}, OnStart: true, Schedules: []Schedule{}}}
@@ -22,7 +22,7 @@ func TestADeviceFileRoundTrips(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, secret := range []string{"s3cret-community", "auth-pass-1", "priv-pass-1", "trap-s3cret"} {
+		for _, secret := range []string{"s3cret-community", "wr1te-community", "auth-pass-1", "priv-pass-1", "trap-s3cret"} {
 			if bytes.Contains(raw, []byte(secret)) != with {
 				t.Errorf("with secrets %v, the file holding %q is %v", with, secret, !with)
 			}

--- a/pkg/simulator/fleet.go
+++ b/pkg/simulator/fleet.go
@@ -16,6 +16,9 @@ var ErrRunning = errors.New("simulator: the device is already running")
 type Fleet struct {
 	mu     sync.Mutex
 	agents map[string]*Agent
+	// RowStatus is given to every device the fleet starts: see
+	// Config.RowStatus. Set before the first start.
+	RowStatus func(instance string) (column string, ok bool)
 }
 
 // NewFleet returns a fleet running nothing.
@@ -32,6 +35,7 @@ func (f *Fleet) Start(d Device) error {
 	if err != nil {
 		return err
 	}
+	cfg.RowStatus = f.RowStatus
 	// Outside the lock: localising the users' keys hashes a megabyte each.
 	a, err := NewAgent(cfg)
 	if err != nil {

--- a/pkg/simulator/model_test.go
+++ b/pkg/simulator/model_test.go
@@ -147,7 +147,7 @@ func TestEveryModelServesAWalk(t *testing.T) {
 			a := startAgent(t, Config{Versions: []string{"v2c"}, Community: "public", Objects: objects})
 			// Everything a request may read: the model's objects less those only a
 			// notification carries, and the agent's own.
-			readable := len(a.tree.entries)
+			readable := len(a.tree.Load().entries)
 			g := connect(t, manager(a, gosnmp.Version2c, "public"))
 			n := 0
 			// Both subtrees a device answers in: LLDP-MIB lives under

--- a/pkg/simulator/notify.go
+++ b/pkg/simulator/notify.go
@@ -631,7 +631,7 @@ func (a *Agent) objectsOf(n Notification, c clock) []gosnmp.SnmpPDU {
 		if err != nil {
 			continue
 		}
-		if e := a.tree.notification(id); e != nil {
+		if e := a.tree.Load().notification(id); e != nil {
 			out = append(out, e.varbind(c))
 		}
 	}
@@ -640,7 +640,7 @@ func (a *Agent) objectsOf(n Notification, c clock) []gosnmp.SnmpPDU {
 
 func (a *Agent) sysObjectID(c clock) (string, bool) {
 	id, _ := parseOID(oidSysObjectID)
-	e := a.tree.get(id)
+	e := a.tree.Load().get(id)
 	if e == nil || e.typ != gosnmp.ObjectIdentifier {
 		return "", false
 	}

--- a/pkg/simulator/package_test.go
+++ b/pkg/simulator/package_test.go
@@ -184,8 +184,8 @@ func TestAPackageServesAWalk(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	if n != len(a.tree.entries) {
-		t.Errorf("walked %d objects of %d", n, len(a.tree.entries))
+	if all := len(a.tree.Load().entries); n != all {
+		t.Errorf("walked %d objects of %d", n, all)
 	}
 	if s := a.Stats(); s.Faults != 0 {
 		t.Errorf("%d answers failed to encode", s.Faults)

--- a/pkg/simulator/pdu.go
+++ b/pkg/simulator/pdu.go
@@ -24,7 +24,7 @@ type answer struct {
 // for SNMPv1, whose errors are different. It counts what SNMPv2-MIB's snmp
 // group counts — the request on arrival, as net-snmp does, so that a GET of
 // snmpInGetRequests counts itself.
-func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock) answer {
+func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock, write bool) answer {
 	st := &a.stats
 	switch req.PDUType {
 	case gosnmp.GetRequest:
@@ -38,9 +38,13 @@ func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock)
 	}
 	ans, injected := a.injectedError(ver, req)
 	if !injected {
-		ans = a.dispatch(ver, req, c)
+		ans = a.dispatch(ver, req, c, write)
 	}
-	if ans.status == gosnmp.NoError && req.PDUType != gosnmp.SetRequest {
+	switch {
+	case ans.status != gosnmp.NoError:
+	case req.PDUType == gosnmp.SetRequest:
+		st.inTotalSetVars.Add(uint32(len(ans.vars)))
+	default:
 		st.inTotalReqVars.Add(uint32(len(ans.vars)))
 	}
 	if ans.status == gosnmp.NoSuchName {
@@ -50,7 +54,7 @@ func (a *Agent) process(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock)
 	return ans
 }
 
-func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock) answer {
+func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock, write bool) answer {
 	v1 := ver == gosnmp.Version1
 	switch req.PDUType {
 	case gosnmp.GetRequest:
@@ -60,11 +64,19 @@ func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock
 	case gosnmp.GetBulkRequest:
 		return a.getBulk(req, c)
 	}
-	// A SET. Nothing in a simulated device is writable yet; SNMPv1 has no
-	// notWritable, and RFC 3584 has a v1 agent say noSuchName instead.
-	status := gosnmp.NotWritable
+	if write {
+		return a.set(ver, req)
+	}
+	// A SET from a manager that only reads: nothing is in the view it may
+	// write, which RFC 3416 4.2.5 answers noAccess — net-snmp's answer to a
+	// rocommunity or a rouser. SNMPv1 has no noAccess, and RFC 3584 has a v1
+	// agent say noSuchName instead. A community used so is counted.
+	if ver != gosnmp.Version3 {
+		a.stats.badCommunityUses.Add(1)
+	}
+	status := gosnmp.NoAccess
 	if v1 {
-		status = gosnmp.NoSuchName
+		status = v1Status(status)
 	}
 	return answer{vars: req.Variables, status: status, index: errIndex(0, len(req.Variables))}
 }
@@ -75,12 +87,13 @@ func (a *Agent) dispatch(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket, c clock
 func v1Hidden(e *entry) bool { return e.typ == gosnmp.Counter64 }
 
 func (a *Agent) get(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
+	t := a.tree.Load()
 	out := make([]gosnmp.SnmpPDU, len(vars))
 	for i, v := range vars {
 		id, err := parseArcs(v.Name)
 		var e *entry
 		if err == nil {
-			e = a.tree.get(id)
+			e = t.get(id)
 		}
 		switch {
 		case e != nil && !(v1 && v1Hidden(e)):
@@ -88,7 +101,7 @@ func (a *Agent) get(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
 		case v1:
 			return answer{vars: vars, status: gosnmp.NoSuchName, index: errIndex(i, len(vars))}
 		default:
-			out[i] = gosnmp.SnmpPDU{Name: v.Name, Type: a.tree.missing(id)}
+			out[i] = gosnmp.SnmpPDU{Name: v.Name, Type: t.missing(id)}
 		}
 	}
 	return answer{vars: out}
@@ -99,12 +112,13 @@ func (a *Agent) getNext(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
 	if v1 {
 		skip = v1Hidden
 	}
+	t := a.tree.Load()
 	out := make([]gosnmp.SnmpPDU, len(vars))
 	for i, v := range vars {
 		// A name that does not parse is placed before every object, so its
 		// successor is the first one.
 		id, _ := parseArcs(v.Name)
-		switch e := a.tree.next(id, skip); {
+		switch e := t.next(id, skip); {
 		case e != nil:
 			out[i] = e.varbind(c)
 		case v1:
@@ -120,6 +134,7 @@ func (a *Agent) getNext(v1 bool, vars []gosnmp.SnmpPDU, c clock) answer {
 // GETNEXT, then the rest max-repetitions times, each repetition carrying on
 // from the one before.
 func (a *Agent) getBulk(req *gosnmp.SnmpPacket, c clock) answer {
+	t := a.tree.Load()
 	vars := req.Variables
 	n := min(int(req.NonRepeaters), len(vars))
 	out := a.getNext(false, vars[:n], c).vars
@@ -133,7 +148,7 @@ func (a *Agent) getBulk(req *gosnmp.SnmpPacket, c clock) answer {
 	for rep := 0; rep < int(req.MaxRepetitions) && len(repeaters) > 0 && len(out)+len(repeaters) <= maxBulk; rep++ {
 		ended := true
 		for j := range repeaters {
-			if e := a.tree.next(last[j], nil); e != nil {
+			if e := t.next(last[j], nil); e != nil {
 				out = append(out, e.varbind(c))
 				last[j], names[j], ended = e.oid, e.name, false
 			} else {

--- a/pkg/simulator/set.go
+++ b/pkg/simulator/set.go
@@ -1,0 +1,264 @@
+package simulator
+
+import (
+	"bytes"
+	"errors"
+	"maps"
+	"math"
+	"slices"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+// A device written to. A SET from a manager allowed to write — the write
+// community, or a v3 user with write access — changes what the device answers
+// until it restarts, as a running agent's configuration does until it is saved.
+// RFC 3416 4.2.5: every varbind is checked before any is applied, and a SET is
+// applied whole or not at all.
+//
+// Everything a manager reads may be written, except what the agent answers
+// itself — its counters, its engine, the USM and the VACM — and an object only
+// a notification carries. A varbind naming an instance nothing answers creates
+// it, when it would sit in the tree the way an instance does: a leaf, under no
+// other instance and with none under it. That is what lets a table be given a
+// row.
+//
+// Rows proper need the MIB: which column is a RowStatus (RFC 2579). The agent
+// has no MIB, so it is told (Config.RowStatus), and it then does what RFC 2579
+// has an agent do — createAndGo makes the row active, createAndWait
+// notInService, destroy removes every instance of the row — and refuses what the
+// RFC refuses.
+
+// The values of a RowStatus (RFC 2579).
+const (
+	rowActive        = 1
+	rowNotInService  = 2
+	rowCreateAndGo   = 4
+	rowCreateAndWait = 5
+	rowDestroy       = 6
+)
+
+// change is one varbind of a SET, checked and ready to apply.
+type change struct {
+	id  oid
+	typ gosnmp.Asn1BER
+	val any
+	// destroy removes a row — every instance under entry whose index is index
+	// — rather than writing a value.
+	destroy      bool
+	entry, index oid
+}
+
+// set answers a SET from a manager allowed to write. Requests are handled on
+// the receive goroutine alone, so no other SET comes between the Load and the
+// Store: notifications only read the tree.
+func (a *Agent) set(ver gosnmp.SnmpVersion, req *gosnmp.SnmpPacket) answer {
+	t := a.tree.Load()
+	fail := func(i int, status gosnmp.SNMPError) answer {
+		if ver == gosnmp.Version1 {
+			status = v1Status(status)
+		}
+		return answer{vars: req.Variables, status: status, index: errIndex(i, len(req.Variables))}
+	}
+	changes := make([]change, 0, len(req.Variables))
+	for i, v := range req.Variables {
+		id, err := parseArcs(v.Name)
+		if err != nil || len(id) < 2 {
+			return fail(i, gosnmp.NoCreation)
+		}
+		if slices.ContainsFunc(agentSubtrees, id.hasPrefix) || t.notifyOnly[id.String()] != nil {
+			return fail(i, gosnmp.NotWritable)
+		}
+		e := t.get(id)
+		switch {
+		case e != nil && v.Type != e.typ:
+			return fail(i, gosnmp.WrongType)
+		case e == nil && !t.placeable(id):
+			return fail(i, gosnmp.NoCreation)
+		}
+		val, status := setValue(v.Type, v.Value)
+		if status != gosnmp.NoError {
+			return fail(i, status)
+		}
+		ch := change{id: id, typ: v.Type, val: val}
+		if column, ok := a.rowStatusColumn(id); ok {
+			asked, isInt := val.(int)
+			if !isInt {
+				return fail(i, gosnmp.WrongType)
+			}
+			next, status := rowStatus(e != nil, asked)
+			switch {
+			case status != gosnmp.NoError:
+				return fail(i, status)
+			case next == rowDestroy:
+				ch = change{id: id, destroy: true, entry: column[:len(column)-1], index: id[len(column):]}
+			default:
+				ch.val = next
+			}
+		}
+		changes = append(changes, ch)
+	}
+	next, err := t.with(changes)
+	if err != nil {
+		// Two instances of one SET, one under the other.
+		return fail(0, gosnmp.NoCreation)
+	}
+	a.tree.Store(next)
+	return answer{vars: req.Variables}
+}
+
+// rowStatusColumn is the RowStatus column id is an instance of, when the agent
+// has been told of one.
+func (a *Agent) rowStatusColumn(id oid) (oid, bool) {
+	if a.rowStatus == nil {
+		return nil, false
+	}
+	name, ok := a.rowStatus(id.String())
+	if !ok {
+		return nil, false
+	}
+	column, err := parseOID(name)
+	if err != nil || len(id) <= len(column) || !id.hasPrefix(column) {
+		return nil, false
+	}
+	return column, true
+}
+
+// rowStatus is what a RowStatus is set to, from what a manager asked for and
+// whether the row exists (RFC 2579): the row made active or notInService, kept
+// as it is asked to be, or destroyed — or the error the RFC answers instead.
+func rowStatus(exists bool, asked int) (int, gosnmp.SNMPError) {
+	switch asked {
+	case rowCreateAndGo, rowCreateAndWait:
+		if exists {
+			return 0, gosnmp.InconsistentValue
+		}
+		if asked == rowCreateAndGo {
+			return rowActive, gosnmp.NoError
+		}
+		return rowNotInService, gosnmp.NoError
+	case rowActive, rowNotInService:
+		if !exists {
+			return 0, gosnmp.InconsistentValue
+		}
+		return asked, gosnmp.NoError
+	case rowDestroy:
+		return rowDestroy, gosnmp.NoError
+	}
+	// notReady(3) is the agent's to say, never a manager's to set.
+	return 0, gosnmp.WrongValue
+}
+
+// setValue is a varbind's value in the Go type Const holds for its type, or
+// the error a SET carrying it earns.
+func setValue(t gosnmp.Asn1BER, v any) (any, gosnmp.SNMPError) {
+	var out any
+	switch t {
+	case gosnmp.Integer:
+		n := gosnmp.ToBigInt(v)
+		if !n.IsInt64() || n.Int64() < math.MinInt32 || n.Int64() > math.MaxInt32 {
+			return nil, gosnmp.WrongValue
+		}
+		out = int(n.Int64())
+	case gosnmp.OctetString, gosnmp.Opaque:
+		switch b := v.(type) {
+		case []byte:
+			out = bytes.Clone(b)
+		case string:
+			out = []byte(b)
+		default:
+			return nil, gosnmp.WrongValue
+		}
+	case gosnmp.ObjectIdentifier, gosnmp.IPAddress:
+		s, ok := v.(string)
+		if !ok {
+			return nil, gosnmp.WrongValue
+		}
+		out = s
+	case gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks:
+		n := gosnmp.ToBigInt(v)
+		if !n.IsUint64() || n.Uint64() > math.MaxUint32 {
+			return nil, gosnmp.WrongValue
+		}
+		out = uint32(n.Uint64())
+	case gosnmp.Counter64:
+		n := gosnmp.ToBigInt(v)
+		if !n.IsUint64() {
+			return nil, gosnmp.WrongValue
+		}
+		out = n.Uint64()
+	default:
+		return nil, gosnmp.WrongType
+	}
+	if err := checkValue(t, out); err != nil {
+		return nil, gosnmp.WrongValue
+	}
+	return out, gosnmp.NoError
+}
+
+// v1Status is an SNMPv2 error as an SNMPv1 agent answers it (RFC 3584 4.4).
+func v1Status(s gosnmp.SNMPError) gosnmp.SNMPError {
+	switch s {
+	case gosnmp.WrongValue, gosnmp.WrongEncoding, gosnmp.WrongType, gosnmp.WrongLength, gosnmp.InconsistentValue:
+		return gosnmp.BadValue
+	case gosnmp.NoAccess, gosnmp.NotWritable, gosnmp.NoCreation, gosnmp.InconsistentName, gosnmp.AuthorizationError:
+		return gosnmp.NoSuchName
+	case gosnmp.ResourceUnavailable, gosnmp.CommitFailed, gosnmp.UndoFailed:
+		return gosnmp.GenErr
+	}
+	return s
+}
+
+// placeable reports whether an instance could be made at o: a leaf, lying
+// under no instance and with none under it.
+func (t *tree) placeable(o oid) bool {
+	i, found := t.find(o)
+	switch {
+	case found:
+		return false
+	case i < len(t.entries) && t.entries[i].oid.hasPrefix(o):
+		return false
+	case i > 0 && o.hasPrefix(t.entries[i-1].oid):
+		return false
+	}
+	return true
+}
+
+// with is t with changes applied. t is left as it is — a request reading it
+// meanwhile sees it whole — and the tree returned shares none of its entries.
+func (t *tree) with(changes []change) (*tree, error) {
+	next := &tree{entries: slices.Clone(t.entries), objects: t.objects, notifyOnly: t.notifyOnly}
+	var made []oid
+	for _, ch := range changes {
+		if ch.destroy {
+			next.entries = slices.DeleteFunc(next.entries, func(e entry) bool { return inRow(e.oid, ch.entry, ch.index) })
+			continue
+		}
+		e := entry{oid: ch.id, name: ch.id.String(), typ: ch.typ, val: Const(ch.val)}
+		i, found := next.find(ch.id)
+		if found {
+			next.entries[i] = e
+			continue
+		}
+		next.entries = slices.Insert(next.entries, i, e)
+		made = append(made, ch.id)
+	}
+	for i := 1; i < len(next.entries); i++ {
+		if next.entries[i].oid.hasPrefix(next.entries[i-1].oid) {
+			return nil, errors.New("an instance lies under another")
+		}
+	}
+	if len(made) > 0 {
+		next.objects = maps.Clone(t.objects)
+		for _, id := range made {
+			next.objects[id[:len(id)-1].String()] = true
+		}
+	}
+	return next, nil
+}
+
+// inRow reports whether o is an instance of the row index names under entry:
+// entry, then a column, then the index.
+func inRow(o, entry, index oid) bool {
+	return len(o) == len(entry)+1+len(index) && o.hasPrefix(entry) && slices.Equal(o[len(entry)+1:], index)
+}

--- a/pkg/simulator/set_test.go
+++ b/pkg/simulator/set_test.go
@@ -1,0 +1,195 @@
+package simulator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+const (
+	sysContactOID  = ".1.3.6.1.2.1.1.4.0"
+	sysLocationOID = ".1.3.6.1.2.1.1.6.0"
+)
+
+// writable is a device answering v1 and v2c, read with "public" and written
+// with "private", holding a contact, a location and a table whose third column
+// the agent is told is a RowStatus.
+func writable(t *testing.T) *Agent {
+	t.Helper()
+	return startAgent(t, Config{
+		Versions: []string{"v1", "v2c"}, Community: "public", WriteCommunity: "private",
+		Objects: []Object{
+			{OID: sysContactOID, Type: gosnmp.OctetString, Value: Const("noc@example.net")},
+			{OID: sysLocationOID, Type: gosnmp.OctetString, Value: Const("Lab")},
+			{OID: "1.3.6.1.4.1.32473.10.1.2.1", Type: gosnmp.OctetString, Value: Const("first")},
+			{OID: "1.3.6.1.4.1.32473.10.1.3.1", Type: gosnmp.Integer, Value: Const(rowActive)},
+		},
+		RowStatus: func(o string) (string, bool) {
+			if strings.HasPrefix(o, ".1.3.6.1.4.1.32473.10.1.3.") {
+				return ".1.3.6.1.4.1.32473.10.1.3", true
+			}
+			return "", false
+		},
+	})
+}
+
+func setOne(t *testing.T, g *gosnmp.GoSNMP, vars ...gosnmp.SnmpPDU) *gosnmp.SnmpPacket {
+	t.Helper()
+	res, err := g.Set(vars)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res
+}
+
+func getOne(t *testing.T, g *gosnmp.GoSNMP, name string) gosnmp.SnmpPDU {
+	t.Helper()
+	res, err := g.Get([]string{name})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res.Variables[0]
+}
+
+// The read community reads and does not write — noAccess in v2c, the
+// noSuchName RFC 3584 has a v1 agent say instead, and counted as a community
+// used for what it may not do — and the write community writes, and reads too.
+func TestOnlyTheWriteCommunityWrites(t *testing.T) {
+	a := writable(t)
+	contact := gosnmp.SnmpPDU{Name: sysContactOID, Type: gosnmp.OctetString, Value: "ops@example.net"}
+	if res := setOne(t, connect(t, manager(a, gosnmp.Version2c, "public")), contact); res.Error != gosnmp.NoAccess {
+		t.Errorf("v2c, read community: %v", res.Error)
+	}
+	if res := setOne(t, connect(t, manager(a, gosnmp.Version1, "public")), contact); res.Error != gosnmp.NoSuchName {
+		t.Errorf("v1, read community: %v", res.Error)
+	}
+	if n := a.stats.badCommunityUses.Load(); n != 2 {
+		t.Errorf("snmpInBadCommunityUses is %d", n)
+	}
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	if res := setOne(t, w, contact); res.Error != gosnmp.NoError {
+		t.Fatalf("v2c, write community: %v", res.Error)
+	}
+	if v := getOne(t, connect(t, manager(a, gosnmp.Version2c, "public")), sysContactOID); text(v) != "ops@example.net" {
+		t.Errorf("read back as %q", text(v))
+	}
+	if v := getOne(t, w, sysLocationOID); text(v) != "Lab" {
+		t.Errorf("the write community reads %q", text(v))
+	}
+	if n := a.stats.inTotalSetVars.Load(); n != 1 {
+		t.Errorf("snmpInTotalSetVars is %d", n)
+	}
+}
+
+// A SET is applied whole or not at all, and an error names its varbind; a v1
+// manager is told badValue where v2c says wrongType.
+func TestASetIsAppliedWholeOrNotAtAll(t *testing.T) {
+	a := writable(t)
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	res := setOne(t, w,
+		gosnmp.SnmpPDU{Name: sysContactOID, Type: gosnmp.OctetString, Value: "changed"},
+		gosnmp.SnmpPDU{Name: sysLocationOID, Type: gosnmp.Integer, Value: 7})
+	if res.Error != gosnmp.WrongType || res.ErrorIndex != 2 {
+		t.Errorf("a location written as an INTEGER: %v at %d", res.Error, res.ErrorIndex)
+	}
+	if v := getOne(t, w, sysContactOID); text(v) != "noc@example.net" {
+		t.Errorf("half a SET was applied: the contact is %q", text(v))
+	}
+	v1 := connect(t, manager(a, gosnmp.Version1, "private"))
+	if res := setOne(t, v1, gosnmp.SnmpPDU{Name: sysLocationOID, Type: gosnmp.Integer, Value: 7}); res.Error != gosnmp.BadValue {
+		t.Errorf("v1: %v", res.Error)
+	}
+}
+
+// What the agent answers itself is not written, and an instance under another
+// is not made; an instance nothing answered is, and a walk finds it.
+func TestASetCreatesAnInstanceWhereOneCanBe(t *testing.T) {
+	a := writable(t)
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.2.1.11.30.0", Type: gosnmp.Integer, Value: 1}); res.Error != gosnmp.NotWritable {
+		t.Errorf("snmpEnableAuthenTraps: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: sysContactOID + ".1", Type: gosnmp.Integer, Value: 1}); res.Error != gosnmp.NoCreation {
+		t.Errorf("under an instance: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.4.1.32473.9.1.0", Type: gosnmp.Gauge32, Value: uint(42)}); res.Error != gosnmp.NoError {
+		t.Fatalf("a new instance: %v", res.Error)
+	}
+	res, err := w.GetNext([]string{".1.3.6.1.4.1.32473.9"})
+	if err != nil || res.Variables[0].Name != ".1.3.6.1.4.1.32473.9.1.0" || gosnmp.ToBigInt(res.Variables[0].Value).Int64() != 42 {
+		t.Errorf("the walk finds %v, %v", res, err)
+	}
+}
+
+// A row is made through its RowStatus — createAndGo leaves it active — and
+// destroyed through it with every instance it has; what RFC 2579 refuses is
+// refused.
+func TestRowsAreMadeAndDestroyedThroughTheirRowStatus(t *testing.T) {
+	a := writable(t)
+	w := connect(t, manager(a, gosnmp.Version2c, "private"))
+	const name, status = ".1.3.6.1.4.1.32473.10.1.2.5", ".1.3.6.1.4.1.32473.10.1.3.5"
+	if res := setOne(t, w,
+		gosnmp.SnmpPDU{Name: name, Type: gosnmp.OctetString, Value: "fifth"},
+		gosnmp.SnmpPDU{Name: status, Type: gosnmp.Integer, Value: rowCreateAndGo}); res.Error != gosnmp.NoError {
+		t.Fatalf("createAndGo: %v", res.Error)
+	}
+	if v := getOne(t, w, status); gosnmp.ToBigInt(v.Value).Int64() != rowActive {
+		t.Errorf("a row made with createAndGo is %v", v.Value)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: status, Type: gosnmp.Integer, Value: rowCreateAndWait}); res.Error != gosnmp.InconsistentValue {
+		t.Errorf("createAndWait on a row that exists: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: status, Type: gosnmp.Integer, Value: rowDestroy}); res.Error != gosnmp.NoError {
+		t.Fatalf("destroy: %v", res.Error)
+	}
+	for _, gone := range []string{name, status} {
+		if v := getOne(t, w, gone); v.Type != gosnmp.NoSuchInstance && v.Type != gosnmp.NoSuchObject {
+			t.Errorf("%s outlived its row: %v", gone, v.Value)
+		}
+	}
+	if v := getOne(t, w, ".1.3.6.1.4.1.32473.10.1.2.1"); text(v) != "first" {
+		t.Errorf("destroying row 5 touched row 1: %v", v.Value)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.4.1.32473.10.1.3.7", Type: gosnmp.Integer, Value: rowActive}); res.Error != gosnmp.InconsistentValue {
+		t.Errorf("active on a row that does not exist: %v", res.Error)
+	}
+	if res := setOne(t, w, gosnmp.SnmpPDU{Name: ".1.3.6.1.4.1.32473.10.1.3.8", Type: gosnmp.Integer, Value: 3}); res.Error != gosnmp.WrongValue {
+		t.Errorf("notReady: %v", res.Error)
+	}
+}
+
+// A v3 user writes only with write access, and what a device was written
+// holds until it restarts: a new agent answers as configured.
+func TestAV3UserWritesWithWriteAccessUntilTheDeviceRestarts(t *testing.T) {
+	cfg := Config{Versions: []string{"v3"}, EngineID: testEngineID, EngineBoots: 1,
+		Users: []User{
+			{Name: "reader", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "authpass-1", PrivProto: "AES", PrivPass: "privpass-1"},
+			{Name: "writer", SecLevel: "AuthPriv", AuthProto: "SHA256", AuthPass: "authpass-2", PrivProto: "AES", PrivPass: "privpass-2", Write: true},
+		},
+		Objects: []Object{{OID: sysContactOID, Type: gosnmp.OctetString, Value: Const("noc@example.net")}},
+	}
+	a := startAgent(t, cfg)
+	as := func(name, auth, priv string) *gosnmp.GoSNMP {
+		return connect(t, v3Manager(a, name, gosnmp.AuthPriv, gosnmp.SHA256, auth, gosnmp.AES, priv))
+	}
+	contact := gosnmp.SnmpPDU{Name: sysContactOID, Type: gosnmp.OctetString, Value: "written"}
+	if res := setOne(t, as("reader", "authpass-1", "privpass-1"), contact); res.Error != gosnmp.NoAccess {
+		t.Errorf("a user without write access: %v", res.Error)
+	}
+	writer := as("writer", "authpass-2", "privpass-2")
+	if res := setOne(t, writer, contact); res.Error != gosnmp.NoError {
+		t.Fatalf("a user with write access: %v", res.Error)
+	}
+	if v := getOne(t, writer, sysContactOID); text(v) != "written" {
+		t.Errorf("read back as %q", text(v))
+	}
+
+	a.Stop()
+	cfg.EngineBoots = 2
+	again := startAgent(t, cfg)
+	g := connect(t, v3Manager(again, "reader", gosnmp.AuthPriv, gosnmp.SHA256, "authpass-1", gosnmp.AES, "privpass-1"))
+	if v := getOne(t, g, sysContactOID); text(v) != "noc@example.net" {
+		t.Errorf("a write outlived the restart: %q", text(v))
+	}
+}

--- a/pkg/simulator/usm.go
+++ b/pkg/simulator/usm.go
@@ -49,6 +49,8 @@ type User struct {
 	AuthPass  string `json:"authPass"`
 	PrivProto string `json:"privProto"` // DES, AES, AES192, AES256, AES192C or AES256C
 	PrivPass  string `json:"privPass"`
+	// Write lets the user SET; a user without it only reads.
+	Write bool `json:"write"`
 }
 
 // The names pkg/snmp maps, mapped the same way; TestSnmpLensReadsTheSimulator
@@ -91,6 +93,7 @@ type user struct {
 	priv    gosnmp.SnmpV3PrivProtocol
 	authKey []byte
 	privKey []byte
+	write   bool
 }
 
 func newUsers(list []User, engineID []byte) (map[string]*user, error) {
@@ -119,7 +122,7 @@ func checkUser(u User) (*user, error) {
 	if !ok {
 		return nil, fmt.Errorf("user %q: %q is not a security level (NoAuthNoPriv, AuthNoPriv or AuthPriv)", u.Name, u.SecLevel)
 	}
-	r := &user{name: u.Name, level: level, auth: gosnmp.NoAuth, priv: gosnmp.NoPriv}
+	r := &user{name: u.Name, level: level, auth: gosnmp.NoAuth, priv: gosnmp.NoPriv, write: u.Write}
 	if level&gosnmp.AuthNoPriv != 0 {
 		if r.auth, ok = authProtocols[strings.ToUpper(u.AuthProto)]; !ok {
 			return nil, fmt.Errorf("user %q: %q is not an authentication protocol", u.Name, u.AuthProto)
@@ -271,7 +274,7 @@ func (a *Agent) answerV3(msg []byte, c clock) []byte {
 		// authorizationError, and nothing read.
 		ans = answer{vars: req.Variables, status: gosnmp.AuthorizationError}
 	} else {
-		ans = a.process(gosnmp.Version3, req, c)
+		ans = a.process(gosnmp.Version3, req, c, u.write)
 	}
 	out, err := fit(ans, bulkFloor(req), tooBig(gosnmp.Version3, req), min(a.maxSize, int(req.MsgMaxSize)),
 		func(ans answer) ([]byte, error) {

--- a/pkg/snmp/simulated_test.go
+++ b/pkg/snmp/simulated_test.go
@@ -13,7 +13,7 @@ import (
 // back through SnmpLens's own client. The target names its port and the port
 // field says 161: the target's port wins, as it does everywhere.
 func TestTheOperationsAgainstASimulatedSwitch(t *testing.T) {
-	d := simtest.Start(t, simulator.Device{Model: "cisco-catalyst-24", Name: "sw-floor-2"})
+	d := simtest.Start(t, simulator.Device{Model: "cisco-catalyst-24", Name: "sw-floor-2", WriteCommunity: "private"})
 	c := NewClient(context.Background())
 	targets := []string{d.Target()}
 	answer := func(t *testing.T, res []*BulkResult) *Result {
@@ -53,9 +53,17 @@ func TestTheOperationsAgainstASimulatedSwitch(t *testing.T) {
 		}
 	})
 	t.Run("SET", func(t *testing.T) {
-		res := c.Set(targets, "1.3.6.1.2.1.1.5.0", "public", "renamed", "OctetString", "v2c", 161, 2, 0, V3Params{})
-		if len(res) != 1 || !strings.Contains(strings.ToLower(res[0].Error), "notwritable") {
-			t.Errorf("a SET the device refuses came back as %+v", res[0])
+		// The read community reads and nothing more, as a rocommunity does.
+		res := c.Set(targets, "1.3.6.1.2.1.1.5.0", "public", "refused", "OctetString", "v2c", 161, 2, 0, V3Params{})
+		if len(res) != 1 || !strings.Contains(strings.ToLower(res[0].Error), "noaccess") {
+			t.Errorf("a SET with the read community came back as %+v", res[0])
+		}
+		res = c.Set(targets, "1.3.6.1.2.1.1.5.0", "private", "renamed", "OctetString", "v2c", 161, 2, 0, V3Params{})
+		if len(res) != 1 || res[0].Error != "" {
+			t.Fatalf("a SET with the write community came back as %+v", res[0])
+		}
+		if r := answer(t, c.Get(targets, "1.3.6.1.2.1.1.5.0", "public", "v2c", 161, 2, 0, V3Params{})); r.Value != "renamed" {
+			t.Errorf("sysName read back as %v", r.Value)
 		}
 	})
 }


### PR DESCRIPTION
Replaces #75, which GitHub closed when its base branch was deleted as #74 merged. The branch had already been rebased onto main — same commit, identical tree — so #75 could not be reopened.

## What

- **SET on simulated devices** (`pkg/simulator/set.go`). A SET from a manager allowed to write changes what the device answers **until it restarts**, as a running configuration does until it is saved. Every varbind is checked before any is applied (RFC 3416 4.2.5): wrong type → `wrongType`, a value out of range → `wrongValue`, the agent's own subtrees (snmp group, engine, USM, VACM) and notification-only objects → `notWritable`, an instance that cannot be placed → `noCreation`. An instance nothing answered is **created** when it would sit in the tree as an instance does, which is what lets a table gain a row. Errors are mapped for v1 per RFC 3584 4.4.
- **Write access.** A **write community** for v1/v2c — a secret, kept in the credential store beside the community, carried by a bench file only when its passwords are, and refused if it equals the read community — and a **per-user `write` flag** for SNMPv3.
- **RowStatus rows.** `createAndGo` makes the row `active`, `createAndWait` `notInService`, `destroy` removes every instance of the row; a create on an existing row, `active` on a missing one and `notReady` are refused as RFC 2579 says. Which column is a RowStatus comes from the **loaded MIBs** through a new `mib.Service.RowStatusColumn`, handed to the fleet in `app.go` (`Config.RowStatus`), so the agent stays free of gosmi.
- **Read-only managers** are answered `noAccess` — net-snmp's answer to a `rocommunity` / `rouser` — or `noSuchName` in v1, and counted in `snmpInBadCommunityUses`. `snmpInTotalSetVars` is now live.
- **Tabbed editor**: Device / Access / Notifications. A tab holding a problem carries a dot, so a greyed-out Save always has a visible reason; the Device tab shows the engine ID and boot count. New fields: write community, **Can write (SET)** per v3 user.
- **Add as target** now prefers identifiers that write: the first v3 user with write access, and the write community before the community.

## Design notes

- **The tree is replaced, not edited.** A SET builds a copy with its changes and swaps it in through an `atomic.Pointer[tree]`: notifications read the tree from their own goroutines, and neither they nor a GETBULK may see a SET half-applied. Requests are handled on the receive goroutine alone, so a Load and a Store never interleave with another SET.
- **Nothing written is saved.** A restart is a new `Agent` built from the model again, which is also what a manager expects of an unsaved running config.
- **`noAccess` rather than `notWritable`** for a read-only manager: `notWritable` says the *object* cannot be written, which is no longer true once a write community exists; `noAccess` says *this manager* may not.
- `RowStatusColumn` takes gosmi's lock once per varbind on the agent's receive goroutine, holding nothing of the agent's while it waits.

## Tests

- `pkg/simulator/set_test.go`: only the write community writes (and reads); a SET is applied whole or not at all, with v1's `badValue`; creation where an instance can sit and nowhere else; rows made and destroyed through their RowStatus, with every refusal; a v3 user writes only with write access, and nothing written outlives a restart.
- `pkg/mib/rowstatus_test.go`: `ifStackStatus` instances are recognised with their column; another column, the column itself and an unknown OID are not.
- `pkg/snmp/simulated_test.go`: SnmpLens's own client is refused with the read community, then writes with the write community and reads the value back.
- App: the write community stays in the credential store and out of the file and the list; a user's write flag survives the list.
- Frontend: editor/payload round trip of the write community and flags, the same-as-read problem, tab marking (every problem `deviceProblems` can report sits on a tab), Add as target's preference.

Run locally: `go vet`, `staticcheck`, `go test -race ./...`, `npm test`, `vite build`.
