### PR TITLE
Say how many times SnmpLens has been downloaded

### DIFF
--- a/docs/assets/github.js
+++ b/docs/assets/github.js
@@ -130,8 +130,12 @@
   // recorded when this was written. What is counted is the installers and the
   // archives — and it is DOWNLOADS, never users: applying an update fetches
   // the binary again, and nothing here can tell that from a new reader.
+  // Two tests rather than one alternation: in /checksums|\.sig$/ the anchor
+  // binds to its own branch alone, so it reads as "contains checksums, or ends
+  // in .sig" and is not what the engine does — CodeQL calls that out, rightly.
   function isBinary(asset) {
-    return !/checksums|\.sig$/i.test(asset.name || '');
+    var name = asset.name || '';
+    return !/checksums/i.test(name) && !/\.sig$/i.test(name);
   }
 
   function downloads() {

--- a/docs/assets/github.js
+++ b/docs/assets/github.js
@@ -122,6 +122,37 @@
     });
   }
 
+  /* --- how many times it has been downloaded ----------------------------- */
+
+  // The checksums file and its signature are NOT counted. The updater fetches
+  // both on every check it makes, so counting them would report the
+  // application's own traffic as people: 54 of the 303 downloads GitHub had
+  // recorded when this was written. What is counted is the installers and the
+  // archives — and it is DOWNLOADS, never users: applying an update fetches
+  // the binary again, and nothing here can tell that from a new reader.
+  function isBinary(asset) {
+    return !/checksums|\.sig$/i.test(asset.name || '');
+  }
+
+  function downloads() {
+    var slot = $('[data-stat="downloads"]');
+    if (!slot) return Promise.resolve();
+
+    // One page of releases. A hundred is far past what this project has, and
+    // paging for older ones would cost every visitor a second request to be
+    // exact about a number nobody reads to the unit.
+    return gh('/releases?per_page=100').then(function (rels) {
+      if (!rels || !rels.length) return; // settle() leaves the fallback
+      var total = 0;
+      rels.forEach(function (r) {
+        (r.assets || []).filter(isBinary).forEach(function (a) {
+          total += a.download_count || 0;
+        });
+      });
+      fill(slot, compact(total));
+    });
+  }
+
   /* --- latest release ---------------------------------------------------- */
 
   // The asset a visitor most likely wants, from what the browser will admit to.
@@ -375,7 +406,7 @@
   /* --- go ----------------------------------------------------------------- */
 
   function start() {
-    Promise.all([repoStats(), latestRelease(), contributors(), releaseHistory()])
+    Promise.all([repoStats(), downloads(), latestRelease(), contributors(), releaseHistory()])
       .catch(function () { settle(); })
       .then(function () { settle(); });
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -664,6 +664,10 @@ try {
         <dd><span class="skeleton" data-stat="forks" data-fallback="—">—</span></dd>
       </div>
       <div>
+        <dt>Downloads</dt>
+        <dd><span class="skeleton" data-stat="downloads" data-fallback="—">—</span></dd>
+      </div>
+      <div>
         <dt>Open issues</dt>
         <dd><span class="skeleton" data-stat="issues" data-fallback="—">—</span></dd>
       </div>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -10,7 +10,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://snmplens.com/</loc>
-    <lastmod>2026-09-11</lastmod>
+    <lastmod>2026-09-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
The home page's statistics strip now says how many times SnmpLens has been downloaded, beside the stars, the forks and the rest.

## What

- `docs/assets/github.js` sums `download_count` over one page of releases (`/releases?per_page=100`) and fills `[data-stat="downloads"]`.
- `docs/index.html` gains the slot, with the same skeleton and `data-fallback` as its neighbours.

## Two decisions in the figure

- **The checksums file and its signature are not counted.** The updater fetches both on every check it makes, so counting them would report the application's own traffic as people: 54 of the 303 downloads GitHub had recorded while writing this. What is counted is the installers and archives — **about 250** as this is written (Windows 182, Linux 37, macOS 30 at the last breakdown).
- **It says downloads, not users.** Applying an update fetches the binary again, and nothing here can tell that from a new reader.

It follows the rules the rest of the file states: it upgrades markup that reads correctly without it, the answer is cached in `sessionStorage` for the session, and a rate-limited, offline or script-blocked visitor keeps the fallback rather than a box that pulses forever. One request is added, on the home page only — the strip is nowhere else.

## Checked

The page served locally and opened in headless Chrome against the real API: the strip reads *Stars 8 · Forks 2 · Downloads 250 · Open issues 1 · Last commit · Latest release v1.5.0*, the slot has shed its skeleton class, and the console has no error. `node tools/check-assets.mjs` passes.
