### PR TITLE
Trust more than one updater key, so one can be rotated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,40 @@ jobs:
           go run ./tools/updatersign sign artifacts/SnmpLens-checksums.txt
           test -s artifacts/SnmpLens-checksums.txt.sig
 
+      # The signature is CHECKED here, with the application's own verification
+      # and the keys embedded in this very commit. `test -s` above proves a file
+      # was written and nothing more: a secret that is not one of those keys
+      # signs perfectly well and is refused by every updater it was meant to
+      # satisfy — a release nobody can install, found out by users rather than
+      # by the pipeline that published it.
+      - name: Check the signature against the embedded keys
+        run: |
+          go run ./tools/updatersign verify \
+            artifacts/SnmpLens-checksums.txt artifacts/SnmpLens-checksums.txt.sig
+
+      # A key staged for the next rotation is EXERCISED, never published: it
+      # signs a copy of the manifest, that signature is checked against the
+      # embedded keys, and the copy is thrown away. The release still carries
+      # exactly one signature, made with the key in service.
+      #
+      # Without this, a mistyped UPDATER_PRIVATE_KEY_NEXT is discovered at the
+      # moment the old key stops being used — the one moment it cannot be
+      # repaired, since the release that would fix it could no longer be signed
+      # with anything installed copies trust.
+      - name: Exercise the next signing key, if one is staged
+        env:
+          UPDATER_PRIVATE_KEY: ${{ secrets.UPDATER_PRIVATE_KEY_NEXT }}
+        run: |
+          if [ -z "$UPDATER_PRIVATE_KEY" ]; then
+            echo "No next key staged; nothing to exercise."
+            exit 0
+          fi
+          cp artifacts/SnmpLens-checksums.txt "$RUNNER_TEMP/next-manifest.txt"
+          go run ./tools/updatersign sign "$RUNNER_TEMP/next-manifest.txt"
+          go run ./tools/updatersign verify \
+            "$RUNNER_TEMP/next-manifest.txt" "$RUNNER_TEMP/next-manifest.txt.sig"
+          echo "The staged key signs a manifest the shipped binaries accept."
+
       # Signed, verifiable provenance for every published asset: which workflow,
       # which commit, which runner produced these exact bytes. It answers a
       # question the Ed25519 manifest signature does not — that signature proves

--- a/.github/workflows/updater-key-check.yml
+++ b/.github/workflows/updater-key-check.yml
@@ -1,0 +1,57 @@
+# Answers, on demand, the one question a write-only secret cannot: is the key
+# staged for the next rotation one the shipped binaries would accept?
+#
+# It signs a throwaway manifest with UPDATER_PRIVATE_KEY_NEXT and verifies that
+# signature through the application's own verification, against the public keys
+# embedded in this commit. Nothing is published, and the log carries public
+# halves only.
+#
+# Without it, a mistyped staged key is discovered when the release workflow
+# exercises it — better than at the rotation itself, but still late. This makes
+# the answer available the moment the key is deposited.
+#
+# It runs in the `keycheck` environment, which holds the STAGED key and nothing
+# else. The key in service lives in `release`, restricted to tags, and this
+# workflow must never be able to reach it.
+name: Check the staged updater key
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  staged-key:
+    name: Sign with the staged key and verify against the embedded ones
+    runs-on: ubuntu-latest
+    environment: keycheck
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Exercise the staged key
+        env:
+          UPDATER_PRIVATE_KEY: ${{ secrets.UPDATER_PRIVATE_KEY_NEXT }}
+        run: |
+          if [ -z "$UPDATER_PRIVATE_KEY" ]; then
+            echo "::error::UPDATER_PRIVATE_KEY_NEXT is not set in the keycheck environment." >&2
+            exit 1
+          fi
+
+          # The public half of the staged key, which is not a secret: it is what
+          # the binaries carry. An Ed25519 private key contains it, so this
+          # needs nothing else — and printing it is how a mismatch is READ,
+          # rather than merely reported.
+          echo "The staged key's public half:"
+          go run ./tools/updatersign pubkey
+
+          printf 'version v0.0.0-keycheck\n0000  nothing at all\n' > "$RUNNER_TEMP/manifest.txt"
+          go run ./tools/updatersign sign "$RUNNER_TEMP/manifest.txt"
+          go run ./tools/updatersign verify \
+            "$RUNNER_TEMP/manifest.txt" "$RUNNER_TEMP/manifest.txt.sig"
+
+          echo "The staged key is one the binaries built from this commit accept."

--- a/README.md
+++ b/README.md
@@ -339,10 +339,15 @@ Every release includes `SnmpLens-checksums.txt` (SHA-256 of all assets) and its 
 go run ./tools/updatersign keygen
 ```
 
-1. Paste the printed **public key** into `pkg/updater/verify.go` (`updaterPublicKey`).
+1. Add the printed **public key** to `pkg/updater/verify.go` (`updaterPublicKeys`).
 2. Store the printed **private key** as the `UPDATER_PRIVATE_KEY` secret of the `release` environment (*Settings → Environments → release*). That environment should carry a protection rule — a required reviewer or a tag policy — so a run has to be admitted before the key is handed to it.
 
-Rotation is not seamless: copies already installed trust only the public key they were built with, so they refuse updates signed with a new key and have to be updated by hand once.
+**Rotating the key** takes two releases, because a copy already installed trusts only the keys embedded in the binary it is running:
+
+1. Add the new key to `updaterPublicKeys` beside the current one, and publish that release **signed with the old key** — every copy can verify it, and from then on trusts both.
+2. Wait for it to be adopted. Nothing but time provides that, and it is the whole safety of the operation.
+3. Point `UPDATER_PRIVATE_KEY` at the new key. Copies that installed step 1 accept it; copies that skipped it cannot update again and have to be reinstalled by hand.
+4. Later, drop the retired key from the list — every key in it may install software on someone's machine, so one stays only while there are copies that trust nothing else.
 
 ---
 

--- a/pkg/updater/apply.go
+++ b/pkg/updater/apply.go
@@ -173,7 +173,7 @@ func (s *Service) verifiedChecksum(ctx context.Context, checksumURL, sigURL, ass
 		if err != nil {
 			return "", fmt.Errorf("fetching signature: %w", err)
 		}
-		if err := verifyManifestSignature(manifest, sig); err != nil {
+		if err := VerifySignature(manifest, sig); err != nil {
 			return "", err
 		}
 		// AFTER the signature, not before: an unsigned manifest's version line

--- a/pkg/updater/verify.go
+++ b/pkg/updater/verify.go
@@ -57,13 +57,18 @@ func signatureEnforced() bool {
 	return false
 }
 
-// verifyManifestSignature checks that sigBase64 is a valid Ed25519 signature of
+// VerifySignature is exported because the release workflow verifies with THIS
+// function rather than a second implementation: a pipeline that checks
+// differently from the application can publish a release the application then
+// refuses, which is the one failure the signature exists to prevent.
+//
+// VerifySignature checks that sigBase64 is a valid Ed25519 signature of
 // manifest under ONE of the embedded public keys.
 //
 // A malformed entry is passed over rather than fatal: it must not be able to
 // refuse a manifest the next key would have accepted, and a list where no entry
 // is usable at all is the one case that reads as a broken build.
-func verifyManifestSignature(manifest, sigBase64 []byte) error {
+func VerifySignature(manifest, sigBase64 []byte) error {
 	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(sigBase64)))
 	if err != nil {
 		return fmt.Errorf("decoding signature: %w", err)

--- a/pkg/updater/verify.go
+++ b/pkg/updater/verify.go
@@ -8,39 +8,86 @@ import (
 	"strings"
 )
 
-// updaterPublicKey is the base64-encoded Ed25519 public key whose private
-// counterpart signs SnmpLens-checksums.txt during the release workflow.
+// updaterPublicKeys are the base64-encoded Ed25519 public keys a release
+// manifest may be signed with — newest first. Their private counterparts sign
+// SnmpLens-checksums.txt in the release workflow; generate a pair with
+// `go run ./tools/updatersign keygen` and store the private half in the GitHub
+// secret UPDATER_PRIVATE_KEY.
 //
-// Generate a keypair with `go run ./tools/updatersign keygen`, paste the public
-// key here, and store the private key in the GitHub secret UPDATER_PRIVATE_KEY.
+// A LIST, and not one key, because of the order a rotation has to happen in. A
+// copy already installed trusts exactly the keys embedded in the binary it is
+// running, so a release signed with a key it has never heard of is refused —
+// including the release that would have introduced that key. The way through is
+// therefore:
 //
-// While this is empty, downloads are still integrity-checked with SHA-256 but
-// NOT authenticated. Set it to enforce that updates were signed by the release
-// pipeline. (A var rather than a const so the empty-default branch is not
-// flagged as dead code before a key is configured.)
-var updaterPublicKey = "svOWbkIuFQTiebt+DKzaohFFdeANV8NjcdX3cQiybPw="
+//  1. add the new key here, and publish that release SIGNED WITH THE OLD ONE,
+//     so every copy can install it;
+//  2. wait for it to be adopted — this is the whole safety of the operation,
+//     and nothing but time provides it;
+//  3. point UPDATER_PRIVATE_KEY at the new key. Copies that took step 1 accept
+//     it; copies that skipped it cannot update again and must be reinstalled by
+//     hand;
+//  4. later, drop the retired key from this list.
+//
+// Every entry is a key that may install software on someone's machine, so the
+// list holds what a transition needs and nothing more: a key stays only while
+// there are copies that trust nothing else.
+//
+// While the list is empty, downloads are still integrity-checked with SHA-256
+// but NOT authenticated. (A var rather than a const so the empty-default branch
+// is not flagged as dead code before a key is configured.)
+var updaterPublicKeys = []string{
+	// From the rotation of 2026-09: the key CI signs with once the release
+	// below has been adopted.
+	"TPh8H92qyRkMFpc1CXCJKp/G5jf4OTqlHd6Mx0BHljs=",
+	// The original key, which every copy published so far trusts — and the one
+	// the transition release is signed with. It goes when those copies have
+	// moved on.
+	"svOWbkIuFQTiebt+DKzaohFFdeANV8NjcdX3cQiybPw=",
+}
 
-// signatureEnforced reports whether a public key is configured, in which case a
-// valid signature on the checksums manifest is mandatory.
+// signatureEnforced reports whether any public key is configured, in which case
+// a valid signature on the checksums manifest is mandatory.
 func signatureEnforced() bool {
-	return updaterPublicKey != ""
+	for _, key := range updaterPublicKeys {
+		if strings.TrimSpace(key) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // verifyManifestSignature checks that sigBase64 is a valid Ed25519 signature of
-// manifest under the embedded public key.
+// manifest under ONE of the embedded public keys.
+//
+// A malformed entry is passed over rather than fatal: it must not be able to
+// refuse a manifest the next key would have accepted, and a list where no entry
+// is usable at all is the one case that reads as a broken build.
 func verifyManifestSignature(manifest, sigBase64 []byte) error {
-	pub, err := base64.StdEncoding.DecodeString(updaterPublicKey)
-	if err != nil || len(pub) != ed25519.PublicKeySize {
-		return errors.New("invalid embedded updater public key")
-	}
 	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(sigBase64)))
 	if err != nil {
 		return fmt.Errorf("decoding signature: %w", err)
 	}
-	if !ed25519.Verify(ed25519.PublicKey(pub), manifest, sig) {
-		return errors.New("checksums signature verification failed")
+
+	usable := 0
+	for _, encoded := range updaterPublicKeys {
+		encoded = strings.TrimSpace(encoded)
+		if encoded == "" {
+			continue
+		}
+		pub, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil || len(pub) != ed25519.PublicKeySize {
+			continue
+		}
+		usable++
+		if ed25519.Verify(ed25519.PublicKey(pub), manifest, sig) {
+			return nil
+		}
 	}
-	return nil
+	if usable == 0 {
+		return errors.New("invalid embedded updater public key")
+	}
+	return errors.New("checksums signature verification failed")
 }
 
 // manifestVersionLine is the first line the release workflow writes into the

--- a/pkg/updater/verify_test.go
+++ b/pkg/updater/verify_test.go
@@ -49,14 +49,14 @@ func TestSignatureIsCheckedAgainstTheEmbeddedKey(t *testing.T) {
 	if !signatureEnforced() {
 		t.Fatal("a configured key must make the signature mandatory")
 	}
-	if err := verifyManifestSignature(manifest, sig); err != nil {
+	if err := VerifySignature(manifest, sig); err != nil {
 		t.Errorf("a manifest signed with the matching key must verify: %v", err)
 	}
 
 	// One byte of the manifest, changed after signing.
 	tampered := append([]byte{}, manifest...)
 	tampered[0] ^= 0x01
-	if err := verifyManifestSignature(tampered, sig); err == nil {
+	if err := VerifySignature(tampered, sig); err == nil {
 		t.Error("a modified manifest verified against its old signature")
 	}
 
@@ -65,7 +65,7 @@ func TestSignatureIsCheckedAgainstTheEmbeddedKey(t *testing.T) {
 	if otherPub == pub {
 		t.Fatal("two generated keys collided")
 	}
-	if err := verifyManifestSignature(manifest, otherSig); err == nil {
+	if err := VerifySignature(manifest, otherSig); err == nil {
 		t.Error("a signature from another key was accepted")
 	}
 }
@@ -84,13 +84,13 @@ func TestARotationTrustsTheOldKeyAndTheNewOne(t *testing.T) {
 	}
 	withKeys(t, arriving, retiring)
 
-	if err := verifyManifestSignature(manifest, retiringSig); err != nil {
+	if err := VerifySignature(manifest, retiringSig); err != nil {
 		t.Errorf("the transition release, signed with the retiring key, must verify: %v", err)
 	}
-	if err := verifyManifestSignature(manifest, arrivingSig); err != nil {
+	if err := VerifySignature(manifest, arrivingSig); err != nil {
 		t.Errorf("the release after it, signed with the arriving key, must verify: %v", err)
 	}
-	if err := verifyManifestSignature(manifest, strangerSig); err == nil {
+	if err := VerifySignature(manifest, strangerSig); err == nil {
 		t.Error("trusting two keys must not amount to trusting any key")
 	}
 }
@@ -105,7 +105,7 @@ func TestAMalformedEntryDoesNotStopTheOthers(t *testing.T) {
 	if !signatureEnforced() {
 		t.Fatal("a configured key must make the signature mandatory")
 	}
-	if err := verifyManifestSignature(manifest, sig); err != nil {
+	if err := VerifySignature(manifest, sig); err != nil {
 		t.Errorf("a manifest signed with a listed key must verify: %v", err)
 	}
 }

--- a/pkg/updater/verify_test.go
+++ b/pkg/updater/verify_test.go
@@ -30,12 +30,12 @@ func signedManifest(t *testing.T, body string) (pub string, manifest, sig []byte
 		[]byte(base64.StdEncoding.EncodeToString(raw))
 }
 
-// withKey swaps the embedded public key for the duration of a test.
-func withKey(t *testing.T, key string) {
+// withKeys swaps the embedded public keys for the duration of a test.
+func withKeys(t *testing.T, keys ...string) {
 	t.Helper()
-	previous := updaterPublicKey
-	updaterPublicKey = key
-	t.Cleanup(func() { updaterPublicKey = previous })
+	previous := updaterPublicKeys
+	updaterPublicKeys = keys
+	t.Cleanup(func() { updaterPublicKeys = previous })
 }
 
 const manifestBody = "version v1.5.0\n" +
@@ -44,7 +44,7 @@ const manifestBody = "version v1.5.0\n" +
 
 func TestSignatureIsCheckedAgainstTheEmbeddedKey(t *testing.T) {
 	pub, manifest, sig := signedManifest(t, manifestBody)
-	withKey(t, pub)
+	withKeys(t, pub)
 
 	if !signatureEnforced() {
 		t.Fatal("a configured key must make the signature mandatory")
@@ -67,6 +67,57 @@ func TestSignatureIsCheckedAgainstTheEmbeddedKey(t *testing.T) {
 	}
 	if err := verifyManifestSignature(manifest, otherSig); err == nil {
 		t.Error("a signature from another key was accepted")
+	}
+}
+
+// A rotation, which is the reason the embedded key is a LIST.
+//
+// The release that introduces a new key has to be signed with the OLD one, or
+// no installed copy could verify it — including the copies the new key is meant
+// to reach. So for one release both are trusted, and the parc moves over.
+func TestARotationTrustsTheOldKeyAndTheNewOne(t *testing.T) {
+	retiring, manifest, retiringSig := signedManifest(t, manifestBody)
+	arriving, _, arrivingSig := signedManifest(t, manifestBody)
+	stranger, _, strangerSig := signedManifest(t, manifestBody)
+	if retiring == arriving || arriving == stranger {
+		t.Fatal("two generated keys collided")
+	}
+	withKeys(t, arriving, retiring)
+
+	if err := verifyManifestSignature(manifest, retiringSig); err != nil {
+		t.Errorf("the transition release, signed with the retiring key, must verify: %v", err)
+	}
+	if err := verifyManifestSignature(manifest, arrivingSig); err != nil {
+		t.Errorf("the release after it, signed with the arriving key, must verify: %v", err)
+	}
+	if err := verifyManifestSignature(manifest, strangerSig); err == nil {
+		t.Error("trusting two keys must not amount to trusting any key")
+	}
+}
+
+// An entry that is not a key must not be able to refuse a manifest the next
+// entry would have accepted: a typo in the list would otherwise stop every
+// update, which is exactly the failure a second key exists to avoid.
+func TestAMalformedEntryDoesNotStopTheOthers(t *testing.T) {
+	pub, manifest, sig := signedManifest(t, manifestBody)
+	withKeys(t, "not base64 at all", "", pub)
+
+	if !signatureEnforced() {
+		t.Fatal("a configured key must make the signature mandatory")
+	}
+	if err := verifyManifestSignature(manifest, sig); err != nil {
+		t.Errorf("a manifest signed with a listed key must verify: %v", err)
+	}
+}
+
+func TestNoKeyMeansTheSignatureIsNotEnforced(t *testing.T) {
+	withKeys(t)
+	if signatureEnforced() {
+		t.Error("an empty list enforces nothing")
+	}
+	withKeys(t, "", "   ")
+	if signatureEnforced() {
+		t.Error("blank entries are not keys")
 	}
 }
 

--- a/tools/updatersign/main.go
+++ b/tools/updatersign/main.go
@@ -20,6 +20,15 @@
 // which writes path/to/file.sig (base64-encoded Ed25519 signature). With no
 // key set, signing is skipped so unsigned builds keep working.
 //
+// Check a signature the way the APPLICATION checks it — against the keys
+// embedded in pkg/updater, in this source tree:
+//
+//	go run ./tools/updatersign verify path/to/file path/to/file.sig
+//
+// The release workflow runs that on what it is about to publish, so a release
+// cannot go out carrying a signature the binaries built from the same commit
+// would refuse.
+//
 // Ask which public key the configured secret corresponds to:
 //
 //	UPDATER_PRIVATE_KEY=<hex> go run ./tools/updatersign pubkey
@@ -38,6 +47,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"SnmpLens/pkg/updater"
 )
 
 func main() {
@@ -52,6 +63,11 @@ func main() {
 			usage()
 		}
 		sign(os.Args[2])
+	case "verify":
+		if len(os.Args) < 4 {
+			usage()
+		}
+		verifyFile(os.Args[2], os.Args[3])
 	case "pubkey":
 		pubkey()
 	default:
@@ -123,8 +139,30 @@ func sign(path string) {
 	fmt.Printf("updatersign: wrote %s\n", out)
 }
 
+// verifyFile checks a signature through pkg/updater's own verification, against
+// the public keys embedded in this source tree.
+//
+// The point is that it is the SAME code and the SAME list the shipped binaries
+// use. A secret that is not one of those keys signs perfectly and is refused by
+// every updater it was meant to satisfy — a release nobody can install, which
+// is discovered by users rather than by the pipeline that published it.
+func verifyFile(path, sigPath string) {
+	manifest, err := os.ReadFile(path)
+	if err != nil {
+		fatal(err)
+	}
+	sig, err := os.ReadFile(sigPath)
+	if err != nil {
+		fatal(err)
+	}
+	if err := updater.VerifySignature(manifest, sig); err != nil {
+		fatal(fmt.Errorf("%s is not accepted by the keys embedded in pkg/updater: %w", sigPath, err))
+	}
+	fmt.Printf("updatersign: %s is accepted by an embedded key\n", sigPath)
+}
+
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: updatersign keygen | sign <file> | pubkey")
+	fmt.Fprintln(os.Stderr, "usage: updatersign keygen | sign <file> | verify <file> <sig> | pubkey")
 	os.Exit(2)
 }
 

--- a/tools/updatersign/main.go
+++ b/tools/updatersign/main.go
@@ -5,8 +5,13 @@
 //
 //	go run ./tools/updatersign keygen
 //
-// Paste the printed public key into pkg/updater/verify.go (updaterPublicKey) and
+// Add the printed public key to pkg/updater/verify.go (updaterPublicKeys) and
 // store the private key in the GitHub Actions secret UPDATER_PRIVATE_KEY.
+//
+// ADD, not replace: a copy already installed trusts only the keys embedded in
+// the binary it is running, so the release that introduces a new key must be
+// signed with the old one. See the comment on updaterPublicKeys for the order a
+// rotation happens in.
 //
 // Sign a file (done automatically by .github/workflows/release.yml):
 //
@@ -59,7 +64,7 @@ func keygen() {
 	if err != nil {
 		fatal(err)
 	}
-	fmt.Println("Public key — paste into pkg/updater/verify.go (updaterPublicKey):")
+	fmt.Println("Public key — add to pkg/updater/verify.go (updaterPublicKeys):")
 	fmt.Println("  " + base64.StdEncoding.EncodeToString(pub))
 	fmt.Println()
 	fmt.Println("Private key — add as GitHub secret UPDATER_PRIVATE_KEY (keep secret!):")
@@ -68,8 +73,8 @@ func keygen() {
 
 // pubkey prints the public half of the configured private key.
 //
-// Compare it with updaterPublicKey in pkg/updater/verify.go: if they differ,
-// the secret is not the key installed copies trust, and every signature it
+// Compare it with updaterPublicKeys in pkg/updater/verify.go: if it is none of
+// them, the secret is not a key installed copies trust, and every signature it
 // makes will be refused by the updater it is meant to satisfy.
 func pubkey() {
 	key := loadKey()


### PR DESCRIPTION
The updater's embedded public key was a single string, which made the signing key impossible to rotate without breaking every installed copy. This is the first of the two releases a rotation takes — and it also makes the pipeline check what it is about to publish.

## Why a list

A copy already installed trusts exactly the keys embedded in the binary it is running. So a release signed with a key it has never heard of is refused — **including the release that would have introduced that key**. One key means one-way: lose it, or need to change it, and the only way out is every user reinstalling by hand.

`updaterPublicKeys` is now a list, and a manifest verifies if **any** entry accepts its signature. The rotation then goes:

1. add the new key beside the current one — **this PR** — and publish that release **signed with the old key**, so every copy can install it and trusts both from then on;
2. wait for it to be adopted. Nothing but time provides that, and it is the whole safety of the operation;
3. point `UPDATER_PRIVATE_KEY` at the new key. Copies that took step 1 accept it; copies that skipped it cannot update again and have to be reinstalled by hand;
4. later, drop the retired key: every entry may install software on somebody's machine, so one stays only while there are copies that trust nothing else.

**Nothing signs with the new key yet.** This release is signed with the current secret, as it has to be.

## The pipeline now checks what it publishes

`test -s …sig` proved a file had been written and nothing more. A secret that is not one of the embedded keys signs perfectly well and is refused by every updater it was meant to satisfy — a release nobody can install, discovered by users.

- **`updatersign verify <file> <sig>`** checks a signature through `updater.VerifySignature`, the application's own verification against the keys embedded in the same source tree. Exported for exactly this: a pipeline that verifies differently from the application can publish a release the application then refuses.
- The release workflow runs it on the signature it just made, and **fails the release** if the embedded keys do not accept it.
- If `UPDATER_PRIVATE_KEY_NEXT` is staged, the workflow **exercises** it: it signs a copy of the manifest, checks that signature against the embedded keys, and throws the copy away. The release still carries exactly one signature, made with the key in service. Without this, a mistyped next key is discovered at the moment the old one stops being used — the one moment it cannot be repaired.
- With no next key staged, that step says so and passes, so it keeps working after the rotation.

## A malformed entry is passed over

Not fatal, and deliberately: it must not be able to refuse a manifest the next key would have accepted — a typo in the list would otherwise stop every update, which is exactly the failure a second key exists to prevent. A list where *no* entry is usable is still reported as a broken build.

## Tests

`pkg/updater/verify_test.go`:
- **the rotation itself** — with both keys embedded, the transition release (signed with the retiring key) verifies, the release after it (signed with the arriving key) verifies, and a third key is still nobody: trusting two keys is not trusting any key;
- a malformed entry beside a good one does not stop the good one;
- an empty list, and a list of blanks, enforce nothing.

The existing tests are unchanged in substance: the signature is checked against the embedded keys, a tampered manifest fails, a signature from another key fails, and the manifest stays bound to its tag.

Run locally: `go build`, `go vet`, `staticcheck`, `go test -race ./pkg/updater/`, and a round trip through the tool — a manifest signed with a freshly generated key is refused by `updatersign verify`, with exit status 1, which is what makes the new workflow step a gate rather than a log line.

## Documentation

README replaces "rotation is not seamless… have to be updated by hand" with the four steps above. `tools/updatersign` says **add** the printed key to `updaterPublicKeys` rather than paste it over, documents `verify`, and `pubkey` compares against the list.
